### PR TITLE
Increasing the scope of the TSC and Incubator.

### DIFF
--- a/Project-Lifecycle.md
+++ b/Project-Lifecycle.md
@@ -98,6 +98,8 @@ vote to abstain from representation on the TSC.
 
 ## Applying to join
 
+The Node.js Foundation only admits projects written in Node.js.
+
 A proposal to join the Node.js Foundation as a top-level Project or
 Working Group must include:
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,42 @@
 
 The Node.js Foundation Technical Steering Committee is the technical governing body of the Node.js Foundation. It admits and oversees all top-level Projects in the Node.js Foundation. It also elects a representative to the Node.js Foundation Board of Directors.
 
+The TSC is community and contributor driven and is a home for community managed 
+projects and assets. The mission of the Node.js Foundation is to enable and encourage 
+the adoption of Node.js and the TSC is the home of the community driven portion
+of executing that mission.
+
+Since the Foundation and the TSC are intended to support the community the size and scope
+of the work and projects in it will grow to accomodate the needs of the community.
+
 For more details read the [TSC Charter](https://github.com/nodejs/TSC/blob/master/TSC-Charter.md) adopted by the Node.js Foundation Board of Directors on June 17th 2015.
 
 If your project is interested in joining the Node.js Foundation please read the [Project Lifecycle.md](./Project-Lifecycle.md) documentation.
+
+## Projects, Working Groups and the Incubator
+
+The Node.js Foundation is setup to be the home of multiple autonomous projects. Projects are 
+admitted into the incubator and are mentored until their governance and contributor 
+base reach a state of maturity. They are then given a proper charter and a seat on the TSC.
+
+The TSC also forms Working Groups to tackle tasks that don't scope to a single project. These 
+Working Groups can be given a seat on the TSC at the TSC's discretion.
+
+The goal of the Incubator is to:
+
+* Support the Node.js Ecosystem.
+* Provide a neutral "home" for projects so that they are not owned by a single individual or company.
+* Mentor projects in the Node.js community on open governance and liberal contribution policies.
+* Ensure that the Node.js Foundation does not charter projects that do not adhere to the values 
+of the Node.js Foundation. Projects must be: Transparent, Participatory and Effective.
+* The TSC does not "pick winners" and may admit multiple projects that serve similar use cases. 
+Admitting a project for incubation or even chartering it is not an endorsement by the Node.js 
+Foundation or TSC on the technical merits of a project, it is only an endorsement that the project 
+adheres to the TSC's values.
+
+Other than being written in Node.js there are no technical requirements on projects to be admitted
+into the Node.js Foundation. However, because resources may be limited from time to the TSC may
+elect to delay admission until resources become available.
 
 ## TSC Members
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Node.js Foundation Technical Steering Committee is the technical governing b
 
 It is the mission of the Node.js Foundation and the TSC to provide a home for 
 openly-governed and community-managed open source projects that are focused on 
-supporting and providing benefit to the entire Node.js ecosystem.
+supporting and providing benefit to the Node.js ecosystem.
 
 Project and Working Groups under the TSC are governed by the contributors
 and users of those projects.
@@ -39,7 +39,7 @@ The goal of the Incubator is to:
   Projects must be: Transparent, Participatory and Effective.
 * Ensure that the Node.js Foundation and the TSC does not "pick a winner" in 
   the ecosystem by equally and fairly mentoring multiple projects that serve 
-  similar use cases. Admitting project's for incubation, or chartering mature 
+  similar use cases. Admitting projects for incubation, or chartering mature 
   projects, is not an endorsement by the Node.js Foundation or TSC on the 
   technical merits of a project; rather, it is an endorsement that the project 
   adheres to the Node.js Foundation and TSC's open governance values.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 The Node.js Foundation Technical Steering Committee is the technical governing body of the Node.js Foundation. It admits and oversees all top-level Projects in the Node.js Foundation. It also elects a representative to the Node.js Foundation Board of Directors.
 
-The TSC is community and contributor driven and is a home for community managed 
-projects and assets. The mission of the Node.js Foundation is to enable and encourage 
-the adoption of Node.js and the TSC is the home of the community driven portion
-of executing that mission.
+It is the mission of the Node.js Foundation and the TSC to provide a home for 
+openly-governed and community-managed open source projects that are focused on 
+supporting and providing benefit to the entire Node.js ecosystem.
+
+Project and Working Groups under the TSC are governed by the contributors
+and users of those projects.
 
 Since the Foundation and the TSC are intended to support the community the size and scope
 of the work and projects in it will grow to accomodate the needs of the community.
@@ -16,28 +18,39 @@ If your project is interested in joining the Node.js Foundation please read the 
 
 ## Projects, Working Groups and the Incubator
 
-The Node.js Foundation is setup to be the home of multiple autonomous projects. Projects are 
-admitted into the incubator and are mentored until their governance and contributor 
-base reach a state of maturity. They are then given a proper charter and a seat on the TSC.
+The Node.js Foundation is structured to serve as a home for multiple 
+autonomous projects. Projects are first admitted into an incubation 
+phase where they are mentored until the project governance and 
+contributor base reaches a state of maturity. The TSC then works 
+with the project to establish an official charter and a seat on the TSC.
 
 The TSC also forms Working Groups to tackle tasks that don't scope to a single project. These 
 Working Groups can be given a seat on the TSC at the TSC's discretion.
 
 The goal of the Incubator is to:
 
-* Support the Node.js Ecosystem.
-* Provide a neutral "home" for projects so that they are not owned by a single individual or company.
-* Mentor projects in the Node.js community on open governance and liberal contribution policies.
-* Ensure that the Node.js Foundation does not charter projects that do not adhere to the values 
-of the Node.js Foundation. Projects must be: Transparent, Participatory and Effective.
-* The TSC does not "pick winners" and may admit multiple projects that serve similar use cases. 
-Admitting a project for incubation or even chartering it is not an endorsement by the Node.js 
-Foundation or TSC on the technical merits of a project, it is only an endorsement that the project 
-adheres to the TSC's values.
+* Support the ecosystem of Node.js users and contributors by providing a 
+  home for openly governed and community managed projects built on, or 
+  built to support Node.js.
+* Mentor projects within the Node.js community on open governance and liberal 
+  contribution policies.
+* Ensure that the Node.js Foundation does not charter projects that do not 
+  adhere to the values upon which the Node.js Foundation was established. 
+  Projects must be: Transparent, Participatory and Effective.
+* Ensure that the Node.js Foundation and the TSC does not "pick a winner" in 
+  the ecosystem by equally and fairly mentoring multiple projects that serve 
+  similar use cases. Admitting project's for incubation, or chartering mature 
+  projects, is not an endorsement by the Node.js Foundation or TSC on the 
+  technical merits of a project; rather, it is an endorsement that the project 
+  adheres to the Node.js Foundation and TSC's open governance values.
 
-Other than being written in Node.js there are no technical requirements on projects to be admitted
-into the Node.js Foundation. However, because resources may be limited from time to the TSC may
-elect to delay admission until resources become available.
+There are no technical requirements on projects to be admitted into the Node.js 
+Foundation incubator. The projects will, however, be evaluated on various 
+criteria including alignment with Node.js Foundation goals, support of and for 
+the Node.js ecosystem, and relevance of scope to Node.js development. 
+
+Because resources may be limited from time to time the TSC may elect to delay 
+admission until resources become available.
 
 ## TSC Members
 


### PR DESCRIPTION
After today's TSC meeting I sat down and attempted to write something that might define the scope of what we would or would not admit into the incubator. The more I tried to clarify that language the more I stop believing it could actually be done.

Here's the problem: If we are going to increase the scope of the TSC to supporting the ecosystem, which is to say we are opening it up to helping the broader community, then the scope and priorities of what to admit need to be dictated by that community and not whoever happens to be in the TSC at any given point in time. Whatever we could write in an attempt to define a scope will be incorrect because it will be driven by our own views of what the ecosystem is or needs rather than on what that community is actually asking for and saying that it needs.

All I believe we can do is outline what we can't do and outline how we will protect the foundation and the incubator from abuse or how we might protect any resources we have that are finite.

I imagine this will kick off a whole new discussion now about what the scope of the TSC and Incubator should be, so here's my personal thoughts:
- Proliferating open governance strengthens the resiliency of our community and, ultimately, of Node.js as a technology and a solution everywhere it is adopted. We have collected a surprising amount of experience in how to do this and know that there is no "one size fits all" approach, it's about values and mentorship.
- For a variety of reasons projects need a "home." We have very little control over when they decide they need that home but we do know, from some of our own experiences on the matter, that when the contributors/users decide they need a neutral home it's hard if not impossible to make progress without one. We could be that home and, provided we can do so at little to no cost to our existing liabilities, we probably should be.
- For better or worse we're now who people are looking to in the Node.js community for guidance. To me that means we have a responsibility to respond and offer our support because this is our community after all.

I'm not saying we should "grow just to grow." I'm saying that we should grow to be as big as our community is asking us to be. We have a fair amount of infrastructure that we've built and I'm having a very hard time figuring out exactly what we lose by using it to support _any_ part of our community that asks for it.
