### PR TITLE
Add term "collaborator" to CONTRIBUTING.md

### DIFF
--- a/BasePolicies/CONTRIBUTING.md
+++ b/BasePolicies/CONTRIBUTING.md
@@ -19,6 +19,7 @@ and the Node.js project.
 
 * A **Contributor** is any individual creating or commenting on an issue or pull request.
 * A **Committer** is a subset of contributors who have been given write access to the repository.
+* A **Collaborator** is a committer, but may use more time labelling and closing issues, rather than commit code.
 * A **TC (Technical Committee)** is a group of committers representing the required technical 
 expertise to resolve rare disputes.
 


### PR DESCRIPTION
I've previously opened issue https://github.com/nodejs/TSC/issues/89 to clarify the difference between "committer" and "collaborator". It's very confusing that `Baseline/CONTRIBUTING.md` doesn't even mention "collaborator", when that's clearly the term most feel comfortable using compared to "committer", ref comments in #89.

I couldn't really find a good definition for it my self which makes sense compared to "committer", any thoughts and suggestions are much appreciated. And if we can't really find a good definition for it, might I suggest we drop using "committer" and stick with "collaborator"?

Closes https://github.com/nodejs/TSC/issues/89
