### PR TITLE
add all meeting minutes to date

### DIFF
--- a/meetings/2015-12-03.md
+++ b/meetings/2015-12-03.md
@@ -1,0 +1,1 @@
+No meeting minutes were taken.

--- a/meetings/2016-01-07.md
+++ b/meetings/2016-01-07.md
@@ -1,0 +1,52 @@
+# Node Foundation TSC Meeting 2016-01-07
+## Links
+
+* **Video Recording**: Not available
+* **GitHub Issue**: https://github.com/nodejs/TSC/issues/27
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1_37koaKsVacCB6_iBdZ1qka5UVzKVF3fm6QUBpveuFk>
+* **Previous Minutes Google Doc**: ???
+
+## Present
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+
+### nodejs/node
+
+* invite prior contributors to the nodejs org [#3802](https://github.com/nodejs/node/issues/3802)
+
+### nodejs/email
+
+* Add inclusivity@ for inclusivity WG [#13](https://github.com/nodejs/email/pull/13)
+* email: add lts email alias [#12](https://github.com/nodejs/email/pull/12)
+
+### nodejs/TSC
+
+* doc: add Working Groups document [#24](https://github.com/nodejs/TSC/pull/24)
+
+## Standup
+
+
+
+
+## Review of last meeting
+
+
+???
+
+
+## Minutes
+
+### invite prior contributors to the nodejs org [#3802](https://github.com/nodejs/node/issues/3802)
+
+### nodejs/email
+* Add inclusivity@ for inclusivity WG [#13](https://github.com/nodejs/email/pull/13)
+* email: add lts email alias [#12](https://github.com/nodejs/email/pull/12)
+
+### doc: add Working Groups document [#24](https://github.com/nodejs/TSC/pull/24)
+
+## Next Meeting
+
+2016-01-14 ??
+

--- a/meetings/2016-01-14.md
+++ b/meetings/2016-01-14.md
@@ -1,0 +1,48 @@
+# Node Foundation TSC Meeting 2016-01-14
+
+## Links
+
+* **Video Recording**: Not available
+* **GitHub Issue**: https://github.com/nodejs/TSC/issues/31
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1jYeIgo3rEUyV0haqFQ4pEvo2lDVitJMWNeIXLRrssuM/edit>
+* **Previous Minutes Google Doc**: https://docs.google.com/document/d/1_37koaKsVacCB6_iBdZ1qka5UVzKVF3fm6QUBpveuFk
+
+## Present
+
+* Rod Vagg (TSC)
+* Mikeal Rogers (Observer)
+* James Snell (TSC)
+* Alexis Campailla (TSC)
+* Jeremiah Senkpiel (TSC)
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+
+### nodejs/TSC
+
+* add inclusivity working group [#29](https://github.com/nodejs/TSC/pull/29)
+
+
+## Standup
+
+* Skipped
+
+
+## Review of last meeting
+
+
+* Small meeting, only James, Mikeal and Jeremiah, no official notes but the recording will be made available
+
+
+## Minutes
+
+### add inclusivity working group [#29](https://github.com/nodejs/TSC/pull/29)
+
+* Quick discussion about the PR, James mentioned the original objection was regarding language around “enforcement” which has now been changed to a “resource for enforcement”.
+* No objections, Inclusivity WG was ratified as a top-level WG, group agreed to reach out and ask them to nominate someone to the TSC (it was noted that we don’t have a formal requirement to add WG members to the TSC, just top-level _projects_.)
+
+## Next Meeting
+
+2016-01-21
+

--- a/meetings/2016-01-21.md
+++ b/meetings/2016-01-21.md
@@ -1,0 +1,40 @@
+# Node Foundation TSC Meeting 2016-01-21
+
+## Links
+
+* **Video Recording**: Not available
+* **GitHub Issue**: https://github.com/nodejs/TSC/issues/33
+* **Minutes Google Doc**: <https://docs.google.com/document/d/13ikZGN-sokY8Lwqc7A6dx6QyeSmfR3lhxqJofPTr9PE>
+* **Previous Minutes Google Doc**: https://docs.google.com/document/d/1jYeIgo3rEUyV0haqFQ4pEvo2lDVitJMWNeIXLRrssuM
+
+## Present
+
+* Rod Vagg (TSC)
+* Mikeal Rogers (Observer)
+* James Snell (TSC)
+* Alexis Campailla (TSC)
+* Jeremiah Senkpiel (TSC)
+* Colin Ihrig (TSC)
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+
+
+
+## Standup
+
+* Skipped
+
+
+## Review of last meeting
+
+* add inclusivity working group [#29](https://github.com/nodejs/TSC/pull/29)
+
+## Minutes
+
+
+## Next Meeting
+
+2016-01-28
+

--- a/meetings/2016-01-28.md
+++ b/meetings/2016-01-28.md
@@ -1,0 +1,39 @@
+# Node Foundation TSC Meeting 2016-01-28
+
+## Links
+
+* **Video Recording**: Not available
+* **GitHub Issue**: https://github.com/nodejs/TSC/issues/38
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1WliRr9DCue8MjRMsPrg33eOvOvfbelHKwbwD36N4_Qk>
+* **Previous Minutes Google Doc**: nil_
+
+## Present
+
+* Rod Vagg (TSC)
+* Mikeal Rogers (Observer)
+* James Snell (TSC)
+* Alexis Campailla (TSC)
+* Jeremiah Senkpiel (TSC)
+* Colin Ihrig (TSC)
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+
+
+
+## Standup
+
+*
+
+
+## Review of last meeting
+
+nothing covered
+
+## Minutes
+
+
+## Next Meeting
+
+

--- a/meetings/2016-02-04.md
+++ b/meetings/2016-02-04.md
@@ -1,0 +1,86 @@
+# Node Foundation TSC Meeting 2016-02-04
+
+## Links
+
+* **Video Recording**: Not available
+* **GitHub Issue**: https://github.com/nodejs/TSC/issues/41
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1wJ0fuc1BcPn1armdR3D5NF6lTGyA3SiBCDktc2p5Voo>
+* **Previous Minutes Google Doc**: nil_
+
+## Present
+
+* Rod Vagg (TSC)
+* Mikeal Rogers (Observer)
+* James Snell (TSC)
+* Alexis Campailla (TSC)
+* Jeremiah Senkpiel (TSC)
+* Colin Ihrig (TSC)
+* Michael Dawson (Observer)
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+
+
+## Standup
+
+skipped (we all met yesterday)
+
+## Review of last meeting
+
+nothing officially covered
+
+## Minutes
+
+### Express PR https://github.com/nodejs/TSC/pull/39
+
+James: moved quickly since last week, Doug has decided to contribute a large portion of his modules to the submission. Updated PR today, basic idea is to have a rough TC containing current owners of express, pillarjs, jshtttp org owners [RV: not sure I have that list correct]. There are a large number of modules that are included. Lots to be done on the PR still.
+
+Mikeal: multiple-org thing is reshaping our assumptions about what the incubator would look like and what the process looks like. Makes sense to assign 2 mentors to express and 2 to libuv. Tell other projects that we are taking a month-long hiatus to figure this stuff out and build up base-level documentation.
+
+James: lots of modules being proposed are outside of express, we need to decide what to do with these.
+
+Jeremiah: do we need every dependency to be in the foundation?
+
+Mikeal: only actual requirement is that any module being brought in are under an org controlled by the Foundation. Let the TC decide.
+
+James: only Mikeal is in the orgs under question, suggest we add all TSC members to that.
+
+Mikeal: that’s a lot of people, suggest we hold off on this. We can add moderators later on, or the TC can be responsible for moderation.
+
+_discussion about moderation repos and access_
+
+_discussion around the how to come up with list of packages, general agreement that that should be a role for the TC/WG during the incubation process with very general guidelines._
+
+_discussion around how to connect the efforts with the TSC given time constraints but the need to ensure good communication and a need for mentorship_
+
+James: is there anyone who objects to bringing express in?
+
+_no objection_
+
+Rod: pending finalisation of that PR, we can’t sign off clearly until then, but it seems like this is easier to swallow than other options until we sort out our basics.
+
+James: will try and get an update early next week to try and finalise it.
+
+### non-express business
+
+Agreed to taking a hiatus from making progress on the NodeConf and Appium proposals, letting them know that we’re going to be taking a month or so to try and sort baseline stuff out.
+
+Alexis: had a question about NodeConf—what happens to proceeds of conferences if there are any?
+
+_discussion on finances and accountability, moving back to GitHub for details_
+
+Jeremiah: what are we doing with libuv?
+
+Rod: I’d be OK with helping in that effort, pending time. Perhaps Alexis?
+
+Alexis: would like to be involved, but don’t have much time.
+
+Rod: will probably be very light, maybe a short meeting every 2 weeks to talk about what we need to talk about.
+
+_Rod to start some effort here_
+
+## Next Meeting
+
+2016-02-11
+

--- a/meetings/2016-02-11.md
+++ b/meetings/2016-02-11.md
@@ -1,0 +1,76 @@
+# Node Foundation TSC Meeting 2016-02-11
+
+## Links
+
+* **Video Recording**: Not available
+* **GitHub Issue**: https://github.com/nodejs/TSC/issues/49
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1wJ0fuc1BcPn1armdR3D5NF6lTGyA3SiBCDktc2p5Voo>
+* **Previous Minutes Google Doc**: nil_
+
+## Present
+
+* Rod Vagg (TSC)
+* Mikeal Rogers (Observer)
+* James Snell (TSC)
+* Alexis Campailla (TSC)
+* Jeremiah Senkpiel (TSC)
+* Colin Ihrig (TSC)
+* Michael Dawson (Observer)
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+
+* Improve process and coordination w/ the Foundation PR team [#43](https://github.com/nodejs/TSC/issues/43)
+* Base Contribution policy. [#40](https://github.com/nodejs/TSC/pull/40)
+* add initial TLP application for the Appium project [#34](https://github.com/nodejs/TSC/pull/34)
+* Submitting NodeConf to the Foundation. [#28](https://github.com/nodejs/TSC/pull/28)
+
+## Standup
+
+skipped (we all met yesterday)
+
+## Review of last meeting
+
+* Express PR https://github.com/nodejs/TSC/pull/39
+* non-express business
+
+## Minutes
+
+### Improve process and coordination w/ the Foundation PR team [#43](https://github.com/nodejs/TSC/issues/43)
+
+* Mikeal: We have some good process on our side but coordination with the PR team has been difficult. Putting our press releases need to happen at least a day beforehand. Without communication then we’ll get negativity because the PR team will be looking around for things to announce and they won’t announce what we think they should.
+
+* Rod: back and forth on Express and the security releases has been pretty good between a few of us and the PR team, Zibby is asking for details on releases, how much detail do we want to go in to there?
+
+* Mikeal: We probably should have a discussion at the CTC level about what a significant release is.
+
+### Base Contribution policy. [#40](https://github.com/nodejs/TSC/pull/40)
+
+* Mikeal: this is about ready for merge so we can get feedback outside of our bubble, e.g. over in Express land. Further edits can be done via pull request. It’s intended to be very minimal and easy to understand.
+
+No objections or reasons to hold up merging, group agreed to merge it as is.
+
+### add initial TLP application for the Appium project [#34](https://github.com/nodejs/TSC/pull/34)
+### Submitting NodeConf to the Foundation. [#28](https://github.com/nodejs/TSC/pull/28)
+
+Skipped, with one note that we should mention in those PRs that we are taking a break
+
+### Express status update
+
+* James: PR was merged, express repo was moved to expressjs, created an express team in the orgs with relevant people including Doug, Jeremiah, James and some others. Need to work on API docs from expressjs.com over. There’s no docs license yet, want to donate it to the express repo under MIT. Mikeal is there anything else we need to do there?
+
+* Mikeal: … legal stuff …
+
+_need to stand up a TC_
+
+### Meeting tools
+
+* Mikeal: suggest we try coupling Hangouts with GoToMeeting, Hangouts can dial in, GoToMeeting can be regularly scheduled.
+
+Rod and Mikeal to experiment with it today if possible then try and use it for the next CTC meeting if possible.
+
+## Next Meeting
+
+2016-02-11
+

--- a/meetings/2016-02-18.md
+++ b/meetings/2016-02-18.md
@@ -1,0 +1,71 @@
+# Node Foundation TSC Meeting 2016-02-18
+
+## Links
+
+* **Video Recording**: https://www.youtube.com/watch?v=T6wFkZgnNEQ
+* **GitHub Issue**: https://github.com/nodejs/TSC/issues/50
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1S1hzSEB1-_b2cHhcCSXRIiH1irWiWfLS4KawKQMPwvI>
+* **Previous Minutes Google Doc**: <https://docs.google.com/document/d/1P63hrV4WRdaQ5dAf4or0gP8-mBnuSyIdqFlFsFM-MBM>
+
+## Present
+
+* Rod Vagg (TSC)
+* Mikeal Rogers (Observer)
+* James Snell (TSC)
+* Alexis Campailla (TSC)
+* Jeremiah Senkpiel (TSC)
+* Colin Ihrig (TSC)
+* Bert Belder (TSC)
+* Michael Dawson (Observer)
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+
+* Preferred meeting tools [#48](https://github.com/nodejs/TSC/issues/48)
+* Scope of the TSC (and Incubator)
+* Probably should re-name incubator.
+
+
+## Standup
+
+Note from mikeal: do we need standups in the TSC meeting? can we do a “projects standup” instead where we get an update from each project?
+
+## Review of last meeting
+
+* Express PR https://github.com/nodejs/TSC/pull/39
+* non-express business
+
+## Minutes
+
+### Preferred meeting tools [#48](https://github.com/nodejs/TSC/issues/48)
+
+Mikeal: Covered last week.
+
+### Improve process and coordination w/ the Foundation PR team [#43](https://github.com/nodejs/TSC/issues/43)
+
+
+### add initial TLP application for the Appium project [#34](https://github.com/nodejs/TSC/pull/34)
+
+- Still delaying for now.
+
+### Submitting NodeConf to the Foundation. [#28](https://github.com/nodejs/TSC/pull/28)
+
+- Still delaying for now.
+
+### General discussion about projects entering the foundation
+
+- Lots of details, looking to find some better way to quantify importance to the node.js ecosystem for the TSC members to be able to make more informed decisions.
+
+### Express update
+
+Jeremiah: Still working on getting a first meeting.
+
+James: Timezones are pretty conflicting.
+
+Jeremiah: Been a bit slow but everything seems ok.
+
+## Next Meeting
+
+2016-02-11
+

--- a/meetings/2016-03-03.md
+++ b/meetings/2016-03-03.md
@@ -1,0 +1,57 @@
+# Node Foundation TSC Meeting 2016-03-03
+
+## Links
+
+* **Video Recording**: https://www.youtube.com/watch?v=-vf23GsR6vk
+* **GitHub Issue**: https://github.com/nodejs/TSC/issues/57
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1MW6CXlvxF0IWbb0tg5W70FAdWai5rkQoe_Jt9LhHMqQ>
+* **Previous Minutes Google Doc**: <https://docs.google.com/document/d/1S1hzSEB1-_b2cHhcCSXRIiH1irWiWfLS4KawKQMPwvI>
+
+## Present
+
+* Rod Vagg (TSC)
+* Mikeal Rogers (Observer)
+* James Snell (TSC)
+* Alexis Campailla (TSC)
+* Jeremiah Senkpiel (TSC)
+* Colin Ihrig (TSC)
+* Michael Dawson (Observer)
+* Ben Noordhuis (TSC)
+* Jona Hugger (Observer)
+* Bryan Hughes (Observer)
+* Feross (Observer)
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+
+## Review of last meeting
+
+* Preferred meeting tools [#48](https://github.com/nodejs/TSC/issues/48)
+* Improve process and coordination w/ the Foundation PR team [#43](https://github.com/nodejs/TSC/issues/43)
+* add initial TLP application for the Appium project [#34](https://github.com/nodejs/TSC/pull/34)
+* Submitting NodeConf to the Foundation. [#28](https://github.com/nodejs/TSC/pull/28)
+
+## Standup
+
+* Rod Vagg (TSC): skip
+* Mikeal Rogers (Observer): Lots of foundation stuff
+* James Snell (TSC): conference last week, got married
+* Alexis Campailla (TSC): issues and PR triage, libuv TLP work
+* Jeremiah Senkpiel (TSC): did a release, scheduling an onboarding for node core, misc stuff, idk
+* Colin Ihrig (TSC): issues & pr triage, helping improve testing, libuv work
+* Michael Dawson (Observer): Submitted PR to add more guidance for projects applying to join Foundation.
+* Ben Noordhuis (TSC): nothing
+* Jona Hugger (Observer): inclusivity meeting
+* Bryan Hughes (Observer): onboarding to microsoft, having discussion there about interested parties in the node ecosystem, facilitated inclusivity meeting
+* Feross (Observer): just learning so far
+
+## Minutes
+
+Dicussed https://github.com/nodejs/TSC/issues/57#issuecomment-191943806 -- and more broad TSC and foundation strategy.
+
+Alexis gave a brief overview of libuv in the foundation and steps forward.
+
+## Next Meeting
+
+2016-03-10

--- a/meetings/2016-03-10.md
+++ b/meetings/2016-03-10.md
@@ -1,0 +1,67 @@
+# Node Foundation TSC Meeting 2016-03-10
+
+## Links
+
+* **Video Recording**: https://www.youtube.com/watch?v=UeLv2YTbEfE
+* **GitHub Issue**: https://github.com/nodejs/TSC/issues/61
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1Zt6EnkLghHUxqvn8RKz4ewy-uljIdhqU96KHv_uH6oc>
+* **Previous Minutes Google Doc**: <https://docs.google.com/document/d/1MW6CXlvxF0IWbb0tg5W70FAdWai5rkQoe_Jt9LhHMqQ/edit#>
+
+## Present
+
+* Rod Vagg (TSC)
+* James Snell (TSC)
+* Alexis Campailla (TSC)
+* Jeremiah Senkpiel (TSC)
+* Michael Dawson (Observer)
+* Bryan Hughes (Observer)
+
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+
+* Flatten project, scope TSC, big changes to structure. [#59](https://github.com/nodejs/TSC/pull/59)
+* Add guidance to proposal section [#53](https://github.com/nodejs/TSC/pull/53)
+* Preferred meeting tools [#48](https://github.com/nodejs/TSC/issues/48)
+
+## Review of last meeting
+
+No formal meeting last week, talked about foundation and strategy.
+
+## Standup
+
+
+
+
+## Minutes
+
+### Flatten project, scope TSC, big changes to structure. [#59](https://github.com/nodejs/TSC/pull/59)
+
+* Rod: this is about winding back some of the umbrella program changes, moving things up to the TSC level rather than the CTC, effectively making the CTC a WG of the TSC and refocusing on core.
+* James: have concerns about complicating life for the TSC. It seems that we could redefine many of the working groups as “teams”, we could _uncharter_ them as WGs and switch to teams. Makes sense to move other WGs up to the TSC, including Documentation, Website and Build. We could recast this as moving some WGs up to TSC and the TSC always charters WGs, the rest are then converted to teams and the CTC is responsible for chartering teams.
+* Alexis: this PR bundles two big changes, (1) is changing the mission of the TSC and (2) restructuring. We should consider separating out the two issues.
+* Rod: there’s a lot of continual pivot going on here, big shifts from umbrella back to core, significant amounts of churn that is going to add to the confusion. Also have concerns about narrowing focus too much on core and therefore opening a window to legitimise multiple technical governance groups under the board to focus on different technical concerns—would like to keep technical execution under a single body.
+* Alexis: we should split this up and focus on the question of mission first.
+* Jeremiah: would still like to deal with the org issues because it’s trying to address actual problems that exist out there, i.e. communication.
+* Bryan: there is a perception out there that the TSC is very core-focused.
+
+Rod, James, Alexis, Jeremiah: Agree on splitting up the PR. Discussion around mission and how to focus on that.
+
+### Add guidance to proposal section [#53](https://github.com/nodejs/TSC/pull/53)
+
+
+### Preferred meeting tools [#48](https://github.com/nodejs/TSC/issues/48)
+
+Discussed live-streaming, Jeremiah filled us in on how it’s going and how we might be able to distribute the load a little.
+
+## Q/A
+
+
+
+## Next Meeting
+
+2016-03-17
+
+
+

--- a/meetings/2016-03-17.md
+++ b/meetings/2016-03-17.md
@@ -1,0 +1,74 @@
+(doc to move to nodejs/node repository after meeting)
+
+# Node Foundation TSC Meeting 2016-03-17
+
+## Links
+
+* **Video Recording**: https://www.youtube.com/watch?v=FTIpDAF2ke4
+* **GitHub Issue**: https://github.com/nodejs/TSC/issues/69
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1lFnhNaE2wK0FFyUfDz1LcaBiD3-rW_UKFjUQqqBIZOY>
+* **Previous Minutes Google Doc**: <https://docs.google.com/document/d/1Zt6EnkLghHUxqvn8RKz4ewy-uljIdhqU96KHv_uH6oc>
+
+## Present
+
+* Rod Vagg (TSC)
+* James Snell (TSC)
+* Alexis Campailla (TSC)
+* Jeremiah Senkpiel (TSC)
+* Michael Dawson (Observer)
+* Bert Belder (TSC)
+* Mikeal Rogers (TSC)
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+
+
+* Node.js "Users" feedback [#66](https://github.com/nodejs/TSC/issues/66)
+* Flatten project, scope TSC, big changes to structure. [#59](https://github.com/nodejs/TSC/pull/59)
+* Add guidance to proposal section [#53](https://github.com/nodejs/TSC/pull/53)
+
+
+## Review of last meeting
+
+* Flatten project, scope TSC, big changes to structure. [#59](https://github.com/nodejs/TSC/pull/59)
+* Add guidance to proposal section [#53](https://github.com/nodejs/TSC/pull/53)
+* Preferred meeting tools [#48](https://github.com/nodejs/TSC/issues/48)
+
+
+## Standup
+
+_Skipped_
+
+## Minutes
+
+
+### Node.js "Users" feedback [#66](https://github.com/nodejs/TSC/issues/66)
+
+Michael Dawson: how do we make sure we are getting input from a wider range of users?
+
+Rod: I maintain that our governance model is the best we have so far at controlling the direction of Node, if you want to have a say in that direction, the easiest way is to commit resources to core and surrounding development.
+
+
+Mikeal: The user base is so large that just having representation likely will not cover everything well.
+
+Mikeal: We can actually quantify the data from some of our surveys quite well, last one hit about 12,000 people.
+
+Rod: We need to make sure we don’t have buying into the foundation level giving technical control though.
+
+
+### Flatten project, scope TSC, big changes to structure. [#59](https://github.com/nodejs/TSC/pull/59)
+
+
+
+### Add guidance to proposal section [#53](https://github.com/nodejs/TSC/pull/53)
+
+
+
+## Q/A
+
+
+
+## Next Meeting
+
+2016-03-24

--- a/meetings/2016-03-24.md
+++ b/meetings/2016-03-24.md
@@ -1,0 +1,51 @@
+# Node Foundation TSC Meeting 2016-03-24
+
+## Links
+
+* **Video Recording**: https://www.youtube.com/watch?v=aKr1vQVFIFc
+* **GitHub Issue**: https://github.com/nodejs/TSC/issues/78
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1IySG1HZz83dKzJsy5EWJNPUNkJ073qvl-fMAHXX0odk>
+* **Previous Minutes Google Doc**: <https://docs.google.com/document/d/1lFnhNaE2wK0FFyUfDz1LcaBiD3-rW_UKFjUQqqBIZOY/edit#>
+
+## Present
+
+* Rod Vagg (TSC)
+* James Snell (TSC)
+* Alexis Campailla (TSC)
+* Jeremiah Senkpiel (TSC)
+* Michael Dawson (Observer)
+* Bert Belder (TSC)
+* Mikeal Rogers (TSC)
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+
+### nodejs/TSC
+
+* Proposed Node.js Foundation Mission, Structure and Strategy [#77](https://github.com/nodejs/TSC/pull/77)
+
+
+## Review of last meeting
+
+* Node.js "Users" feedback [#66](https://github.com/nodejs/TSC/issues/66)
+* Flatten project, scope TSC, big changes to structure. [#59](https://github.com/nodejs/TSC/pull/59)
+* Add guidance to proposal section [#53](https://github.com/nodejs/TSC/pull/53)
+
+
+## Standup
+
+_Skipped_
+
+## Minutes
+
+
+### Proposed Node.js Foundation Mission, Structure and Strategy [#77](https://github.com/nodejs/TSC/pull/77)
+
+
+
+## Q/A
+
+
+
+## Next Meeting

--- a/meetings/2016-04-07.md
+++ b/meetings/2016-04-07.md
@@ -1,0 +1,60 @@
+# Node Foundation TSC Meeting 2016-04-07
+
+## Links
+
+* **Video Recording**: https://www.youtube.com/watch?v=O5kwBkhGFPY
+* **GitHub Issue**: https://github.com/nodejs/TSC/issues/87
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1pQK1fk7rAjFL8bwQHcmpln9plRqvqcw2Xr4Cp4wTyDo>
+* **Previous Minutes Google Doc**: <https://docs.google.com/document/d/1lFnhNaE2wK0FFyUfDz1LcaBiD3-rW_UKFjUQqqBIZOY>
+
+## Present
+
+* Rod Vagg (TSC)
+* James Snell (TSC)
+* Alexis Campailla (TSC)
+* Jeremiah Senkpiel (TSC)
+* Michael Dawson (Observer)
+* Bert Belder (TSC)
+* Mikeal Rogers (TSC)
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+
+
+* Define "Node.js core" [#84](https://github.com/nodejs/TSC/issues/84)
+
+## Review of last meeting
+
+* Node.js "Users" feedback [#66](https://github.com/nodejs/TSC/issues/66)
+* Flatten project, scope TSC, big changes to structure. [#59](https://github.com/nodejs/TSC/pull/59)
+* Add guidance to proposal section [#53](https://github.com/nodejs/TSC/pull/53)
+
+
+## Standup
+
+* James Snell (TSC): Node.js Board meeting as an observer last week, had interesting conversation around top-level projects and also NPM-related discussions. Ran the VM SUmmit this week.
+* Alexis Campailla (TSC): VM Summit
+* Michael Dawson (Observer): VM Summit
+* Bryan Huges: Inclusivity WG, getting some processes in place to get together better moderation policy suggestions
+* Josh Gavent (Observer): VM Summit
+* Jeremiah Senkpiel (TSC): Working on a github bot for the org, VM Summit, official irc moderation policy first draft
+
+## Minutes
+
+### Define "Node.js core" [#84](https://github.com/nodejs/TSC/issues/84)
+
+- James telling us what was discussed at the board meeting
+
+- Refs: https://github.com/nodejs/TSC/pull/77
+
+Board had an underlying question of, “what exactly is node core”?
+
+- Agenda again next week.
+
+## Q/A
+
+
+
+## Next Meeting
+

--- a/meetings/2016-04-21.md
+++ b/meetings/2016-04-21.md
@@ -1,0 +1,62 @@
+# Node Foundation TSC Meeting 2016-04-21
+
+## Links
+
+* **Video Recording**: https://www.youtube.com/watch?v=usJOL0C_v0Y
+* **GitHub Issue**: https://github.com/nodejs/TSC/issues/94
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1iruXOBUlwbtrdNVkhI_MQF3VpBZvBdS5uUAcqVfOnQc>
+* **Previous Minutes Google Doc**: <https://docs.google.com/document/d/1pQK1fk7rAjFL8bwQHcmpln9plRqvqcw2Xr4Cp4wTyDo>
+
+## Present
+
+* Rod Vagg (TSC)
+* James Snell (TSC)
+* Alexis Campailla (TSC)
+* Jeremiah Senkpiel (TSC)
+* Michael Dawson (Observer)
+* Bert Belder (TSC)
+* Mikeal Rogers (TSC)
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+
+
+* Define "Node.js core" [#84](https://github.com/nodejs/TSC/issues/84)
+
+## Review of last meeting
+
+* Node.js "Users" feedback [#66](https://github.com/nodejs/TSC/issues/66)
+* Flatten project, scope TSC, big changes to structure. [#59](https://github.com/nodejs/TSC/pull/59)
+* Add guidance to proposal section [#53](https://github.com/nodejs/TSC/pull/53)
+
+
+## Standup
+
+* James Snell (TSC): Node.js Board meeting as an observer last week, had interesting conversation around top-level projects and also NPM-related discussions. Ran the VM SuUmmit this week.
+* Alexis Campailla (TSC): VM Summit
+* Michael Dawson (Observer): VM Summit
+* Bryan Hughes: Inclusivity WG, getting some processes in place to get together better moderation policy suggestions
+* Josh Gavent (Observer): VM Summit
+* Jeremiah Senkpiel (TSC): Working on a github bot for the org, VM Summit, official irc moderation policy first draft
+
+## Minutes
+
+### Define "Node.js core" [#84](https://github.com/nodejs/TSC/issues/84)
+
+- James telling us what was discussed at the board meeting
+
+- Refs: https://github.com/nodejs/TSC/pull/77
+
+Board had an underlying question of, “what exactly is node core”?
+
+- Agenda again next week.
+
+## Q/A
+
+
+
+## Next Meeting
+
+
+

--- a/meetings/2016-05-05.md
+++ b/meetings/2016-05-05.md
@@ -1,0 +1,84 @@
+# Node Foundation TSC Meeting 2016-05-05
+
+## Links
+
+* **Video Recording**: https://www.youtube.com/watch?v=-vf23GsR6vk
+* **GitHub Issue**: https://github.com/nodejs/TSC/issues/99
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1R2DTBrkmKakDI0UCDTD-2ppmrBHbnXDOaU2IvrN5toQ>
+* **Previous Minutes Google Doc**: <https://docs.google.com/document/d/1iruXOBUlwbtrdNVkhI_MQF3VpBZvBdS5uUAcqVfOnQc>
+
+## Present
+
+* Rod Vagg (TSC)
+* James Snell (TSC)
+* Alexis Campailla (TSC)
+* Jeremiah Senkpiel (TSC)
+* Michael Dawson (Observer)
+* Bert Belder (TSC)
+* Mikeal Rogers (TSC)
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+
+
+### nodejs/build
+
+* OS X buildbots/ci: call to action [#367](https://github.com/nodejs/build/issues/367)
+
+### nodejs/TSC
+
+* Define "Node.js core" [#84](https://github.com/nodejs/TSC/issues/84)
+* Meetings every two weeks?
+* Roll-up reporting
+
+## Review of last meeting
+
+
+## Standup
+
+- Mikeal Rogers: LF Offsite this week, getting ready of Node.js Live in Beijing
+- Rod Vagg: Taking time off, doing security stuff
+- Jeremiah Senkpiel: Nothing significant on the TSC end
+- Michael Dawson: Nothing on the TSC end, let me know if there is something that needs help on.
+- Bryan Hughes: Inclusivity WG work, was a meeting this morning
+- Alexis Campailla: nothing TSC level
+
+
+## Minutes
+
+
+### OS X buildbots/ci: call to action [#367](https://github.com/nodejs/build/issues/367)
+
+* Rod discussed the unsustainable situation we are at with Voxer and how we need to find a new donor or ask the Foundation for money.
+* Mikeal: Yahoo! Might have some resources that we could use. Rod should reach out to Dav Glass or Brian English.
+
+### Define "Node.js core" [#84](https://github.com/nodejs/TSC/issues/84)
+
+* Mikeal: last person in the nvm thread made a good comment about the TSC’s role being to set standards, the whole area of how to install Node is a mess because package managers don’t update quick enough.
+* Alexis: what is the purpose of the definition of Node core? Is it to define the responsibility of the TSC?
+* Mikeal: to help define what the level of support is that we want to offer.
+* Rod: basically comes down to the scope of the TSC’s autonomy.
+* Rod proposed a definition that includes “those components that are required to build, maintain and ship a basic Node.js development and production environment to users” … approximately.
+* Discussion around this type of definition.
+* Bryan: extend it to include “being able to install components from the ecosystem” (would include npm and NAN and node-gyp)
+
+### Rod Vagg: can we make these meetings once every two weeks?
+
+
+*  Group agreed
+
+
+### Roll-up reporting
+
+* Rod to propose on GitHub that we ask for regular roll-up reporting for active working groups, ask what they are working on and planning on working on.
+
+
+## Q/A
+
+
+
+## Next Meeting
+
+
+

--- a/meetings/2016-05-19.md
+++ b/meetings/2016-05-19.md
@@ -1,0 +1,4 @@
+No meeting minutes taken.
+
+See: https://github.com/nodejs/TSC/issues/103
+

--- a/meetings/2016-06-16.md
+++ b/meetings/2016-06-16.md
@@ -1,0 +1,112 @@
+# Node Foundation TSC Meeting 2016-06-16
+
+## Links
+
+* **Video Recording**: https://www.youtube.com/watch?v=L9ebH9A75AA
+* **GitHub Issue**: https://github.com/nodejs/TSC/issues/110
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1WMrf2OmU11zqlu9SAHeKq8dwH1CSnW-eavLZ8kPCAJo>
+* **Previous Minutes Google Doc**: <https://docs.google.com/document/d/1O-nRwKhmKG_vpyGkzlhFe5m5qi-H81cB6nagL4d_7Yw>
+
+## Present
+
+* Rod Vagg (TSC)
+* Alexis Campailla (TSC)
+* Jeremiah Senkpiel (TSC)
+* Michael Dawson (Observer)
+* Bryan Hughes
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+
+* Regular roll-up reporting for active working groups [#109](https://github.com/nodejs/TSC/issues/109)
+* Add @nebrius as a member of the TSC [#108](https://github.com/nodejs/TSC/pull/108)
+* Define "Node.js core" [#84](https://github.com/nodejs/TSC/issues/84)
+
+## Review of last meeting
+
+### nodejs/build
+
+* OS X buildbots/ci: call to action [#367](https://github.com/nodejs/build/issues/367)
+
+### nodejs/TSC
+
+* Define "Node.js core" [#84](https://github.com/nodejs/TSC/issues/84)
+* Meetings every two weeks?
+* Roll-up reporting
+
+## Standup
+
+* Jeremiah Senkpiel: NodeConf.
+* Rod Vagg: CTC repo, work on TC39 relationship, work on Electron relationship
+* Michael Dawson: No specific TSC related business
+* Bryan Hughes: Facilitation discussions at NodeConf
+* Alexis Campailla: no specific TSC related business
+
+## Minutes
+
+### Regular roll-up reporting for active working groups [#109](https://github.com/nodejs/TSC/issues/109)
+
+* Rod: we need to figure out if this is worthwhile, then which working groups and how frequent.
+* Jeremiah: what’s the overlap with the regular blog posts that we’re doing on the nodesource.com?
+* Rod: this would be getting the groups to report for themselves, and also be a chance for evangelisation and talking about future-facing things.
+
+List of working groups that we want to have included (not exclusive):
+
+* LTS
+* Diagnostics
+* Inclusivity
+* Build
+* Benchmarking
+* Website
+* Testing
+* Documentation
+
+Projects:
+
+* citgm
+* node-gyp
+* nan
+* libuv
+* nodejs-github-bot
+
+* CTC: big-picture things, releases, important decisions made
+
+* Bryan: maybe have more regular reporting for TSC & CTC
+* Rod: we could couple it with the TSC meetings, finalise content and report every two weeks.
+* Discussed where to report: nodejs.org blog
+* Discussed how to collect reports: ask the WGs to decide how and who to collect this information.
+
+How frequently to report:
+
+* Monthly or quarterly or two-monthly?
+
+What to ask from the groups:
+
+* What’s happened, what’s on the horizon
+* Provide suggested options about how they can collect information
+
+### Add @nebrius as a member of the TSC [#108](https://github.com/nodejs/TSC/pull/108)
+
+* Rod reiterated his comments from #108 and why there’s been a delay
+* Took a vote, got 3/3 endorsing @nebrius, Rod to chase up more votes on GitHub
+
+### Define "Node.js core" [#84](https://github.com/nodejs/TSC/issues/84)
+
+* Discussed ideas that have been raised so far and how we make progress.
+* Michael: maybe we rephrase the question to ask what is the area on which the TSC has authority and autonomy around?
+* Discussed the option of having a basic definition + a list of projects that are included.
+* Rod: the board is likely to be cooperative if we wanted to expand anyway.
+* Michael to start a new issue to rekindle the discussion with a strawman list of projects that would fit under “node core”
+
+## Q/A
+
+* William Kapke made suggestions about how to collect reporting and getting WGs to assign a secretarial role
+* Josh Gavant commented that it’s not currently clear how TSC membership is qualified
+
+## Next Meeting
+
+2016-06-30
+
+
+

--- a/meetings/2016-06-16.md
+++ b/meetings/2016-06-16.md
@@ -17,10 +17,13 @@
 
 ## Agenda
 
-Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+Extracted from **tsc-agenda** labelled issues and pull requests
+from the **nodejs org** prior to the meeting.
 
-* Regular roll-up reporting for active working groups [#109](https://github.com/nodejs/TSC/issues/109)
-* Add @nebrius as a member of the TSC [#108](https://github.com/nodejs/TSC/pull/108)
+* Regular roll-up reporting for active working groups
+  [#109](https://github.com/nodejs/TSC/issues/109)
+* Add @nebrius as a member of the TSC
+  [#108](https://github.com/nodejs/TSC/pull/108)
 * Define "Node.js core" [#84](https://github.com/nodejs/TSC/issues/84)
 
 ## Review of last meeting
@@ -47,11 +50,17 @@ Extracted from **tsc-agenda** labelled issues and pull requests from the **nodej
 
 ### Regular roll-up reporting for active working groups [#109](https://github.com/nodejs/TSC/issues/109)
 
-* Rod: we need to figure out if this is worthwhile, then which working groups and how frequent.
-* Jeremiah: what’s the overlap with the regular blog posts that we’re doing on the nodesource.com?
-* Rod: this would be getting the groups to report for themselves, and also be a chance for evangelisation and talking about future-facing things.
+* Rod: we need to figure out if this is worthwhile, then which
+  working groups and how frequent.
+* Jeremiah: what's the overlap with the regular blog posts
+  that we're doing on the nodesource.com ?
+* Rod: this would be getting the groups to report for themselves,
+  and also be a chance for evangelisation and talking about future-facing things.
+* General discussion and agreement that its a good thing to do.
 
-List of working groups that we want to have included (not exclusive):
+We want to give option to all groups to provide an update but there
+are some we'd plan to chase if we don't get updates.  This List
+would include: (not exclusive):
 
 * LTS
 * Diagnostics
@@ -72,41 +81,53 @@ Projects:
 
 * CTC: big-picture things, releases, important decisions made
 
-* Bryan: maybe have more regular reporting for TSC & CTC
-* Rod: we could couple it with the TSC meetings, finalise content and report every two weeks.
+Logistics
+
+* Bryan: maybe have more regular reporting for TSC & CTC.
+* Rod: we could couple it with the TSC meetings,
+  finalise content and report every two weeks.
 * Discussed where to report: nodejs.org blog
-* Discussed how to collect reports: ask the WGs to decide how and who to collect this information.
+* Discussed how to collect reports: ask the WGs to decide
+  how and who to collect this information.
 
 How frequently to report:
 
-* Monthly or quarterly or two-monthly?
+* Monthly or quarterly or two-monthly? Feels
+  like 3 months is too long but some concern that
+  every month might be hard to make happen.  One
+  suggestion was to do monthly but not necessarily
+  include reports from all groups. We decided to 
+  take this back to GitHub for more discussion.
 
 What to ask from the groups:
 
-* What’s happened, what’s on the horizon
-* Provide suggested options about how they can collect information
+* What's happened, what's on the horizon
+* Provide suggested options about how they
+  can collect information.
 
 ### Add @nebrius as a member of the TSC [#108](https://github.com/nodejs/TSC/pull/108)
 
-* Rod reiterated his comments from #108 and why there’s been a delay
-* Took a vote, got 3/3 endorsing @nebrius, Rod to chase up more votes on GitHub
+* Rod reiterated his comments from #108 and why there's been a delay.
+* Took a vote, got 3/3 endorsing @nebrius, Rod to chase up more votes on GitHub.
 
 ### Define "Node.js core" [#84](https://github.com/nodejs/TSC/issues/84)
 
 * Discussed ideas that have been raised so far and how we make progress.
-* Michael: maybe we rephrase the question to ask what is the area on which the TSC has authority and autonomy around?
-* Discussed the option of having a basic definition + a list of projects that are included.
+* Michael: maybe we rephrase the question to ask what is the area
+  on which the TSC has authority and autonomy around?
+* Discussed the option of having a basic definition + 
+  a list of projects that are included.
 * Rod: the board is likely to be cooperative if we wanted to expand anyway.
-* Michael to start a new issue to rekindle the discussion with a strawman list of projects that would fit under “node core”
+* Michael to start a new issue to rekindle the discussion with a strawman
+  list of projects that would fit under `node core`.
 
 ## Q/A
 
-* William Kapke made suggestions about how to collect reporting and getting WGs to assign a secretarial role
-* Josh Gavant commented that it’s not currently clear how TSC membership is qualified
+* William Kapke made suggestions about how to collect reporting
+  and getting WGs to assign a secretarial role.
+* Josh Gavant commented that it's not currently clear how
+  TSC membership is qualified.
 
 ## Next Meeting
 
 2016-06-30
-
-
-


### PR DESCRIPTION
Ever notice that first line in all the google agenda docs?
> (doc to move to nodejs/node repository after meeting)

...welp, here is a PR to make that happen. I've added in all the video & issue links too. Since (I believe) the google docs are created by copying+paste of an old one, I noticed some things were lingering from the copied version. Often the "Next Meeting" section. So I updated or removed them.

