### PR TITLE
Added link about personal identity

### DIFF
--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -40,11 +40,11 @@ for the Node.js project:
 Its responsibilites are:
 
 * Foster a welcoming environment that ensures participants are valued and can
-feel confident contributing or joining discussions, regardless of any aspect of 
-their identity.
+feel confident contributing or joining discussions, regardless of any [aspect of
+their identity](https://github.com/nodejs/inclusivity/#list-of-responsibilities).
 * Proactively seek and propose concrete steps the project can take to increase
 inclusivity.
-* Serve as a resource for the development and enforcement of workflows that 
+* Serve as a resource for the development and enforcement of workflows that
 protect community members and projects from harassment and abuse.
 * Acknowledge and celebrate existing diversity accomplishments within the
 project while seeking to build upon them.

--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -30,6 +30,11 @@ NOTE: Technical Working Groups exist in the [nodejs/node repository](https://git
 
 ### [Inclusivity](https://github.com/nodejs/inclusivity)
 
+<!--
+This information should mostly mirror:
+https://github.com/nodejs/inclusivity#statement-of-purpose
+-->
+
 The Inclusivity Working Group seeks to increase inclusivity and diversity
 for the Node.js project:
   * *Increasing inclusivity* means making the Node.js project a safe and
@@ -38,6 +43,11 @@ for the Node.js project:
     backgrounds to the Node.js project and maintaining their participation.
 
 Its responsibilites are:
+
+<!--
+This information should mostly mirror:
+https://github.com/nodejs/inclusivity/blob/master/README.md#list-of-responsibilities
+-->
 
 * Foster a welcoming environment that ensures participants are valued and can
 feel confident contributing or joining discussions, regardless of any [aspect of


### PR DESCRIPTION
While reviewing https://github.com/nodejs/nodejs.org/pull/623, I noticed that the list of identity traits was removed from the list of responsibilities for the Inclusivity WG section from [TSC/WORKING_GROUPS.md](https://github.com/nodejs/TSC/blob/master/WORKING_GROUPS.md) that is present in [inclusivity/README.md](https://github.com/nodejs/inclusivity/blob/master/README.md).

I think this list of identities is important for understanding what this responsibility means, but at the same time I understand how much length it adds to the document and why it was removed.

As a compromise, I added a link to the Inclusivity WG's section on responsibilities so that people can discover the list and the full meaning of this responsibility without bloating the length of this document.