### PR TITLE
doc: initial moderation policy

### DIFF
--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -47,7 +47,7 @@ Use of the `report@node.js` email address -- or private email to individual TSC 
 
 When a request is sent by email to the `report@node.js` (or directly to a TSC member) a new issue detailing the request must be created in the private nodejs/moderation repository. The identity of the individual submitting the request should be omitted from the issue unless permission to include the identity is provided by the reporter.
 
-Requests should contain as much information and context as possible, including the URL and a screenshot of the Post in question. Screenshots should be modified to obscure obscene or offensive content.
+Requests should contain as much information and context as possible, including the URL and a screenshot of the Post in question. Screenshots may be modified to obscure obscene or offensive content.
 
 External public venues or social media services such as Twitter should never be used to request Moderation.
 

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -32,7 +32,7 @@ Individual Working Groups and Top Level Projects chartered by the TSC may adopt 
  * A new post within the original thread, or
  * A new issue within the private nodejs/moderation repository.
 * Explanations of Moderation actions for non-Collaborator Posts must be provided in:
- * The original Post being modified (as the replacement content),
+ * The original Post being modified (as replacement or appended content),
  * A new post within the original thread, or
  * A new issue within the private nodejs/moderation repository.
 * Any Collaborator who habitually authors Posts that must be Moderated will be subject to possible removal from the Node.js Github Organization. Such action can only be taken through normal TSC motion and vote.

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -29,7 +29,7 @@ Any alternative Moderation Policy used for a given repository must be included i
 
 ### Terms
 
-* "Collaborator" refers to any individual member or "outside collaborator" of the Node.js GitHub Organization.
+* "Collaborator" refers to any public or private member of the Node.js GitHub organization (as listed in https://github.com/orgs/nodejs/people) as well as any individual that has been given Node.js repository access but who is not a member of the Node.js GitHub organization (i.e. "Outside Collaborators" as listed in https://github.com/orgs/nodejs/outside-collaborators).
 * "Post" refers to the content and titles of any issue, pull request, comment or wiki page.
 * "Moderate" refers to the act of modifying the content and title of, or deleting, any Post.
 * "Ban" refers to the act of blocking an individual GitHub account from any further participation in the Node.js GitHub Organization.

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -5,10 +5,10 @@ If you are not a member of the Node.js Github Organization and wish to submit a 
 * [Applicability](#applicability)
 * [Terms](#terms)
 * [Requesting Moderation](#requesting-moderation)
+* [Consideration of Intent](#consideration-of-intent)
 * [Policy](#policy)
  * [Collaborator Posts](#collaborator-posts)
  * [Non-Collaborator Posts](#non-collaborator-posts)
-* [Consideration of Intent](#consideration-of-intent)
 * [Privacy of the nodejs/moderation Repository](#privacy-of-the-nodejsmoderation-repository)
 * [TSC Delegation of Authority to a "Moderation Working Group"](tsc-delegation-of-authority-to-a-moderation-working-group)
 * [Modifications to this Policy](#modifications-to-this-policy)
@@ -55,9 +55,13 @@ Use of the `report@node.js` email address, or private email to individual TSC me
 
 Requests should contain as much information and context as possible, including the URL and a screenshot of the Post in question. Screenshots may be modified to obscure obscene or offensive content.
 
-External public venues or social media services such as Twitter should never be used to request Moderation or to discuss the details of a Moderation request.
+External public venues or social media services such as Twitter should never be used to request Moderation.
 
-Multiple moderation requests for the same Post are unnecessary.
+Collaborators should never discuss the specific details of a Moderation request in any public forum or any social media service outside of the Node.js Github Organization.
+
+### Consideration of Intent
+
+Before Moderating or a Post, Collaborators should carefully consider the possible intent of the author. It may be that the author has simply made an error or is not familiar with the [Code of Conduct](https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md); or it may be that cultural differences exist or that the author is unaware that certain content is considered inappropriate. Unless the offense or the intent to disrupt, annoy or harass is obvious, an author should be given the benefit of the doubt and be given an opportunity to correct any mistake that may have been made.
 
 ### Policy
 
@@ -71,7 +75,7 @@ Multiple moderation requests for the same Post are unnecessary.
 * Collaborators must not Moderate any Post authored by another Collaborator without first giving the author at least 24 hours (from the time of the initial request) to modify or remove the Post on their own.
 * If the author of the Post disagrees that Moderation is required, the matter can be escalated to the TSC by creating a new issue (or using an existing one) within the nodejs/moderation repository with the label `tsc-agenda`. In such cases, the TSC will serve as the final arbiter.
 * While Moderation of a Collaborator's Post is in dispute, no Moderation action should be taken until a decision by the TSC is made.
-* In extreme circumstances involving either obvious gross violations of the Node.js Code of Conduct or possible compromise of a Collaborator's Github account, the TSC can be consulted to waive the 24 hour grace period and dispute process.
+* In extreme circumstances involving either obvious gross violations of the [Node.js Code of Conduct](https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md) or possible compromise of a Collaborator's Github account, the TSC can be consulted to waive the 24 hour grace period and dispute process.
 * For Moderation issues involving a TSC member, the member in question is expected to recuse themselves from any decisions required to resolve the issue.
 * When Moderating any Post authored by another Collaborator, the moderating Collaborator must:
  * Explain the justification for Moderating the post,
@@ -84,7 +88,7 @@ Multiple moderation requests for the same Post are unnecessary.
 
 #### Non-Collaborator Posts
 
-* Posts authored by non-Collaborators are always subject to immediate Moderation by any Collaborator if the content is intentionally disruptive or in violation of the Node.js Code of Conduct.
+* Posts authored by non-Collaborators are always subject to immediate Moderation by any Collaborator if the content is intentionally disruptive or in violation of the [Node.js Code of Conduct](https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md).
 * When Moderating non-Collaborator Posts, the moderating Collaborator should:
  * Explain the justification for Moderating the post, and
  * Identify all changes made to the Post.
@@ -95,10 +99,6 @@ Multiple moderation requests for the same Post are unnecessary.
 * Moderation of Posts authored by non-Collaborators may result in those non-Collaborators being Banned from further participation in the Node.js Github Organization for an indefinite period of time.
 
 Note that Moderating non-Collaborator posts can often lead to retaliation or escalation of inappropriate behavior by the individual whose post is being Moderated. This is true primarily of individuals whose intent is to harass, disrupt or annoy individual members of the community. In such cases, it is best to handle the Moderation as quickly and as quietly as possible without drawing any further undue attention to the Post in question.
-
-### Consideration of Intent
-
-Before Moderating a Post, Collaborators should carefully consider the possible intent of the author. It may be that the author has simply made an error or is not familiar with the Code of Conduct; or it may be that cultural differences exist or that the author is unaware that certain content is considered inappropriate. Unless the offense or the intent to disrupt, annoy or harass is obvious, an author should be given the benefit of the doubt and be given an opportunity to correct any mistake that may have been made.
 
 ### Privacy of the nodejs/moderation Repository
 

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -1,6 +1,6 @@
 ## Moderation policy
 
-If you are not a member of the Node.js Github Organization and wish to submit a moderation request, please see [Requesting Moderation](#requesting-moderation)
+If you are not a member of the Node.js GitHub Organization and wish to submit a moderation request, please see [Requesting Moderation](#requesting-moderation)
 
 * [Applicability](#applicability)
 * [Terms](#terms)
@@ -15,7 +15,7 @@ If you are not a member of the Node.js Github Organization and wish to submit a 
 
 ### Applicability
 
-By default, this policy applies to all repositories under the Node.js Github Organization and all Node.js Working Groups.
+By default, this policy applies to all repositories under the Node.js GitHub Organization and all Node.js Working Groups.
 
 Individual Working Groups and Top Level Projects chartered by the TSC may adopt an alternative Moderation Policy for any repository under their stewardship so long as:
 * The Moderation Policy is openly documented as part of the Working Group or Project Charter and;
@@ -29,10 +29,10 @@ Any alternative Moderation Policy used for a given repository must be included i
 
 ### Terms
 
-* "Collaborator" refers to any individual member or "outside collaborator" of the Node.js Github Organization.
+* "Collaborator" refers to any individual member or "outside collaborator" of the Node.js GitHub Organization.
 * "Post" refers to the content of any issue, pull request, comment or wiki page.
 * "Moderate" refers to the act of modifying the content of or deleting any Post.
-* "Ban" refers to the act of blocking an individual Github account from any further participation in the Node.js Github Organization.
+* "Ban" refers to the act of blocking an individual GitHub account from any further participation in the Node.js GitHub Organization.
 
 ### Requesting Moderation
 
@@ -43,39 +43,40 @@ Moderation requests are only necessary when:
 * The Post in question was authored by a Collaborator, or
 * The request is originating from a non-Collaborator.
 
-Requesting Moderation of a Post can be accomplished in one of five ways:
+Requesting Moderation of a Post can be accomplished in one of four ways:
 
 * Via the `report@node.js` email address,
 * Via private email to individual TSC members,
 * Via a new Post in the same thread as the Post being requested for Moderation,
-* Via a new Post in the private nodejs/moderation repository, or
-* Private communication between the individuals involved,
+* Via a new Post in the private nodejs/moderation repository.
 
 Use of the `report@node.js` email address, or private email to individual TSC members, is appropriate when the individual requesting the Moderation does not feel comfortable directly or publicly making the request. All emails sent to the `report@node.js` address are currently forwarded to all members of the TSC. [[ED NOTE: This has not yet been set up]]
+
+When a request is sent by email either to the `report@node.js` or directly to a TSC member, a new issue detailing the request must be created in the private nodejs/moderation repository. The identity of the individual submitting the request may be omitted from that issue.
 
 Requests should contain as much information and context as possible, including the URL and a screenshot of the Post in question. Screenshots may be modified to obscure obscene or offensive content.
 
 External public venues or social media services such as Twitter should never be used to request Moderation.
 
-Collaborators should never discuss the specific details of a Moderation request in any public forum or any social media service outside of the Node.js Github Organization.
+Collaborators should never discuss the specific details of a Moderation request in any public forum or any social media service outside of the Node.js GitHub Organization.
 
 ### Consideration of Intent
 
-Before Moderating or a Post, Collaborators should carefully consider the possible intent of the author. It may be that the author has simply made an error or is not familiar with the [Code of Conduct](https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md); or it may be that cultural differences exist or that the author is unaware that certain content is considered inappropriate. Unless the offense or the intent to disrupt, annoy or harass is obvious, an author should be given the benefit of the doubt and be given an opportunity to correct any mistake that may have been made.
+Before Moderating a Post, Collaborators should carefully consider the possible intent of the author. It may be that the author has simply made an error or is not familiar with the [Code of Conduct](https://GitHub.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md); or it may be that cultural differences exist or that the author is unaware that certain content is considered inappropriate. Unless the offense or the intent to disrupt, annoy or harass is obvious, an author should be given the benefit of the doubt and be given an opportunity to correct any mistake that may have been made.
 
 ### Policy
 
-* All Posts are expected to respect the [Node.js Code of Conduct](https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md).
+* All Posts are expected to respect the [Node.js Code of Conduct](https://GitHub.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md).
 * Only Collaborators with commit rights to a given repository may Moderate Posts within that repository's issue tracker.
-* Only a TSC member may Ban an individual from the Node.js Github Organization.
-* Any individual Banned from the Node.js Github Organization will be recommended for exclusion from any Node.js Foundation sponsored event or activity.
+* Only a TSC member may Ban an individual from the Node.js GitHub Organization.
+* Any individual Banned from the Node.js GitHub Organization will be recommended for exclusion from any Node.js Foundation sponsored event or activity.
 
 #### Collaborator Posts
 
 * Collaborators must not Moderate any Post authored by another Collaborator without first giving the author at least 24 hours (from the time of the initial request) to modify or remove the Post on their own.
 * If the author of the Post disagrees that Moderation is required, the matter can be escalated to the TSC by creating a new issue (or using an existing one) within the nodejs/moderation repository with the label `tsc-agenda`. In such cases, the TSC will serve as the final arbiter.
 * While Moderation of a Collaborator's Post is in dispute, no Moderation action should be taken until a decision by the TSC is made.
-* In extreme circumstances involving either obvious gross violations of the [Node.js Code of Conduct](https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md) or possible compromise of a Collaborator's Github account, the TSC can be consulted to waive the 24 hour grace period and dispute process.
+* In extreme circumstances involving either obvious gross violations of the [Node.js Code of Conduct](https://GitHub.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md) or possible compromise of a Collaborator's GitHub account, the TSC can be consulted to waive the 24 hour grace period and dispute process.
 * For Moderation issues involving a TSC member, the member in question is expected to recuse themselves from any decisions required to resolve the issue.
 * When Moderating any Post authored by another Collaborator, the moderating Collaborator must:
  * Explain the justification for Moderating the post,
@@ -84,11 +85,11 @@ Before Moderating or a Post, Collaborators should carefully consider the possibl
 * Explanations of Moderation actions on Collaborator Posts must be provided in:
  * A new post within the original thread, or
  * A new issue within the private nodejs/moderation repository.
-* Any Collaborator who habitually authors Posts that must be Moderated will be subject to possible removal from the Node.js Github Organization. Such action can only be taken through normal TSC motion and vote.
+* Any Collaborator who habitually authors Posts that must be Moderated will be subject to possible removal from the Node.js GitHub Organization. Such action can only be taken through normal TSC motion and vote.
 
 #### Non-Collaborator Posts
 
-* Posts authored by non-Collaborators are always subject to immediate Moderation by any Collaborator if the content is intentionally disruptive or in violation of the [Node.js Code of Conduct](https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md).
+* Posts authored by non-Collaborators are always subject to immediate Moderation by any Collaborator if the content is intentionally disruptive or in violation of the [Node.js Code of Conduct](https://GitHub.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md).
 * When Moderating non-Collaborator Posts, the moderating Collaborator should:
  * Explain the justification for Moderating the post, and
  * Identify all changes made to the Post.
@@ -96,18 +97,20 @@ Before Moderating or a Post, Collaborators should carefully consider the possibl
  * The original Post being modified (as replacement or appended content),
  * A new post within the original thread, or
  * A new issue within the private nodejs/moderation repository.
-* Moderation of Posts authored by non-Collaborators may result in those non-Collaborators being Banned from further participation in the Node.js Github Organization for an indefinite period of time.
+* Moderation of Posts authored by non-Collaborators may result in those non-Collaborators being Banned from further participation in the Node.js GitHub Organization for an indefinite period of time.
 
 Note that Moderating non-Collaborator posts can often lead to retaliation or escalation of inappropriate behavior by the individual whose post is being Moderated. This is true primarily of individuals whose intent is to harass, disrupt or annoy individual members of the community. In such cases, it is best to handle the Moderation as quickly and as quietly as possible without drawing any further undue attention to the Post in question.
 
 ### Privacy of the nodejs/moderation Repository
 
-The nodejs/moderation Repository is used to discuss the potentially sensitive details of any specific proposed or actual Moderation or Banning action. The repository is private but accessible to all Collaborators. The details of any issue discussed within the nodejs/moderation repository are expected to remain confidential and are not to be discussed in any public forum or social media service.
+The nodejs/moderation Repository is used to discuss the potentially sensitive details of any specific moderation issue. The repository is private but accessible to all Collaborators. The details of any issue discussed within the nodejs/moderation repository are expected to remain confidential and are not to be discussed in any public forum or social media service.
+
+Any Collaborator found to be violating the privacy of the nodejs/moderation repository by repeatedly sharing or discussing the details of nodejs/moderation issues in any public forum or social media service risks being removed from the Node.js GitHub organization through standard TSC motion and vote.
 
 ### TSC Delegation of Authority to a "Moderation Working Group"
 
-For any Moderation action that does not directly involve a TSC member, the TSC may choose to delegate some or all of it's Moderation-related responsibilities to a "Moderation Working Group". All members of such a Working Group must be Collaborators and the TSC will have responsibility for selecting the membership of that Moderation Working Group.
+For any Moderation issue that does not directly involve a TSC member, the TSC may choose to delegate some or all of it's Moderation-related responsibilities to a "Moderation Working Group". All members of such a Working Group must be Collaborators and the TSC will have responsibility for selecting the membership of that Moderation Working Group.
 
 ### Modifications to This Policy
 
-Modifications to this policy are made through normal [TSC motion and vote](https://github.com/nodejs/TSC/blob/master/TSC-Charter.md#section-8-voting). Any Collaborator may submit a PR proposing changes to this policy. Those PRs must be labeled using the `tsc-agenda` label. Including a mention to `@nodejs/tsc` can be used to call the issue to TSC's attention.
+Modifications to this policy are made through normal [TSC motion and vote](https://GitHub.com/nodejs/TSC/blob/master/TSC-Charter.md#section-8-voting). Any Collaborator may submit a PR proposing changes to this policy. Those PRs must be labeled using the `tsc-agenda` label. Including a mention to `@nodejs/tsc` can be used to call the issue to TSC's attention.

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -17,7 +17,7 @@ Any alternative Moderation Policy used for a given repository must be included i
 ### Terms
 
 * "Collaborator" refers to any individual member or "outside collaborator" of the Node.js Github Organization.
-* "Post" refers to the content of any issue, pull request or comment.
+* "Post" refers to the content of any issue, pull request, comment or wiki page.
 * "Moderate" refers to the act of modifying the content of or deleting any Post.
 * "Ban" refers to the act of blocking an individual Github account from any further participation in the Node.js Github Organization.
 

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -42,6 +42,8 @@ Any alternative Moderation Policy used for a given repository must be included i
 
 Any Post considered to be in violation of the [Node.js Code of Conduct](https://GitHub.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md) is subject to Moderation.
 
+The TSC is solely responsible for deciding what constitutes inappropriate behavior that may be subject to Moderation (see: [Escalation to the TSC](#escalation-to-the-tsc)).
+
 ### Requesting Moderation
 
 Anyone may request Moderation of a Post. Requesting Moderation of a Post can be accomplished in one of four ways:
@@ -77,7 +79,7 @@ Note, however, that unfamiliarity with the [Code of Conduct](https://GitHub.com/
 
 * All Posts are expected to respect the [Node.js Code of Conduct](https://GitHub.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md).
 * Only Collaborators with commit rights to a given repository may Moderate Posts within that repository's issue tracker.
-* The TSC serves as the final arbiter for all Moderation issues; including deciding what constitutes inappropriate behavior that may be subject to Moderation (see: [Escalation to the TSC](#escalation-to-the-tsc)).
+* The TSC serves as the final arbiter for all Moderation issues (see: [Escalation to the TSC](#escalation-to-the-tsc)).
 * Only a TSC member may Ban an individual from the Node.js GitHub Organization.
 * Any individual Banned from the Node.js GitHub Organization will be recommended for exclusion from any Node.js Foundation sponsored event or activity.
 * Minor edits to the formatting of a Post or to correct typographical errors are not considered to be "Moderation". Such edits and their intent should still be documented with a short note indicating who made the edit and why.

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -46,16 +46,16 @@ Any Post considered to be in violation of the [Node.js Code of Conduct](https://
 
 Anyone may request Moderation of a Post. Requesting Moderation of a Post can be accomplished in one of four ways:
 
-* Via the `report@node.js` email address,
+* Via the [report@nodejs.org](mailto:report@nodejs.org) email address,
 * Via private email to individual TSC members,
 * Via a new Post in the same thread as the Post being requested for Moderation,
 * Via a new Post in the private nodejs/moderation repository.
 
 Note that Collaborators may Moderate non-Collaborator Posts at any time without submitting an initial request (see: [Non-Collaborator Posts](#non-collaborator-posts)).
 
-Use of the `report@node.js` email address -- or private email to individual TSC members -- is appropriate when the individual requesting the Moderation does not feel comfortable directly or publicly making the request. All emails sent to the `report@node.js` address are currently forwarded to all members of the TSC. [[ED NOTE: This has not yet been set up]]
+Use of the [report@nodejs.org](mailto:report@nodejs.org) email address -- or private email to individual TSC members -- is appropriate when the individual requesting the Moderation does not feel comfortable directly or publicly making the request. All emails sent to the [report@nodejs.org](mailto:report@nodejs.org) address are currently forwarded to all members of the TSC. [[ED NOTE: This has not yet been set up]]
 
-When a request is sent by email to the `report@node.js` (or directly to a TSC member) a new issue detailing the request must be created in the private nodejs/moderation repository. The identity of the individual submitting the request should be omitted from the issue unless permission to include the identity is provided by the reporter.
+When a request is sent by email to the [report@nodejs.org](mailto:report@nodejs.org) (or directly to a TSC member) a new issue detailing the request must be created in the private nodejs/moderation repository. The identity of the individual submitting the request should be omitted from the issue unless permission to include the identity is provided by the reporter.
 
 Requests should contain as much information and context as possible, including the URL and a screenshot of the Post in question. Screenshots may be modified to obscure obscene or offensive content.
 

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -31,12 +31,12 @@ Any alternative Moderation Policy used for a given repository must be included i
 
 ### Terms
 
-* "Collaborator" refers to any individual with configured access permissions to any Node.js GitHub organization repository. See [GitHub's access permissions documentation](https://help.github.com/articles/what-are-the-different-access-permissions/) for more information.
-* "TSC" refers to the [Node.js Technical Steering Committee](https://github.com/nodejs/node#tsc-technical-steering-committee).
-* "Post" refers to the content and titles of any issue, pull request, comment or wiki page.
-* "Moderate" refers to the act of modifying the content and title of, or deleting, any Post for the purpose of correcting or addressing Code of Conduct violations.
-* "Ban" refers to the act of blocking an individual GitHub account from any further participation in the Node.js GitHub Organization.
-* "Requester" refers to an individual requesting Moderation on a Post.
+* *Collaborator* refers to any individual with configured access permissions to any Node.js GitHub organization repository. See [GitHub's access permissions documentation](https://help.github.com/articles/what-are-the-different-access-permissions/) for more information.
+* *TSC* refers to the [Node.js Technical Steering Committee](https://github.com/nodejs/node#tsc-technical-steering-committee).
+* *Post* refers to the content and titles of any issue, pull request, comment or wiki page.
+* *Moderate* refers to the act of modifying the content and title of, or deleting, any Post for the purpose of correcting or addressing Code of Conduct violations.
+* *Ban* refers to the act of blocking an individual GitHub account from any further participation in the Node.js GitHub Organization.
+* *Requester* refers to an individual requesting Moderation on a Post.
 
 ### Grounds for Moderation
 
@@ -114,6 +114,8 @@ Note that Moderating non-Collaborator posts can often lead to retaliation or esc
 ### Escalation to the TSC
 
 Any Moderation issue or dispute can be escalated to the TSC by "mentioning" `@nodejs/tsc` in the body of a GitHub issue either in the original thread or in the private nodejs/moderation repository. Optionally, the `tsc-agenda` label may be attached to the issue to request that it be added to the TSC meeting agenda.
+
+(Note that using the `@nodejs/tsc` syntax to mention the TSC in the body of a request only will only work if the author of the Post is currently a member of the Node.js GitHub organization.)
 
 All Moderation-related decisions follow the normal [TSC motion and voting process](https://GitHub.com/nodejs/TSC/blob/master/TSC-Charter.md#section-8-voting).
 

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -91,6 +91,10 @@ Before Moderating a Post, Collaborator's should carefully consider the possible 
 
 The nodejs/moderation Repository is used to discuss the potentially sensitive details of any specific proposed or actual Moderation or Banning action. The repository is private but accessible to all Collaborators. The details of any issue discussed within the nodejs/moderation repository are expected to remain confidential and are not to be discussed in any public forum or social media service.
 
+### TSC Delegation of Authority to a "Moderation Working Group"
+
+For any Moderation action that does not directly involve a TSC member, the TSC may choose to delegate some or all of it's Moderation-related responsibilities to a "Moderation Working Group". All members of such a Working Group must be Collaborators and the TSC will have responsibility for selecting the membership of that Moderation Working Group.
+
 ### Modifications to This Policy
 
 Modifications to this policy are made through normal [TSC motion and vote](https://github.com/nodejs/TSC/blob/master/TSC-Charter.md#section-8-voting). Any Collaborator may submit a PR proposing changes to this policy. Those PRs must be labeled using the `tsc-agenda` label. Including a mention to `@nodejs/tsc` can be used to call the issue to TSC's attention.

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -1,0 +1,48 @@
+## Moderation policy
+
+### Applicability
+
+By default, this policy applies to all repositories under the Node.js Github Organization and all Node.js Working Groups.
+
+Individual Working Groups and Top Level Projects chartered by the TSC may adopt an alternative Moderation Policy for any repository under their stewardship so long as:
+* The Moderation Policy is openly documented as part of the Working Group or Project Charter and;
+* Includes provisions for clearly and openly documenting Moderation actions taken.
+
+### Terms
+
+* "Collaborator" refers to any individual member or "outside collaborator" of the Node.js Github Organization.
+* "Post" refers to the content of any issue, pull request or comment.
+* "Moderate" refers to the act of modifying the content of or deleting any Post that is in obvious violation of the Node.js Code of Conduct.
+* "Ban" refers to the act of blocking an individual Github account from any further participation in the Node.js Github Organization.
+
+### Policy
+
+* All Posts are expected to respect the Node.js Code of Conduct.
+* Only Collaborators with commit rights to a given repository may Moderate Posts within that repository's issue tracker.
+* Collaborator's must not Moderate any Post authored by another Collaborator without first giving the author an opportunity of at least 24 hours to modify or remove the Post on their own.
+* Posts authored by non-Collaborator's are always subject to immediate Moderation by any Collaborator if the content is intentionally disruptive or in violation of the Node.js Code of Conduct.
+* When Moderating any Post authored by another Collaborator, the moderating Collaborator must:
+ * Explain the justification for Moderating the post,
+ * Identify all changes made to the Post, and
+ * Identify the steps previously taken to resolve the issue.
+* When Moderating non-Collaborator Posts, the moderating Collaborator should:
+ * Explain the justification for Moderating the post, and
+ * Identify all changes made to the Post.
+* Explanations of Moderation actions on Collaborator Posts must be provided in:
+ * A new post within the original thread, or
+ * A new issue within the private nodejs/moderation repository.
+* Explanations of Moderation actions for non-Collaborator Posts must be provided in:
+ * The original Post being modified (as the replacement content),
+ * A new post within the original thread, or
+ * A new issue within the private nodejs/moderation repository.
+* Any Collaborator who habitually authors Posts that must be Moderated will be subject to possible removal from the Node.js Github Organization. Such action can only be taken through normal TSC motion and vote.
+* Moderation of Posts authored by non-Collaborators may result in those non-Collaborators being Banned from further participation in the Node.js Github Organization for an indefinite period of time.
+* Only a TSC member may Ban an individual from the Node.js Github Organization.
+
+### Privacy of the nodejs/moderation Repository
+
+The nodejs/moderation Repository is used to discuss the details of any specific proposed or actual Moderation or Banning action. The repository is private but accessible to all Collaborators. The details of any issue discussed within the nodejs/moderation repository are expected to remain confidential and are not to be discussed in any external or public forum.
+
+### Modifications to This Policy
+
+Modifications to this policy are made through normal TSC motion and vote. Any Collaborator may submit a PR proposing changes to this policy. Those PRs must be labeled using the `tsc-agenda` label.

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -21,20 +21,13 @@ Any alternative Moderation Policy used for a given repository must be included i
 * "Moderate" refers to the act of modifying the content of or deleting any Post.
 * "Ban" refers to the act of blocking an individual Github account from any further participation in the Node.js Github Organization.
 
-### Policy
-
-* All Posts are expected to respect the Node.js Code of Conduct.
-* Only Collaborators with commit rights to a given repository may Moderate Posts within that repository's issue tracker.
-* Only a TSC member may Ban an individual from the Node.js Github Organization.
-* Any individual Banned from the Node.js Github Organization will be recommended for exclusion from any Node.js Foundation sponsored event or activity.
-
-#### Requesting Moderation
+### Requesting Moderation
 
 Anyone may request Moderation of a Post.
 
-Moderation requests are only necessary when the Post in question was either:
+Moderation requests are only necessary when:
  
-* Authored by a Collaborator, or
+* The Post in question was authored by a Collaborator, or
 * The request is originating from a non-Collaborator.
 
 Requesting Moderation of a Post can be accomplished in one of five ways:
@@ -53,11 +46,19 @@ External public venues or social media services such as Twitter should never be 
 
 Multiple moderation requests for the same Post are unnecessary.
 
+### Policy
+
+* All Posts are expected to respect the [Node.js Code of Conduct](https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md).
+* Only Collaborators with commit rights to a given repository may Moderate Posts within that repository's issue tracker.
+* Only a TSC member may Ban an individual from the Node.js Github Organization.
+* Any individual Banned from the Node.js Github Organization will be recommended for exclusion from any Node.js Foundation sponsored event or activity.
+
 #### Collaborator Posts
 
 * Collaborator's must not Moderate any Post authored by another Collaborator without first giving the author at least 24 hours (from the time of the initial request) to modify or remove the Post on their own.
-* In extreme circumstances the TSC can be consulted to waive the 24 hour grace period.
 * If the author of the Post disagrees that Moderation is required, the matter can be escalated to the TSC by creating a new issue (or using an existing one) within the nodejs/moderation repository with the label `tsc-agenda`. In such cases, the TSC will serve as the final arbiter.
+* While Moderation of a Collaborator's Post is in dispute, no Moderation action should be taken until a decision by the TSC is made.
+* In extreme circumstances involving either obvious gross violations of the Node.js Code of Conduct or possible compromise of a Collaborator's Github account, the TSC can be consulted to waive the 24 hour grace period and dispute process.
 * For Moderation issues involving a TSC member, the member in question is expected to recuse themselves from any decisions required to resolve the issue.
 * When Moderating any Post authored by another Collaborator, the moderating Collaborator must:
  * Explain the justification for Moderating the post,

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -65,6 +65,8 @@ Collaborators should never discuss the specific details of a Moderation request 
 
 Note that quoting the original content of a Post within a Moderation request or nodejs/moderation repository issue is not considered a violation of the Code of Conduct. However, discretion is advised when including such quotes in requests posted to public repositories.
 
+Requests for Moderation that do not appear to have been submitted in good faith with intent to address a legitimate Code of Conduct violation, as determined by the TSC, may be ignored.
+
 ### Consideration of Intent
 
 Before Moderating a Post, Collaborators should carefully consider the possible intent of the author. It may be that the author has simply made an error or is not yet familiar with the [Code of Conduct](https://GitHub.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md); or it may be that cultural differences exist, or that the author is unaware that certain content is considered inappropriate. In such cases, the author should be given an opportunity to correct any error that may have been made.
@@ -75,7 +77,7 @@ Note, however, that unfamiliarity with the [Code of Conduct](https://GitHub.com/
 
 * All Posts are expected to respect the [Node.js Code of Conduct](https://GitHub.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md).
 * Only Collaborators with commit rights to a given repository may Moderate Posts within that repository's issue tracker.
-* The TSC serves as the final arbiter for all Moderation issues (see: [Escalation to the TSC](#escalation-to-the-tsc)).
+* The TSC serves as the final arbiter for all Moderation issues; including deciding what constitutes inappropriate behavior that may be subject to Moderation (see: [Escalation to the TSC](#escalation-to-the-tsc)).
 * Only a TSC member may Ban an individual from the Node.js GitHub Organization.
 * Any individual Banned from the Node.js GitHub Organization will be recommended for exclusion from any Node.js Foundation sponsored event or activity.
 * Minor edits to the formatting of a Post or to correct typographical errors are not considered to be "Moderation". Such edits and their intent should still be documented with a short note indicating who made the edit and why.
@@ -105,16 +107,9 @@ Note, however, that unfamiliarity with the [Code of Conduct](https://GitHub.com/
  * A new post within the original thread, or
  * A new issue within the private nodejs/moderation repository.
 * Moderation of Posts authored by non-Collaborators may result in those non-Collaborators being Banned from further participation in the Node.js GitHub organization for an indefinite period of time.
+* In the case where a GitHub Account appears to have been created with no intention to collaborate in good faith, swift actions may be taken without following the above procedures including: removing Posts, Banning, and reporting accounts to GitHub.
 
 Note that Moderating non-Collaborator posts can often lead to retaliation or escalation of inappropriate behavior by the individual whose post is being Moderated. This is true primarily of individuals whose intent is to harass, disrupt or annoy individual members of the community. In such cases, it is best to handle the Moderation as quickly and as quietly as possible without drawing any further undue attention to the Post in question.
-
-#### Trolling
-
-Trolling is generally defined as the act of creating deliberately offensive or provocative Posts for the sole purpose of derailing a conversation, stealing attention, inciting an angry response or disrupting the usability of physical and electronic spaces used by the contributors to the Node.js project. More specifically, within the context of the Node.js project, Trolling consists of *any behavior considered by the TSC to be intentionally disruptive, offensive or abusive*.
-
-Trolling behavior of any kind is not tolerated and will be subject to immediate Moderation. The author of Trolling Posts will be subject to permanent Banning from the GitHub organization and will be recommended for exclusion from all Node.js Foundation events and activities.
-
-Determination of what constitutes "Trolling behavior" within the Node.js project is solely at the discretion of the TSC.
 
 ### Escalation to the TSC
 

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -62,6 +62,8 @@ External public venues or social media services such as Twitter should never be 
 
 Collaborators should never discuss the specific details of a Moderation request in any public forum or any social media service outside of the Node.js GitHub Organization.
 
+Note that quoting the original content of a Post within a Moderation request or nodejs/moderation repository issue is not considered a violation of the Code of Conduct. However, discretion is advised when including such quotes in requests posted to public repositories.
+
 ### Consideration of Intent
 
 Before Moderating a Post, Collaborators should carefully consider the possible intent of the author. It may be that the author has simply made an error or is not yet familiar with the [Code of Conduct](https://GitHub.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md); or it may be that cultural differences exist, or that the author is unaware that certain content is considered inappropriate. In such cases, the author should be given an opportunity to correct any error that may have been made.

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -30,39 +30,36 @@ Any alternative Moderation Policy used for a given repository must be included i
 ### Terms
 
 * "Collaborator" refers to any individual member or "outside collaborator" of the Node.js GitHub Organization.
-* "Post" refers to the content of any issue, pull request, comment or wiki page.
-* "Moderate" refers to the act of modifying the content of or deleting any Post.
+* "Post" refers to the content and titles of any issue, pull request, comment or wiki page.
+* "Moderate" refers to the act of modifying the content and title of, or deleting, any Post.
 * "Ban" refers to the act of blocking an individual GitHub account from any further participation in the Node.js GitHub Organization.
 
 ### Requesting Moderation
 
-Anyone may request Moderation of a Post.
-
-Moderation requests are only necessary when:
- 
-* The Post in question was authored by a Collaborator, or
-* The request is originating from a non-Collaborator.
-
-Requesting Moderation of a Post can be accomplished in one of four ways:
+Anyone may request Moderation of a Post. Requesting Moderation of a Post can be accomplished in one of four ways:
 
 * Via the `report@node.js` email address,
 * Via private email to individual TSC members,
 * Via a new Post in the same thread as the Post being requested for Moderation,
 * Via a new Post in the private nodejs/moderation repository.
 
-Use of the `report@node.js` email address, or private email to individual TSC members, is appropriate when the individual requesting the Moderation does not feel comfortable directly or publicly making the request. All emails sent to the `report@node.js` address are currently forwarded to all members of the TSC. [[ED NOTE: This has not yet been set up]]
+Use of the `report@node.js` email address -- or private email to individual TSC members -- is appropriate when the individual requesting the Moderation does not feel comfortable directly or publicly making the request. All emails sent to the `report@node.js` address are currently forwarded to all members of the TSC. [[ED NOTE: This has not yet been set up]]
 
-When a request is sent by email either to the `report@node.js` or directly to a TSC member, a new issue detailing the request must be created in the private nodejs/moderation repository. The identity of the individual submitting the request may be omitted from that issue.
+When a request is sent by email to the `report@node.js` (or directly to a TSC member) a new issue detailing the request must be created in the private nodejs/moderation repository. The identity of the individual submitting the request should be omitted from that issue unless specified by the reporter.
 
-Requests should contain as much information and context as possible, including the URL and a screenshot of the Post in question. Screenshots may be modified to obscure obscene or offensive content.
+Requests should contain as much information and context as possible, including the URL and a screenshot of the Post in question. Screenshots should be modified to obscure obscene or offensive content.
 
 External public venues or social media services such as Twitter should never be used to request Moderation.
 
 Collaborators should never discuss the specific details of a Moderation request in any public forum or any social media service outside of the Node.js GitHub Organization.
 
+Note that Collaborators may Moderate non-Collaborator Posts at any time without submitting an initial request (see: [Non-Collaborator Posts](#non-collaborator-posts)).
+
 ### Consideration of Intent
 
-Before Moderating a Post, Collaborators should carefully consider the possible intent of the author. It may be that the author has simply made an error or is not familiar with the [Code of Conduct](https://GitHub.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md); or it may be that cultural differences exist or that the author is unaware that certain content is considered inappropriate. Unless the offense or the intent to disrupt, annoy or harass is obvious, an author should be given the benefit of the doubt and be given an opportunity to correct any mistake that may have been made.
+Before Moderating a Post, Collaborators should carefully consider the possible intent of the author. It may be that the author has simply made an error or is not yet familiar with the [Code of Conduct](https://GitHub.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md); or it may be that cultural differences exist, or that the author is unaware that certain content is considered inappropriate. In such cases, the author should be given an opportunity to correct any error that may have been made.
+
+Note, however, that unfamiliarity with the [Code of Conduct](https://GitHub.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md) does not excuse a Post from Moderation.
 
 ### Policy
 

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -29,7 +29,7 @@ Any alternative Moderation Policy used for a given repository must be included i
 
 ### Terms
 
-* "Collaborator" refers to any public or private member of the Node.js GitHub organization (as listed in https://github.com/orgs/nodejs/people) as well as any individual that has been given Node.js repository access but who is not a member of the Node.js GitHub organization (i.e. "Outside Collaborators" as listed in https://github.com/orgs/nodejs/outside-collaborators).
+* "Collaborator" refers to any individual with configured access permissions to any Node.js GitHub organization repository. See [GitHub's access permissions documentation](https://help.github.com/articles/what-are-the-different-access-permissions/) for more information.
 * "Post" refers to the content and titles of any issue, pull request, comment or wiki page.
 * "Moderate" refers to the act of modifying the content and title of, or deleting, any Post.
 * "Ban" refers to the act of blocking an individual GitHub account from any further participation in the Node.js GitHub Organization.

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -1,5 +1,18 @@
 ## Moderation policy
 
+If you are not a member of the Node.js Github Organization and wish to submit a moderation request, please see [Requesting Moderation](#requesting-moderation)
+
+* [Applicability](#applicability)
+* [Terms](#terms)
+* [Requesting Moderation](#requesting-moderation)
+* [Policy](#policy)
+ * [Collaborator Posts](#collaborator-posts)
+ * [Non-Collaborator Posts](#non-collaborator-posts)
+* [Consideration of Intent](#consideration-of-intent)
+* [Privacy of the nodejs/moderation Repository](#privacy-of-the-nodejsmoderation-repository)
+* [TSC Delegation of Authority to a "Moderation Working Group"](tsc-delegation-of-authority-to-a-moderation-working-group)
+* [Modifications to this Policy](#modifications-to-this-policy)
+
 ### Applicability
 
 By default, this policy applies to all repositories under the Node.js Github Organization and all Node.js Working Groups.
@@ -12,7 +25,7 @@ If a particular repository can be considered to fall under the stewardship of mu
 * Decide between themselves which Moderation Policy will be in effect for the repository in question, or
 * Ask the TSC to determine which Moderation Policy should apply.
 
-Any alternative Moderation Policy used for a given repository must be included in the root directory of the repository using the `Moderation-Policy.md` filename.
+Any alternative Moderation Policy used for a given repository must be included in the root directory of the repository using the `Moderation-Policy.md` filename. If a repository does not contain a `Moderation-Policy.md` file, then this default policy applies.
 
 ### Terms
 
@@ -32,13 +45,13 @@ Moderation requests are only necessary when:
 
 Requesting Moderation of a Post can be accomplished in one of five ways:
 
-* Private communication between the individuals involved,
-* Via the `report@io.js` email address,
+* Via the `report@node.js` email address,
 * Via private email to individual TSC members,
 * Via a new Post in the same thread as the Post being requested for Moderation, or
 * Via a new Post in the private nodejs/moderation repository.
+* Private communication between the individuals involved,
 
-Use of the `report@io.js` email address, or private email to individual TSC members, is appropriate when the individual requesting the Moderation does not feel comfortable directly or publicly making the request. All emails sent to the `report@io.js` address are currently forwarded to all members of the TSC. [[ED NOTE: This has not yet been set up]]
+Use of the `report@node.js` email address, or private email to individual TSC members, is appropriate when the individual requesting the Moderation does not feel comfortable directly or publicly making the request. All emails sent to the `report@node.js` address are currently forwarded to all members of the TSC. [[ED NOTE: This has not yet been set up]]
 
 Requests should contain as much information and context as possible, including the URL and a screenshot of the Post in question. Screenshots may be modified to obscure obscene or offensive content.
 
@@ -55,7 +68,7 @@ Multiple moderation requests for the same Post are unnecessary.
 
 #### Collaborator Posts
 
-* Collaborator's must not Moderate any Post authored by another Collaborator without first giving the author at least 24 hours (from the time of the initial request) to modify or remove the Post on their own.
+* Collaborators must not Moderate any Post authored by another Collaborator without first giving the author at least 24 hours (from the time of the initial request) to modify or remove the Post on their own.
 * If the author of the Post disagrees that Moderation is required, the matter can be escalated to the TSC by creating a new issue (or using an existing one) within the nodejs/moderation repository with the label `tsc-agenda`. In such cases, the TSC will serve as the final arbiter.
 * While Moderation of a Collaborator's Post is in dispute, no Moderation action should be taken until a decision by the TSC is made.
 * In extreme circumstances involving either obvious gross violations of the Node.js Code of Conduct or possible compromise of a Collaborator's Github account, the TSC can be consulted to waive the 24 hour grace period and dispute process.
@@ -71,7 +84,7 @@ Multiple moderation requests for the same Post are unnecessary.
 
 #### Non-Collaborator Posts
 
-* Posts authored by non-Collaborator's are always subject to immediate Moderation by any Collaborator if the content is intentionally disruptive or in violation of the Node.js Code of Conduct.
+* Posts authored by non-Collaborators are always subject to immediate Moderation by any Collaborator if the content is intentionally disruptive or in violation of the Node.js Code of Conduct.
 * When Moderating non-Collaborator Posts, the moderating Collaborator should:
  * Explain the justification for Moderating the post, and
  * Identify all changes made to the Post.
@@ -85,7 +98,7 @@ Note that Moderating non-Collaborator posts can often lead to retaliation or esc
 
 ### Consideration of Intent
 
-Before Moderating a Post, Collaborator's should carefully consider the possible intent of the author. It may be that the author has simply made an error or is not familiar with the Code of Conduct; or it may be that cultural differences exist or that the author is unaware that certain content is considered inappropriate. Unless the offense or the intent to disrupt, annoy or harass is obvious, an author should be given the benefit of the doubt and be given an opportunity to correct any mistake that may have been made.
+Before Moderating a Post, Collaborators should carefully consider the possible intent of the author. It may be that the author has simply made an error or is not familiar with the Code of Conduct; or it may be that cultural differences exist or that the author is unaware that certain content is considered inappropriate. Unless the offense or the intent to disrupt, annoy or harass is obvious, an author should be given the benefit of the doubt and be given an opportunity to correct any mistake that may have been made.
 
 ### Privacy of the nodejs/moderation Repository
 

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -12,37 +12,69 @@ Individual Working Groups and Top Level Projects chartered by the TSC may adopt 
 
 * "Collaborator" refers to any individual member or "outside collaborator" of the Node.js Github Organization.
 * "Post" refers to the content of any issue, pull request or comment.
-* "Moderate" refers to the act of modifying the content of or deleting any Post that is in obvious violation of the Node.js Code of Conduct.
+* "Moderate" refers to the act of modifying the content of or deleting any Post.
 * "Ban" refers to the act of blocking an individual Github account from any further participation in the Node.js Github Organization.
 
 ### Policy
 
 * All Posts are expected to respect the Node.js Code of Conduct.
 * Only Collaborators with commit rights to a given repository may Moderate Posts within that repository's issue tracker.
-* Collaborator's must not Moderate any Post authored by another Collaborator without first giving the author an opportunity of at least 24 hours to modify or remove the Post on their own. In extreme circumstances the TSC can be consulted to waive the 24 hour grace period.
-* Posts authored by non-Collaborator's are always subject to immediate Moderation by any Collaborator if the content is intentionally disruptive or in violation of the Node.js Code of Conduct.
+* Only a TSC member may Ban an individual from the Node.js Github Organization.
+* Any individual Banned from the Node.js Github Organization will be recommended for exclusion from any Node.js Foundation sponsored event or activity.
+
+#### Collaborator Posts
+
+* Collaborator's must not Moderate any Post authored by another Collaborator without first giving the author an opportunity of at least 24 hours (from the time of the initial request) to modify or remove the Post on their own.
+* In extreme circumstances the TSC can be consulted to waive the 24 hour grace period.
+* If the author of the Post disagrees that Moderation is required, the matter can be escalated to the TSC by creating a new issue (or using an existing one) within the nodejs/moderation repository with the label `tsc-agenda`. In such cases, the TSC will serve as the final arbiter.
+* For Moderation issues involving a TSC member, the member in question is expected to recuse themselves from any decisions required to resolve the issue.
 * When Moderating any Post authored by another Collaborator, the moderating Collaborator must:
  * Explain the justification for Moderating the post,
  * Identify all changes made to the Post, and
  * Identify the steps previously taken to resolve the issue.
-* When Moderating non-Collaborator Posts, the moderating Collaborator should:
- * Explain the justification for Moderating the post, and
- * Identify all changes made to the Post.
 * Explanations of Moderation actions on Collaborator Posts must be provided in:
  * A new post within the original thread, or
  * A new issue within the private nodejs/moderation repository.
+* Any Collaborator who habitually authors Posts that must be Moderated will be subject to possible removal from the Node.js Github Organization. Such action can only be taken through normal TSC motion and vote.
+
+#### Non-Collaborator Posts
+
+* Posts authored by non-Collaborator's are always subject to immediate Moderation by any Collaborator if the content is intentionally disruptive or in violation of the Node.js Code of Conduct.
+* When Moderating non-Collaborator Posts, the moderating Collaborator should:
+ * Explain the justification for Moderating the post, and
+ * Identify all changes made to the Post.
 * Explanations of Moderation actions for non-Collaborator Posts must be provided in:
  * The original Post being modified (as replacement or appended content),
  * A new post within the original thread, or
  * A new issue within the private nodejs/moderation repository.
-* Any Collaborator who habitually authors Posts that must be Moderated will be subject to possible removal from the Node.js Github Organization. Such action can only be taken through normal TSC motion and vote.
 * Moderation of Posts authored by non-Collaborators may result in those non-Collaborators being Banned from further participation in the Node.js Github Organization for an indefinite period of time.
-* Only a TSC member may Ban an individual from the Node.js Github Organization.
+
+#### Requesting Moderation
+
+Requests to Moderate a Post are only necessary when the Post in question was written by a Collaborator.
+
+Requesting Moderation of a Post can be accomplished in one of five ways:
+
+* Private communication between the individuals involved,
+* Via the `report@io.js` email address,
+* Via private email to individual TSC members,
+* Via a new Post in the same thread as the Post being requested for Moderation, or
+* Via a new Post in the private nodejs/moderation repository.
+
+Use of the `report@io.js` email address, or private email to individual TSC members, is appropriate when the individual requesting the Moderation does not feel comfortable directly or publicly making the request. All emails sent to the `report@io.js` address are currently forwarded to all members of the TSC. [[ED NOTE: This has not yet been set up]]
+
+Requests should contain as much information and context as possible, including the URL of the Post in question.
+
+External public venues or social media services such as Twitter should never be used to request Moderation or to discuss the details of a Moderation request.
+
+### Consideration of Intent
+
+Before Moderating a Post, Collaborator's should carefully consider the possible intent of the author. It may be that the author has simply made an error or is not familiar with the Code of Conduct; or it may be that cultural differences exist or that the author is unaware that certain content is considered inappropriate. Unless the offense or the intent to disrupt, annoy or harass is obvious, an author should be given the benefit of the doubt and be given an opportunity to correct any mistake that may have been made.
 
 ### Privacy of the nodejs/moderation Repository
 
-The nodejs/moderation Repository is used to discuss the details of any specific proposed or actual Moderation or Banning action. The repository is private but accessible to all Collaborators. The details of any issue discussed within the nodejs/moderation repository are expected to remain confidential and are not to be discussed in any external or public forum.
+The nodejs/moderation Repository is used to discuss the potentially sensitive details of any specific proposed or actual Moderation or Banning action. The repository is private but accessible to all Collaborators. The details of any issue discussed within the nodejs/moderation repository are expected to remain confidential and are not to be discussed in any public forum or social media service.
 
 ### Modifications to This Policy
 
-Modifications to this policy are made through normal TSC motion and vote. Any Collaborator may submit a PR proposing changes to this policy. Those PRs must be labeled using the `tsc-agenda` label.
+Modifications to this policy are made through normal [TSC motion and vote](https://github.com/nodejs/TSC/blob/master/TSC-Charter.md#section-8-voting). Any Collaborator may submit a PR proposing changes to this policy. Those PRs must be labeled using the `tsc-agenda` label. Including a mention to `@nodejs/tsc` can be used to call the issue to TSC's attention.

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -45,7 +45,7 @@ Anyone may request Moderation of a Post. Requesting Moderation of a Post can be 
 
 Use of the `report@node.js` email address -- or private email to individual TSC members -- is appropriate when the individual requesting the Moderation does not feel comfortable directly or publicly making the request. All emails sent to the `report@node.js` address are currently forwarded to all members of the TSC. [[ED NOTE: This has not yet been set up]]
 
-When a request is sent by email to the `report@node.js` (or directly to a TSC member) a new issue detailing the request must be created in the private nodejs/moderation repository. The identity of the individual submitting the request should be omitted from that issue unless specified by the reporter.
+When a request is sent by email to the `report@node.js` (or directly to a TSC member) a new issue detailing the request must be created in the private nodejs/moderation repository. The identity of the individual submitting the request should be omitted from the issue unless permission to include the identity is provided by the reporter.
 
 Requests should contain as much information and context as possible, including the URL and a screenshot of the Post in question. Screenshots should be modified to obscure obscene or offensive content.
 

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -8,6 +8,12 @@ Individual Working Groups and Top Level Projects chartered by the TSC may adopt 
 * The Moderation Policy is openly documented as part of the Working Group or Project Charter and;
 * Includes provisions for clearly and openly documenting Moderation actions taken.
 
+If a particular repository can be considered to fall under the stewardship of multiple Working Groups (or Top Level Projects) that have adopted different Moderation Policies, they can choose to either:
+* Decide between themselves which Moderation Policy will be in effect for the repository in question, or
+* Ask the TSC to determine which Moderation Policy should apply.
+
+Any alternative Moderation Policy used for a given repository must be included in the root directory of the repository using the `Moderation-Policy.md` filename.
+
 ### Terms
 
 * "Collaborator" refers to any individual member or "outside collaborator" of the Node.js Github Organization.
@@ -22,9 +28,34 @@ Individual Working Groups and Top Level Projects chartered by the TSC may adopt 
 * Only a TSC member may Ban an individual from the Node.js Github Organization.
 * Any individual Banned from the Node.js Github Organization will be recommended for exclusion from any Node.js Foundation sponsored event or activity.
 
+#### Requesting Moderation
+
+Anyone may request Moderation of a Post.
+
+Moderation requests are only necessary when the Post in question was either:
+ 
+* Authored by a Collaborator, or
+* The request is originating from a non-Collaborator.
+
+Requesting Moderation of a Post can be accomplished in one of five ways:
+
+* Private communication between the individuals involved,
+* Via the `report@io.js` email address,
+* Via private email to individual TSC members,
+* Via a new Post in the same thread as the Post being requested for Moderation, or
+* Via a new Post in the private nodejs/moderation repository.
+
+Use of the `report@io.js` email address, or private email to individual TSC members, is appropriate when the individual requesting the Moderation does not feel comfortable directly or publicly making the request. All emails sent to the `report@io.js` address are currently forwarded to all members of the TSC. [[ED NOTE: This has not yet been set up]]
+
+Requests should contain as much information and context as possible, including the URL and a screenshot of the Post in question. Screenshots may be modified to obscure obscene or offensive content.
+
+External public venues or social media services such as Twitter should never be used to request Moderation or to discuss the details of a Moderation request.
+
+Multiple moderation requests for the same Post are unnecessary.
+
 #### Collaborator Posts
 
-* Collaborator's must not Moderate any Post authored by another Collaborator without first giving the author an opportunity of at least 24 hours (from the time of the initial request) to modify or remove the Post on their own.
+* Collaborator's must not Moderate any Post authored by another Collaborator without first giving the author at least 24 hours (from the time of the initial request) to modify or remove the Post on their own.
 * In extreme circumstances the TSC can be consulted to waive the 24 hour grace period.
 * If the author of the Post disagrees that Moderation is required, the matter can be escalated to the TSC by creating a new issue (or using an existing one) within the nodejs/moderation repository with the label `tsc-agenda`. In such cases, the TSC will serve as the final arbiter.
 * For Moderation issues involving a TSC member, the member in question is expected to recuse themselves from any decisions required to resolve the issue.
@@ -43,29 +74,13 @@ Individual Working Groups and Top Level Projects chartered by the TSC may adopt 
 * When Moderating non-Collaborator Posts, the moderating Collaborator should:
  * Explain the justification for Moderating the post, and
  * Identify all changes made to the Post.
-* Explanations of Moderation actions for non-Collaborator Posts must be provided in:
+* If an explanation of a Moderation action for a non-Collaborator Post is provided, it must be provided in:
  * The original Post being modified (as replacement or appended content),
  * A new post within the original thread, or
  * A new issue within the private nodejs/moderation repository.
 * Moderation of Posts authored by non-Collaborators may result in those non-Collaborators being Banned from further participation in the Node.js Github Organization for an indefinite period of time.
 
-#### Requesting Moderation
-
-Requests to Moderate a Post are only necessary when the Post in question was written by a Collaborator.
-
-Requesting Moderation of a Post can be accomplished in one of five ways:
-
-* Private communication between the individuals involved,
-* Via the `report@io.js` email address,
-* Via private email to individual TSC members,
-* Via a new Post in the same thread as the Post being requested for Moderation, or
-* Via a new Post in the private nodejs/moderation repository.
-
-Use of the `report@io.js` email address, or private email to individual TSC members, is appropriate when the individual requesting the Moderation does not feel comfortable directly or publicly making the request. All emails sent to the `report@io.js` address are currently forwarded to all members of the TSC. [[ED NOTE: This has not yet been set up]]
-
-Requests should contain as much information and context as possible, including the URL of the Post in question.
-
-External public venues or social media services such as Twitter should never be used to request Moderation or to discuss the details of a Moderation request.
+Note that Moderating non-Collaborator posts can often lead to retaliation or escalation of inappropriate behavior by the individual whose post is being Moderated. This is true primarily of individuals whose intent is to harass, disrupt or annoy individual members of the community. In such cases, it is best to handle the Moderation as quickly and as quietly as possible without drawing any further undue attention to the Post in question.
 
 ### Consideration of Intent
 

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -4,11 +4,13 @@ If you are not a member of the Node.js GitHub Organization and wish to submit a 
 
 * [Applicability](#applicability)
 * [Terms](#terms)
+* [Grounds for Moderation](#grounds-for-moderation)
 * [Requesting Moderation](#requesting-moderation)
 * [Consideration of Intent](#consideration-of-intent)
 * [Policy](#policy)
  * [Collaborator Posts](#collaborator-posts)
  * [Non-Collaborator Posts](#non-collaborator-posts)
+* [Escalation to the TSC](#escalation-to-the-tsc)
 * [Privacy of the nodejs/moderation Repository](#privacy-of-the-nodejsmoderation-repository)
 * [TSC Delegation of Authority to a "Moderation Working Group"](tsc-delegation-of-authority-to-a-moderation-working-group)
 * [Modifications to this Policy](#modifications-to-this-policy)
@@ -30,9 +32,14 @@ Any alternative Moderation Policy used for a given repository must be included i
 ### Terms
 
 * "Collaborator" refers to any individual with configured access permissions to any Node.js GitHub organization repository. See [GitHub's access permissions documentation](https://help.github.com/articles/what-are-the-different-access-permissions/) for more information.
+* "TSC" refers to the [Node.js Technical Steering Committee](https://github.com/nodejs/node#tsc-technical-steering-committee).
 * "Post" refers to the content and titles of any issue, pull request, comment or wiki page.
 * "Moderate" refers to the act of modifying the content and title of, or deleting, any Post.
 * "Ban" refers to the act of blocking an individual GitHub account from any further participation in the Node.js GitHub Organization.
+
+### Grounds for Moderation
+
+Any Post considered to be in violation of the [Node.js Code of Conduct](https://GitHub.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md) is subject to Moderation.
 
 ### Requesting Moderation
 
@@ -61,20 +68,19 @@ Before Moderating a Post, Collaborators should carefully consider the possible i
 
 Note, however, that unfamiliarity with the [Code of Conduct](https://GitHub.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md) does not excuse a Post from Moderation.
 
-### Policy
+### Guidelines and Requirements
 
 * All Posts are expected to respect the [Node.js Code of Conduct](https://GitHub.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md).
 * Only Collaborators with commit rights to a given repository may Moderate Posts within that repository's issue tracker.
+* The TSC serves as the final arbiter for all Moderation issues (see [Escalation to the TSC](#escalation-to-the-tsc)).
 * Only a TSC member may Ban an individual from the Node.js GitHub Organization.
 * Any individual Banned from the Node.js GitHub Organization will be recommended for exclusion from any Node.js Foundation sponsored event or activity.
 
 #### Collaborator Posts
 
 * Collaborators must not Moderate any Post authored by another Collaborator without first giving the author at least 24 hours (from the time of the initial request) to modify or remove the Post on their own.
-* If the author of the Post disagrees that Moderation is required, the matter can be escalated to the TSC by creating a new issue (or using an existing one) within the nodejs/moderation repository with the label `tsc-agenda`. In such cases, the TSC will serve as the final arbiter.
-* While Moderation of a Collaborator's Post is in dispute, no Moderation action should be taken until a decision by the TSC is made.
+* If the author of the Post disagrees that Moderation is required, the matter can be [escalated to the TSC](#escalation-to-the-tsc) for resolution. In such cases, no Moderation action should be taken until a decision by the TSC is made.
 * In extreme circumstances involving either obvious gross violations of the [Node.js Code of Conduct](https://GitHub.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md) or possible compromise of a Collaborator's GitHub account, the TSC can be consulted to waive the 24 hour grace period and dispute process.
-* For Moderation issues involving a TSC member, the member in question is expected to recuse themselves from any decisions required to resolve the issue.
 * When Moderating any Post authored by another Collaborator, the moderating Collaborator must:
  * Explain the justification for Moderating the post,
  * Identify all changes made to the Post, and
@@ -90,13 +96,21 @@ Note, however, that unfamiliarity with the [Code of Conduct](https://GitHub.com/
 * When Moderating non-Collaborator Posts, the moderating Collaborator should:
  * Explain the justification for Moderating the post, and
  * Identify all changes made to the Post.
-* If an explanation of a Moderation action for a non-Collaborator Post is provided, it must be provided in:
+* If an explanation of a Moderation action for a non-Collaborator Post is provided, it should be provided in:
  * The original Post being modified (as replacement or appended content),
  * A new post within the original thread, or
  * A new issue within the private nodejs/moderation repository.
 * Moderation of Posts authored by non-Collaborators may result in those non-Collaborators being Banned from further participation in the Node.js GitHub Organization for an indefinite period of time.
 
 Note that Moderating non-Collaborator posts can often lead to retaliation or escalation of inappropriate behavior by the individual whose post is being Moderated. This is true primarily of individuals whose intent is to harass, disrupt or annoy individual members of the community. In such cases, it is best to handle the Moderation as quickly and as quietly as possible without drawing any further undue attention to the Post in question.
+
+### Escalation to the TSC
+
+Any Moderation issue or dispute can be escalated to the TSC by "mentioning" `@nodejs/tsc` in the body of a GitHub issue either in the original thread or in the private nodejs/moderation repository. Optionally, the `tsc-agenda` label may be attached to the issue to request that it be added to the TSC meeting agenda.
+
+All Moderation-related decisions follow the normal [TSC motion and voting process](https://GitHub.com/nodejs/TSC/blob/master/TSC-Charter.md#section-8-voting).
+
+TSC members directly involved in a Moderation issue -- as either the requester or author of the Post in question -- are expected to excuse themselves from any decisions required to resolve the issue.
 
 ### Privacy of the nodejs/moderation Repository
 

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -36,6 +36,7 @@ Any alternative Moderation Policy used for a given repository must be included i
 * "Post" refers to the content and titles of any issue, pull request, comment or wiki page.
 * "Moderate" refers to the act of modifying the content and title of, or deleting, any Post for the purpose of correcting or addressing Code of Conduct violations.
 * "Ban" refers to the act of blocking an individual GitHub account from any further participation in the Node.js GitHub Organization.
+* "Requester" refers to an individual requesting Moderation on a Post.
 
 ### Grounds for Moderation
 
@@ -77,7 +78,7 @@ Note, however, that unfamiliarity with the [Code of Conduct](https://GitHub.com/
 * The TSC serves as the final arbiter for all Moderation issues (see: [Escalation to the TSC](#escalation-to-the-tsc)).
 * Only a TSC member may Ban an individual from the Node.js GitHub Organization.
 * Any individual Banned from the Node.js GitHub Organization will be recommended for exclusion from any Node.js Foundation sponsored event or activity.
-* Minor edits to the formatting of a Post or to correct typographical errors are not considered to be "Moderation". Such edits and their intent should still be documented with a quick note indicating who made the edit and why.
+* Minor edits to the formatting of a Post or to correct typographical errors are not considered to be "Moderation". Such edits and their intent should still be documented with a short note indicating who made the edit and why.
 
 #### Collaborator Posts
 
@@ -109,7 +110,7 @@ Note that Moderating non-Collaborator posts can often lead to retaliation or esc
 
 #### Trolling
 
-Trolling is generally defined as the act of creating deliberatively offensive or provocative Posts for the sole purpose of derailing a conversation, stealing attention, inciting an angry response or disrupting the usability of physical and electronic spaces used by the contributors to the Node.js project. More specifically, within the context of the Node.js project, Trolling consists of *any behavior considered by the TSC to be intentionally disruptive, offensive or abusive*.
+Trolling is generally defined as the act of creating deliberately offensive or provocative Posts for the sole purpose of derailing a conversation, stealing attention, inciting an angry response or disrupting the usability of physical and electronic spaces used by the contributors to the Node.js project. More specifically, within the context of the Node.js project, Trolling consists of *any behavior considered by the TSC to be intentionally disruptive, offensive or abusive*.
 
 Trolling behavior of any kind is not tolerated and will be subject to immediate Moderation. The author of Trolling Posts will be subject to permanent Banning from the GitHub organization and will be recommended for exclusion from all Node.js Foundation events and activities.
 
@@ -121,7 +122,7 @@ Any Moderation issue or dispute can be escalated to the TSC by "mentioning" `@no
 
 All Moderation-related decisions follow the normal [TSC motion and voting process](https://GitHub.com/nodejs/TSC/blob/master/TSC-Charter.md#section-8-voting).
 
-TSC members directly involved in a Moderation issue -- as either the requester or author of the Post in question -- are expected to excuse themselves from any decisions required to resolve the issue.
+TSC members directly involved in a Moderation issue -- as either the Requester or author of the Post in question -- are expected to excuse themselves from any decisions required to resolve the issue.
 
 ### Privacy of the nodejs/moderation Repository
 

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -72,7 +72,7 @@ Note, however, that unfamiliarity with the [Code of Conduct](https://GitHub.com/
 
 * All Posts are expected to respect the [Node.js Code of Conduct](https://GitHub.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md).
 * Only Collaborators with commit rights to a given repository may Moderate Posts within that repository's issue tracker.
-* The TSC serves as the final arbiter for all Moderation issues (see [Escalation to the TSC](#escalation-to-the-tsc)).
+* The TSC serves as the final arbiter for all Moderation issues (see: [Escalation to the TSC](#escalation-to-the-tsc)).
 * Only a TSC member may Ban an individual from the Node.js GitHub Organization.
 * Any individual Banned from the Node.js GitHub Organization will be recommended for exclusion from any Node.js Foundation sponsored event or activity.
 
@@ -88,7 +88,7 @@ Note, however, that unfamiliarity with the [Code of Conduct](https://GitHub.com/
 * Explanations of Moderation actions on Collaborator Posts must be provided in:
  * A new post within the original thread, or
  * A new issue within the private nodejs/moderation repository.
-* Any Collaborator who habitually authors Posts that must be Moderated will be subject to possible removal from the Node.js GitHub Organization. Such action can only be taken through normal TSC motion and vote.
+* Any Collaborator who habitually authors Posts that must be Moderated can be Banned from further participation in the Node.js GitHub organization for an indefinite period of time. Such action can only be taken through normal TSC motion and vote (see: [Escalation to the TSC](#escalation-to-the-tsc)).
 
 #### Non-Collaborator Posts
 
@@ -100,7 +100,7 @@ Note, however, that unfamiliarity with the [Code of Conduct](https://GitHub.com/
  * The original Post being modified (as replacement or appended content),
  * A new post within the original thread, or
  * A new issue within the private nodejs/moderation repository.
-* Moderation of Posts authored by non-Collaborators may result in those non-Collaborators being Banned from further participation in the Node.js GitHub Organization for an indefinite period of time.
+* Moderation of Posts authored by non-Collaborators may result in those non-Collaborators being Banned from further participation in the Node.js GitHub organization for an indefinite period of time.
 
 Note that Moderating non-Collaborator posts can often lead to retaliation or escalation of inappropriate behavior by the individual whose post is being Moderated. This is true primarily of individuals whose intent is to harass, disrupt or annoy individual members of the community. In such cases, it is best to handle the Moderation as quickly and as quietly as possible without drawing any further undue attention to the Post in question.
 

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -47,8 +47,8 @@ Requesting Moderation of a Post can be accomplished in one of five ways:
 
 * Via the `report@node.js` email address,
 * Via private email to individual TSC members,
-* Via a new Post in the same thread as the Post being requested for Moderation, or
-* Via a new Post in the private nodejs/moderation repository.
+* Via a new Post in the same thread as the Post being requested for Moderation,
+* Via a new Post in the private nodejs/moderation repository, or
 * Private communication between the individuals involved,
 
 Use of the `report@node.js` email address, or private email to individual TSC members, is appropriate when the individual requesting the Moderation does not feel comfortable directly or publicly making the request. All emails sent to the `report@node.js` address are currently forwarded to all members of the TSC. [[ED NOTE: This has not yet been set up]]

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -43,6 +43,8 @@ Anyone may request Moderation of a Post. Requesting Moderation of a Post can be 
 * Via a new Post in the same thread as the Post being requested for Moderation,
 * Via a new Post in the private nodejs/moderation repository.
 
+Note that Collaborators may Moderate non-Collaborator Posts at any time without submitting an initial request (see: [Non-Collaborator Posts](#non-collaborator-posts)).
+
 Use of the `report@node.js` email address -- or private email to individual TSC members -- is appropriate when the individual requesting the Moderation does not feel comfortable directly or publicly making the request. All emails sent to the `report@node.js` address are currently forwarded to all members of the TSC. [[ED NOTE: This has not yet been set up]]
 
 When a request is sent by email to the `report@node.js` (or directly to a TSC member) a new issue detailing the request must be created in the private nodejs/moderation repository. The identity of the individual submitting the request should be omitted from the issue unless permission to include the identity is provided by the reporter.
@@ -52,8 +54,6 @@ Requests should contain as much information and context as possible, including t
 External public venues or social media services such as Twitter should never be used to request Moderation.
 
 Collaborators should never discuss the specific details of a Moderation request in any public forum or any social media service outside of the Node.js GitHub Organization.
-
-Note that Collaborators may Moderate non-Collaborator Posts at any time without submitting an initial request (see: [Non-Collaborator Posts](#non-collaborator-posts)).
 
 ### Consideration of Intent
 

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -34,7 +34,7 @@ Any alternative Moderation Policy used for a given repository must be included i
 * "Collaborator" refers to any individual with configured access permissions to any Node.js GitHub organization repository. See [GitHub's access permissions documentation](https://help.github.com/articles/what-are-the-different-access-permissions/) for more information.
 * "TSC" refers to the [Node.js Technical Steering Committee](https://github.com/nodejs/node#tsc-technical-steering-committee).
 * "Post" refers to the content and titles of any issue, pull request, comment or wiki page.
-* "Moderate" refers to the act of modifying the content and title of, or deleting, any Post.
+* "Moderate" refers to the act of modifying the content and title of, or deleting, any Post for the purpose of correcting or addressing Code of Conduct violations.
 * "Ban" refers to the act of blocking an individual GitHub account from any further participation in the Node.js GitHub Organization.
 
 ### Grounds for Moderation
@@ -77,6 +77,7 @@ Note, however, that unfamiliarity with the [Code of Conduct](https://GitHub.com/
 * The TSC serves as the final arbiter for all Moderation issues (see: [Escalation to the TSC](#escalation-to-the-tsc)).
 * Only a TSC member may Ban an individual from the Node.js GitHub Organization.
 * Any individual Banned from the Node.js GitHub Organization will be recommended for exclusion from any Node.js Foundation sponsored event or activity.
+* Minor edits to the formatting of a Post or to correct typographical errors are not considered to be "Moderation". Such edits and their intent should still be documented with a quick note indicating who made the edit and why.
 
 #### Collaborator Posts
 
@@ -105,6 +106,14 @@ Note, however, that unfamiliarity with the [Code of Conduct](https://GitHub.com/
 * Moderation of Posts authored by non-Collaborators may result in those non-Collaborators being Banned from further participation in the Node.js GitHub organization for an indefinite period of time.
 
 Note that Moderating non-Collaborator posts can often lead to retaliation or escalation of inappropriate behavior by the individual whose post is being Moderated. This is true primarily of individuals whose intent is to harass, disrupt or annoy individual members of the community. In such cases, it is best to handle the Moderation as quickly and as quietly as possible without drawing any further undue attention to the Post in question.
+
+#### Trolling
+
+Trolling is generally defined as the act of creating deliberatively offensive or provocative Posts for the sole purpose of derailing a conversation, stealing attention, inciting an angry response or disrupting the usability of physical and electronic spaces used by the contributors to the Node.js project. More specifically, within the context of the Node.js project, Trolling consists of *any behavior considered by the TSC to be intentionally disruptive, offensive or abusive*.
+
+Trolling behavior of any kind is not tolerated and will be subject to immediate Moderation. The author of Trolling Posts will be subject to permanent Banning from the GitHub organization and will be recommended for exclusion from all Node.js Foundation events and activities.
+
+Determination of what constitutes "Trolling behavior" within the Node.js project is solely at the discretion of the TSC.
 
 ### Escalation to the TSC
 

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -19,7 +19,7 @@ Individual Working Groups and Top Level Projects chartered by the TSC may adopt 
 
 * All Posts are expected to respect the Node.js Code of Conduct.
 * Only Collaborators with commit rights to a given repository may Moderate Posts within that repository's issue tracker.
-* Collaborator's must not Moderate any Post authored by another Collaborator without first giving the author an opportunity of at least 24 hours to modify or remove the Post on their own.
+* Collaborator's must not Moderate any Post authored by another Collaborator without first giving the author an opportunity of at least 24 hours to modify or remove the Post on their own. In extreme circumstances the TSC can be consulted to waive the 24 hour grace period.
 * Posts authored by non-Collaborator's are always subject to immediate Moderation by any Collaborator if the content is intentionally disruptive or in violation of the Node.js Code of Conduct.
 * When Moderating any Post authored by another Collaborator, the moderating Collaborator must:
  * Explain the justification for Moderating the post,


### PR DESCRIPTION
@nodejs/tsc ... This is a proposed default moderation policy for the github organization. Please consider it a work in progress. The goal is for moderation actions to be as clear and transparent as possible.

Specific highlights:

* Collaborators must not moderate other Collaborators posts without giving them at least 24 hours to edit it themselves
* All moderation actions must be clearly documented
* Use of the private nodejs/moderation repo is defined

/cc @nodejs/collaborators ... I would appreciate feedback from collaborators on this to ensure it meets the needs of the community.