### PR TITLE
mod-policy: remove ed note

### DIFF
--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -55,7 +55,7 @@ Anyone may request Moderation of a Post. Requesting Moderation of a Post can be 
 
 Note that Collaborators may Moderate non-Collaborator Posts at any time without submitting an initial request (see: [Non-Collaborator Posts](#non-collaborator-posts)).
 
-Use of the [report@nodejs.org](mailto:report@nodejs.org) email address -- or private email to individual TSC members -- is appropriate when the individual requesting the Moderation does not feel comfortable directly or publicly making the request. All emails sent to the [report@nodejs.org](mailto:report@nodejs.org) address are currently forwarded to all members of the TSC. [[ED NOTE: This has not yet been set up]]
+Use of the [report@nodejs.org](mailto:report@nodejs.org) email address -- or private email to individual TSC members -- is appropriate when the individual requesting the Moderation does not feel comfortable directly or publicly making the request. All emails sent to the [report@nodejs.org](mailto:report@nodejs.org) address are currently forwarded to all members of the TSC.
 
 When a request is sent by email to the [report@nodejs.org](mailto:report@nodejs.org) (or directly to a TSC member) a new issue detailing the request must be created in the private nodejs/moderation repository. The identity of the individual submitting the request should be omitted from the issue unless permission to include the identity is provided by the reporter.
 


### PR DESCRIPTION
Removal of Editorial Note that should have been removed on initial checkin
(does not change policy in any way)