### PR TITLE
doc: Add PR for TSC scope

### DIFF
--- a/doc/TSCScope.md
+++ b/doc/TSCScope.md
@@ -5,8 +5,10 @@ other groups, for example the CTC).  Outside of these
 areas the TSC will collaborate with the board
 when making decisions:
 
-* Code/Doc/ changes to any of the repositories under github/nodejs
-* Standards and processes covering contributions to repositories under
+* Changes to the contents of any of the repositories
+  under github/nodejs.
+* Standards and processes covering contributions and interactions
+  with repositories and related Internet properties under
   github/nodejs.
 * Infrastructure and usage of build tools for components
   built from github/nodejs.  

--- a/doc/TSCScope.md
+++ b/doc/TSCScope.md
@@ -1,0 +1,31 @@
+Subject to the contraints defined in the foundation
+charter, these are the areas that the TSC has autonomy
+in making decisions (some of which can be delegated to
+other groups, for example the CTC).  Outside of these
+areas the TSC will collaborate with the board
+when making decisions:
+
+* Code/Doc/ changes to any of the repositories under github/nodejs
+* Standards and processes covering contributions to repositories under
+  github/nodejs.
+* Infrastructure and usage of build tools for components
+  built from github/nodejs.  
+* Release types/schedules/frequency/delivery vehicles
+* Which external components Node will depend on and how they
+  will be bundled into Node distributions. (Examples include
+  node-gyp, v8, opensll, etc.). This does not include bringing 
+  a dependent project itself under the foundation umbrella, but
+  does cover including a copy of the code for the dependency
+  in the deps tree or including them in the node distributions (ex npm).
+* Creating new repositories under github/nodejs and building new
+  code/components in these repositories that may or may not
+  be shipped as part of Node. This is different than moving
+  an existing project/community under the foundation umbrella
+  and adding it to github/nodejs. It is also expected that
+  from time to time the suitability of a repository under
+  github/nodejs may be re-evaluated.
+* Overall technical direction for Node.js. This includes
+  the top level technical direction as well as decisions
+  on which specific features will be included/excluded
+  and where to encourage contributions within the community
+  as well as all aspects of how the technical direction is managed.


### PR DESCRIPTION
Initial version of the document to define the scope
of the TSC.

Content was started in https://github.com/nodejs/TSC/issues/113
and after discussion in the recent TSC meeting
it was agreed that now a PR would make sense so people
can comment and refine the language.
