### PR TITLE
Base Contribution policy.

### DIFF
--- a/BasePolicies/CONTRIBUTING.md
+++ b/BasePolicies/CONTRIBUTING.md
@@ -19,18 +19,20 @@ and the Node.js project.
 
 * A **Contributor** is any individual creating or commenting on an issue or pull request.
 * A **Committer** is a subset of contributors who have been given write access to the repository.
-* A **TC** is a group of committers representing the required technical expertise to 
-resolve rare disputes.
+* A **TC (Technical Committee)** is a group of committers representing the required technical 
+expertise to resolve rare disputes.
 
 # Logging Issues
 
 Log an issue for any question or problem you might have. When in doubt, log an issue, 
-any additional policies about what to include will be provided in the responses.
+any additional policies about what to include will be provided in the responses. The only
+exception is security dislosures which should be sent privately.
 
 Committers may direct you to another repository, ask for additional clarifications, and
 add appropriate metadata before the issue is addressed.
 
-Please be courteous, respectful, and follow the project's Code of Conduct.
+Please be courteous, respectful, and every participant is expected to follow the 
+project's Code of Conduct.
 
 # Contributions
 
@@ -38,20 +40,28 @@ Any change to resources in this repository must be through pull requests. This a
 to documentation, code, binary files, etc. Even long term committers and TC members must use
 pull requests.
 
-No pull request can be merged without being reviewed. Committers should try to avoid merging
-their own pull requests and allow other committers to accept and merge them.
+No pull request can be merged without being reviewed.
 
-For non-trivial contributions pull requests should sit for at least 36 hours to ensure that
-contributors in other timezones have time to review.
+For non-trivial contributions, pull requests should sit for at least 36 hours to ensure that
+contributors in other timezones have time to review. Consideration should also be given to 
+weekends and other holiday periods to ensure active committers all have reasonable time to 
+become involved in the discussion and review process if they wish.
 
 The default for each contribution is that it is accepted once no committer has an objection.
-There is no additional "sign off" process for contributions to land. Once all issues brought
-by committers are addressed it can be landed by any committer. The majority of contributions
-should land this way without escalation to the TC.
+During review committers may also request that a specific contributor who is most versed in a 
+particular area gives a "LGTM" before the PR can be merged. There is no additional "sign off" 
+process for contributions to land. Once all issues brought by committers are addressed it can 
+be landed by any committer.
+
+In the case of an objection being raised in a pull request by another committer, all involved 
+committers should seek to arrive at a consensus by way of addressing concerns being expressed 
+by discussion, compromise on the proposed change, or withdrawal of the proposed change.
 
 If a contribution is controversial and committers cannot agree about how to get it to land
 or if it should land then it should be escalated to the TC. TC members should regularly
-discuss pending contributions in order to find a resolution.
+discuss pending contributions in order to find a resolution. It is expected that only a 
+small minority of issues be brought to the TC for resolution and that discussion and 
+compromise among committers be the default resolution mechanism.
 
 # Becoming a Committer
 
@@ -66,8 +76,15 @@ proper review, and have other committers merge their pull requests.
 The TC uses a "consensus seeking" process for issues that are escalated to the TC. 
 The group tries to find a resolution that has no open objections among TC members.
 If a consensus cannot be reached that has no objections then a majority wins vote
-is called.
+is called. It is also expected that the majority of decisions made by the TC are via 
+a consensus seeking process and that voting is only used as a last-resort.
+
+Resolution may involve returning the issue to committers with suggestions on how to 
+move forward towards a consensus. It is not expected that a meeting of the TC 
+will resolve all issues on its agenda during that meeting and may prefer to continue
+the discussion happening among the committers.
 
 Members can be added to the TC at any time. Any committer can nominate another committer
 to the TC and the TC uses its standard consensus seeking process to evaluate whether or
-not to add this new member.
+not to add this new member. Members who do not participate consistently at the level of 
+a majority of the other members are expected to resign.

--- a/BasePolicies/CONTRIBUTING.md
+++ b/BasePolicies/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Log an issue for any question or problem you might have. When in doubt, log an i
 any additional policies about what to include will be provided in the responses.
 
 Committers may direct you to another repository, ask for additional clarifications, and
-add appropriate metadata before the issue addressed.
+add appropriate metadata before the issue is addressed.
 
 Please be courteous, respectful, and follow the project's Code of Conduct.
 

--- a/BasePolicies/CONTRIBUTING.md
+++ b/BasePolicies/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Node.js Community Contributing Guide 1.0
+
+This document describes a very simple process suitable for most projects
+in the Node.js ecosystem. Projects are encouraged to adopt this whether they
+are hosted in the Node.js or not.
+
+The goal of this document is to create a contribution process that:
+
+* Encourages new contributions.
+* Encourages contributors to remain involved.
+* Avoids unnecessary processes and beuracracy whenenver possible.
+* Creates a more transparent decision making process which makes it clear how
+contributors can be involved in decision making.
+
+This document is based on much prior art in the Node.js community, io.js,
+and the Node.js project.
+
+## Vocabulary
+
+* A **Contributor** is any individual creating or commenting on an issue or pull request.
+* A **Committer** is a subset of contributors who have been given write access to the repository.
+* A **TC** is a group of committers representing the required technical expertise to 
+resolve rare disputes.
+
+# Logging Issues
+
+Log an issue for any question or problem you might have. When in doubt, log an issue, 
+any additional policies about what to include will be provided in the responses.
+
+Committers may direct you to another repository, ask for additional clarifications, and
+add appropriate metadata before the issue addressed.
+
+Please be courteous, respectful, and follow the project's Code of Conduct.
+
+# Contributions
+
+Any change to resources in this repository must be pull requests. This applies to all change
+to documentation, code, binary files, etc. Even long term committers and TC members must be
+pull requests.
+
+No pull request can be merged by the person that created it.
+
+For non-trivial contributions pull requests should sit for at least 36 hours to ensure that
+contributors in other timezones have time to review.
+
+The default for each contribution is that it is accepted once no commiter has an objection.
+There is no additional "sign off" process for contributions to land. Once all issues brought
+by committers is addressed it can be landed by any committer. The majority of contributions
+should land this way without escalation to the TC.
+
+If a contribution is controversial and committers cannot agree about how to get it to land
+or if it should land then it should be escalated to the TC. TC members should regularly
+discuss pending contributions in order to find a resolution.
+
+# TC Process
+
+The TC uses a "consensus seeking" process for issues that are esclated to the TC. 
+The group tries to find a resolution that has no open objections among TC members.
+If a resolution cannot be reached that has no objections then a majority wins vote
+is called.
+
+Members can be added to the TC at any time. Any committer can nominate another committer
+to the TC and the TC uses its standard consensus seeking process to evaluate whether or
+not to add this new member.

--- a/BasePolicies/CONTRIBUTING.md
+++ b/BasePolicies/CONTRIBUTING.md
@@ -2,13 +2,13 @@
 
 This document describes a very simple process suitable for most projects
 in the Node.js ecosystem. Projects are encouraged to adopt this whether they
-are hosted in the Node.js or not.
+are hosted in the Node.js Foundation or not.
 
 The goal of this document is to create a contribution process that:
 
 * Encourages new contributions.
 * Encourages contributors to remain involved.
-* Avoids unnecessary processes and beuracracy whenever possible.
+* Avoids unnecessary processes and bureaucracy whenever possible.
 * Creates a transparent decision making process which makes it clear how
 contributors can be involved in decision making.
 
@@ -34,18 +34,19 @@ Please be courteous, respectful, and follow the project's Code of Conduct.
 
 # Contributions
 
-Any change to resources in this repository must be pull requests. This applies to all change
-to documentation, code, binary files, etc. Even long term committers and TC members must be
+Any change to resources in this repository must be through pull requests. This applies to all changes
+to documentation, code, binary files, etc. Even long term committers and TC members must use
 pull requests.
 
-No pull request can be merged by the person that created it.
+No pull request can be merged without being reviewed. Committers should try to avoid merging
+their own pull requests and allow other committers to accept and merge them.
 
 For non-trivial contributions pull requests should sit for at least 36 hours to ensure that
 contributors in other timezones have time to review.
 
-The default for each contribution is that it is accepted once no commiter has an objection.
+The default for each contribution is that it is accepted once no committer has an objection.
 There is no additional "sign off" process for contributions to land. Once all issues brought
-by committers is addressed it can be landed by any committer. The majority of contributions
+by committers are addressed it can be landed by any committer. The majority of contributions
 should land this way without escalation to the TC.
 
 If a contribution is controversial and committers cannot agree about how to get it to land
@@ -54,7 +55,7 @@ discuss pending contributions in order to find a resolution.
 
 # Becoming a Committer
 
-All contributors who send a non-trivial contribution should be on-boarded in a timely manner,
+All contributors who land a non-trivial contribution should be on-boarded in a timely manner,
 and added as a committer, and be given write access to the repository.
 
 Committers are expected to follow this policy and continue to send pull requests, go through
@@ -62,9 +63,9 @@ proper review, and have other committers merge their pull requests.
 
 # TC Process
 
-The TC uses a "consensus seeking" process for issues that are esclated to the TC. 
+The TC uses a "consensus seeking" process for issues that are escalated to the TC. 
 The group tries to find a resolution that has no open objections among TC members.
-If a resolution cannot be reached that has no objections then a majority wins vote
+If a consensus cannot be reached that has no objections then a majority wins vote
 is called.
 
 Members can be added to the TC at any time. Any committer can nominate another committer

--- a/BasePolicies/CONTRIBUTING.md
+++ b/BasePolicies/CONTRIBUTING.md
@@ -8,8 +8,8 @@ The goal of this document is to create a contribution process that:
 
 * Encourages new contributions.
 * Encourages contributors to remain involved.
-* Avoids unnecessary processes and beuracracy whenenver possible.
-* Creates a more transparent decision making process which makes it clear how
+* Avoids unnecessary processes and beuracracy whenever possible.
+* Creates a transparent decision making process which makes it clear how
 contributors can be involved in decision making.
 
 This document is based on much prior art in the Node.js community, io.js,
@@ -52,10 +52,10 @@ If a contribution is controversial and committers cannot agree about how to get 
 or if it should land then it should be escalated to the TC. TC members should regularly
 discuss pending contributions in order to find a resolution.
 
-# Becoming a committer.
+# Becoming a Committer
 
-All contributors who send a non-trivial contribution should be on-boarded in a timely manor
-and added as a committer and be given write access to the repository.
+All contributors who send a non-trivial contribution should be on-boarded in a timely manner,
+and added as a committer, and be given write access to the repository.
 
 Committers are expected to follow this policy and continue to send pull requests, go through
 proper review, and have other committers merge their pull requests.

--- a/BasePolicies/CONTRIBUTING.md
+++ b/BasePolicies/CONTRIBUTING.md
@@ -52,6 +52,14 @@ If a contribution is controversial and committers cannot agree about how to get 
 or if it should land then it should be escalated to the TC. TC members should regularly
 discuss pending contributions in order to find a resolution.
 
+# Becoming a committer.
+
+All contributors who send a non-trivial contribution should be on-boarded in a timely manor
+and added as a committer and be given write access to the repository.
+
+Committers are expected to follow this policy and continue to send pull requests, go through
+proper review, and have other committers merge their pull requests.
+
 # TC Process
 
 The TC uses a "consensus seeking" process for issues that are esclated to the TC. 


### PR DESCRIPTION
Talking to @dougwilson in the express thread made me realize that we don't have a simple explanation of our preferred processes that is suitable for simple project.

Now that we're potentially admitting hundreds of individual repos that feed into a single TC I figured it was important to explain the flow of contributions and the governance in a much plainer way.

I also realized that this would make a good starting point for projects in the Node.js Community.