### PR TITLE
put bootstrap template in markdown code fence

### DIFF
--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -93,6 +93,7 @@ documentation for governance, contribution, conduct and an MIT
 LICENSE. The WG is free to change these documents through their own
 governance process, hence the term "bootstrap."
 
+```markdown
 ### *[insert WG name]* Working Group
 
 The Node.js *[insert WG name]* is jointly governed by a Working Group (WG)
@@ -253,3 +254,4 @@ The [Node.js Code of Conduct][] applies to this WG.
 
 [Node.js Code of Conduct]: https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md
 [Node.js Moderation Policy]: https://github.com/nodejs/TSC/blob/master/Moderation-Policy.md
+```


### PR DESCRIPTION
Markdown inside markdown!

It is hard to tell that the **Bootstrap** section is a template at first. This PR just adds a code fence around the template section to make it more obvious.

Make sure to hit the "View" button to see how it looks rendered.