### PR TITLE
put admittance on hold & correct links. fixes #73

### DIFF
--- a/Project-Lifecycle.md
+++ b/Project-Lifecycle.md
@@ -63,7 +63,7 @@ is expected to be larger than the TSC.
 
 The Foundation shall encourage new Projects and innovation in the
 community. New Projects enter the Node.js Foundation through a
-[Proposal](#Proposal).
+[Proposal](#applying-to-join).
 
 The project should be considered mature and have a history of releases
 before applying to enter the foundation.
@@ -97,6 +97,9 @@ Each TLP TC must elect a representative to the Node.js Foundation TSC or
 vote to abstain from representation on the TSC.
 
 ## Applying to join
+
+**SPECIAL NOTICE:**
+Project [admittance is on hold](#admittance).
 
 A proposal to join the Node.js Foundation as a top-level Project or
 Working Group must include:
@@ -134,10 +137,6 @@ BSD, ISC or Apache2 license.
 
 ### Admittance
 
-The Node.js Foundation is quite new and currently has limited resources
-available to mentor new projects. As such, projects are chosen for
-admission in groups as mentors become available.
-
-You can apply at any time and the TSC and available mentors will help
-improve your application while awaiting the next available approval
-phase.
+**SPECIAL NOTICE:**
+The TSC is not currently accepting new applications while it defines a 
+suitable organizational structure that can accommodate new projects.

--- a/README.md
+++ b/README.md
@@ -20,26 +20,26 @@ minutiae as the TSC delegates most of its responsibilities to other projects and
 Every Top Level Project not currently incubating can appoint someone to the TSC who they elect
 at their own discretion.
 
+## Mentors
+
+Project mentorship is not a technical role. In fact, mentors are
+discouraged from giving technical advice to projects. Instead, the
+purpose of mentorship is to encourage and improve a projects ability
+to be participatory, transparent, and effective. Mentors are there to
+help projects adopt and iterate on policies and processes that achieve
+these goals and eventually allow them to graduate the incubation phase.
+
+  * Mikeal Rogers (@mikeal) Currently assigned to Express.
+  * James Snell (@jasnell) Currently assigned to Express.
+  * Rod Vagg (@rvagg) Currently assigned to libuv.
+  * Alexis Campailla (@orangemocha) Currently assigned to libuv.
+
 ## Top-Level WGs and TLPs
-
-* [Working Groups](WORKING_GROUPS.md)
-* Mentors
-
-    Project mentorship is not a technical role. In fact, mentors are
-    discouraged from giving technical advice to projects. Instead, the
-    purpose of mentorship is to encourage and improve a projects ability
-    to be participatory, transparent, and effective. Mentors are there to
-    help projects adopt and iterate on policies and processes that achieve
-    these goals and eventually allow them to graduate the incubation phase.
-
-      * Mikeal Rogers (@mikeal) Currently assigned to Express.
-      * James Snell (@jasnell) Currently assigned to Express.
-      * Rod Vagg (@rvagg) Currently assigned to libuv.
-      * Alexis Campailla (@orangemocha) Currently assigned to libuv.
 
 * Top-Level Projects
  * Core TLP
   * Core WGs (streams, http, Intl)
+* [Working Groups](WORKING_GROUPS.md)
 
 ## Policy Change Proposal Process
 


### PR DESCRIPTION
Per #73, adding a note about not accepting projects at this time. I decided against @mikeal's suggestion to remove the entire "Apply To Join" section since I think it provides needed context/documentation/history for others. Instead, I just added some notes about it being on-hold.

README.md changes:
There was a "Mentors" bullet that seemed better suited in its own section- and this provided a hash reference (#mentors) for Project-Lifecycle.md.
