### PR TITLE
Flatten project, scope TSC, big changes to structure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,30 +24,24 @@ Adding a new project or working group can be done through a pull request. Since
 each group is autonomous any new group taking on responsibility from another
 group would need that group's approval.
 
+Any project or working group can create teams at their discretion. Any org member
+can create a new repo for organizing this kind of effort without a charter or other
+process. Examples of Core teams are: Long Term Support, Cryto, Roadmap, Benchmark,
+Streams, Testing.
+
 ## Projects
 
 * Core
 * Website
-* Streams
-* Docker
 * nan
 
 ## Working Groups
 
 * Inclusivity
 * Build
-* Tracing
 * i18n
 * Evangelism
-* Roadmap
-* Addon API
-* Benchmarking
-* Post-mortem
-* Intl
-* HTTP
 * Documentation
-* Promises
-* Security
 
 ## Mentorship Program
 

--- a/README.md
+++ b/README.md
@@ -1,62 +1,66 @@
 # The Node.js Foundation TSC
 
-The Node.js Foundation Technical Steering Committee is the technical governing body of the Node.js Foundation. It admits and oversees all top-level Projects in the Node.js Foundation. It also elects a representative to the Node.js Foundation Board of Directors.
+This is the primary communication and governance hub of the Node.js
+Foundation's Technical Steering Committee. Its goal are:
 
-For more details read the [TSC Charter](https://github.com/nodejs/TSC/blob/master/TSC-Charter.md) adopted by the Node.js Foundation Board of Directors on June 17th 2015.
+* Maintaining, releasing and improving a healthy Node.js Core project.
+* Fostering and encouraging a healthy Node.js open source ecosystem.
 
-If your project is interested in joining the Node.js Foundation please read the [Project Lifecycle.md](./Project-Lifecycle.md) documentation.
+# TSC
+
+The TSC has many working groups and projects. Each group and project
+has a connection to the development of Node.js Core but their work and
+responsibilities often extend far beyond Core and potentially even Node.js.
+
+The TSC also leads several efforts to improve the health and sustainability
+of the ecosystem but it not a long term host of ecosystem projects which are
+not integrated into Core development.
+
+Each effort, project, and working group is autonomous. The scope of work and 
+autonomy is described in their charter. The TSC works to increase communication 
+and collaboration between these parts.
+
+Adding a new project or working group can be done through a pull request. Since
+each group is autonomous any new group taking on responsibility from another
+group would need that group's approval.
+
+## Projects
+
+* Core
+* Website
+* Streams
+* Docker
+* nan
+
+## Working Groups
+
+* Inclusivity
+* Build
+* Tracing
+* i18n
+* Evangelism
+* Roadmap
+* Addon API
+* Benchmarking
+* Post-mortem
+* Intl
+* HTTP
+* Documentation
+* Promises
+* Security
+
+## Mentorship Program
+
+The TSC administers a mentorship program for critical projects in the ecosystem.
+Projects are assigned mentors from the TSC to adapt modern best practices to the 
+specific needs of each project.
+
+* libuv
+* Express
+
 
 ## TSC Members
 
-TSC members are responsible for top level technical community concerns. The role is 
-mostly administrative and is responsible for admitting new Top Level Projects, Top Level
-Working Groups, and advocating for any needs in the technical side of the foundation to
-the Node.js Foundation Board of Directors.
-
-TSC members can nominate new members at any time. Candidates for membership tend to be people
-who have a competancy for community management and a high tolerance and patience for process
-minutiae as the TSC delegates most of its responsibilities to other projects and working groups.
-
-Every Top Level Project not currently incubating can appoint someone to the TSC who they elect
-at their own discretion.
-
-## Top-Level WGs and TLPs
-
-* [Working Groups](WORKING_GROUPS.md)
-* Mentors
-
-    Project mentorship is not a technical role. In fact, mentors are
-    discouraged from giving technical advice to projects. Instead, the
-    purpose of mentorship is to encourage and improve a projects ability
-    to be participatory, transparent, and effective. Mentors are there to
-    help projects adopt and iterate on policies and processes that achieve
-    these goals and eventually allow them to graduate the incubation phase.
-
-      * Mikeal Rogers (@mikeal)
-* Top-Level Projects
- * Core TLP
-  * Core WGs (streams, http, Intl)
-
-## Policy Change Proposal Process
-
-The Node.js TSC is chartered to oversee the technical governance of all Top
-Level Projects and Working Groups under the Node.js Foundation. The TSC
-establishes the default governance, conduct, and licensing policies for all Top
-Level Projects. Top Level Projects and Working Groups have broad powers of
-self-governance.
-
-To propose a change or addition to policies or processes that are intended to
-cover all Top Level Projects and Working Groups in the foundation, a PR should
-be opened in the `nodejs/TSC` repository.
-
-The pull request can be labeled `tsc-agenda` to request that it be put on the
-agenda for the next TSC meeting.
-
-The Node.js Foundation Board of Directors retains certain rights (especially
-legal considerations). If the TSC endorses a proposal, they will escalate to the
-Node.js Foundation Board of Directors when required to do so.
-
-In some cases, existing individual groups have the right to refuse changes to
-their charters. The TSC can not mandate existing working groups alter their
-charters. If such a situation arises, the TSC may decide to revoke the group's
-charter.
+TSC members are responsible for administration and communitication. The role is 
+mostly administrative and is responsible for admitting new projects, working groups 
+and representing them to  Node.js Foundation Board of Directors.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # The Node.js Foundation TSC
 
 This is the primary communication and governance hub of the Node.js
-Foundation's Technical Steering Committee. Its goal are:
+Foundation's Technical Steering Committee. Its goals are:
 
 * Maintaining, releasing and improving a healthy Node.js Core project.
 * Fostering and encouraging a healthy Node.js open source ecosystem.
@@ -13,12 +13,12 @@ has a connection to the development of Node.js Core but their work and
 responsibilities often extend far beyond Core and potentially even Node.js.
 
 The TSC also leads several efforts to improve the health and sustainability
-of the ecosystem but it not a long term host of ecosystem projects which are
+of the ecosystem but it is not a long term host of ecosystem projects which are
 not integrated into Core development.
 
-Each effort, project, and working group is autonomous. The scope of work and 
+Each project and working group is autonomous. The scope of work and 
 autonomy is described in their charter. The TSC works to increase communication 
-and collaboration between these parts.
+and collaboration between all these parts.
 
 Adding a new project or working group can be done through a pull request. Since
 each group is autonomous any new group taking on responsibility from another
@@ -57,7 +57,6 @@ specific needs of each project.
 
 * libuv
 * Express
-
 
 ## TSC Members
 


### PR DESCRIPTION
Based on the recent TSC meeting and some of the feedback I've gotten on recent issues I've logged I created this initial draft of a new structure.

This does a few critical things:

* Sets the boundary for "long term project hosting" under the TSC to projects that are connected to Core development. However, it makes it clear that projects that are connected to Core development may stretch far beyond the needs of Core (evangelism, website, documentation).
* Renames the "Incubator" to "Mentorship" in order to reduce many false assumptions from Apache's Incubator. This still reserves the ability for the TSC to intervene in projects outside of the above scope, like Express, without assuming the TSC will host them long term. The issue of where to host these projects long term is a question for another day -- there are many options we can explore.
* Flattens all projects and Working Groups under the TSC. The line between what should and should not be under the CTC was always a bit difficult to draw. Flattening makes autonomy more clear and allows the TSC to focus on improving communication and collaboration between the different parts (which the CTC has never done much of because it's so focused on the needs of direct Core development).

There's some very good things this accomplishes.
*  It solves the "blessing projects" problem. By not hosting projects next to Core we can avoid making them "official."
* It makes the TSC focus on some core problems we're experiencing at scale.
 * Automating reporting, communication and transparency for projects and working groups.
 * Creating and promoting contribution and governance policies for use both within the TSC and **in the ecosystem**.
 * Creating measurements and tools for evaluating project health. First for use within the Foundation but conceptually for use outside it later on.

The good thing about flattening this stuff and staying away from a hierarchy is that we do a better and more explicit job of groups being service providers. This allows group to be more effective in this role within the project but also with the broader community.

What is not yet resolved is the question of who is on the TSC. Proportional representation is difficult, anything as simple as "one rep per project" ignores the disparity in contributors and scope between projects.

This document also isn't enough, there's a lot of other process points in other now irrelevant documents.

And finally, because this is a huge change that effects every group and project it's going to need to reach a consensus among all the sub projects. @nodejs/tsc @nodejs/ctc 

