### PR TITLE
Move TSC meeting minutes into nodejs/tsc repo

### DIFF
--- a/meetings/2015-05-27.md
+++ b/meetings/2015-05-27.md
@@ -1,0 +1,143 @@
+# Node Foundation TSC Meeting 2015-05-27
+
+## Links
+
+* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-05-27
+* **Public YouTube feed**: http://www.youtube.com/watch?v=0DPfLxulsbQ
+* **GitHub Issue**: https://github.com/nodejs/node-convergence-archive/issues/41
+* **Original Minutes Google Doc**: https://docs.google.com/document/d/1-KlxiQGMsJFNJu3meok9e9XFsM39k_PMnQmY_9d_cy0
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting.
+
+### nodejs/node-convergence-archive
+
+* \[Converge\] timers: Avoid linear scan in `_unrefActive`. [#23](https://github.com/nodejs/node-convergence-archive/issues/23)
+* \[Converge\] child_process argument type checking [#22](https://github.com/nodejs/node-convergence-archive/issues/22)
+* \[Converge\] SSLv2/3 disable/enable related commits [#20](https://github.com/nodejs/node-convergence-archive/issues/20)
+* doc: Add new working groups [#15](https://github.com/nodejs/node-convergence-archive/pull/15)
+
+### nodejs/io.js
+
+* Buffer implemented using Uint8Array [#1810](https://github.com/nodejs/io.js/issues/1810)
+* \[Discussion\] FFI - Giving Buffer more low-level C functionality [#1750](https://github.com/nodejs/io.js/pull/1750)
+* Chrome 43 released; time for V8 4.3! [#1735](https://github.com/nodejs/io.js/issues/1735)
+* Deprecation Policy [#1704](https://github.com/nodejs/io.js/issues/1704)
+* TSC needs to elect a board representative. [#1697](https://github.com/nodejs/io.js/issues/1697)
+* V8 4.4 to remove indexed properties via external data [#1451](https://github.com/nodejs/io.js/issues/1451)
+
+### joyent/node
+
+## Present
+
+* Alexis Campailla (TSC)
+* Ben Noordhuis (TSC)
+* Bert Belder (TSC)
+* Brian White
+* Chris Dickinson (TSC)
+* Colin Ihrig (TSC)
+* James M Snell (TSC)
+* Jeremiah Senkpiel (TSC)
+* Mikeal Rogers
+* Michael Dawson (TSC)
+* Mike Dolan (TSC)
+* Rod Vagg (TSC)
+* Shigeki Ohtsu
+* Trevor Norris (TSC)
+
+## Quick stand-up
+
+* Rod: Working on combining the build, 3.0
+* James: Working on repo convergence, triaging joyent/node issues, LTS policy drafting
+* Shigeki: Investigating a slow tls test and SSL mitigations for a log jam attack. 
+* Jeremiah: Lots of little things
+* Colin: Libuv work for os.homedir()
+* Chris: Removing sys, checking breakage; fixing bug I introduced in persistent history
+* Bert: Looking at issues
+* Alexis: Working on combining the build, fixing windows issues
+* Trevor: Working on the new Buffer impl using Uint8Array
+* Michael: Traging joyent/node, spun up the benchmarking WG, looking into adding powerpc build machines
+* Brian: Almost done the pure JS dns resolver, all tests are passing
+* Ben: 
+ - Make require faster
+ - Date.now() perf improvements
+
+## Review of last meeting
+
+* _Skipping_
+
+## Minutes
+
+### \[Converge\] timers: Avoid linear scan in `_unrefActive`. [#23](https://github.com/nodejs/node-convergence-archive/issues/23)
+
+* James: conflicting approaches in both repos
+* Ben: both are terrible under different workloads - do away with the code and start again
+* Jeremiah: might have a go at it, working off an existing heap impl by Ben (ACTION)
+* Bert: some problems with http - discussion happened about the implementation
+* Chris: would be good to have Julien’s input since he was active on the joyent/node impl
+
+### \[Converge\] child_process argument type checking [#22](https://github.com/nodejs/node-convergence-archive/issues/22)
+
+* James: arg checking merged in 0.10 after the fork
+* Discussion about why this wasn’t merged to io.js
+* Defer back to GitHub discussion after no reason for not merging could be found on the call
+
+### \[Converge\] SSLv2/3 disable/enable related commits [#20](https://github.com/nodejs/node-convergence-archive/issues/20)
+
+* James: SSLv2/3 removed in io.js, merging these commits would involve reverting
+* Jeremiah proposed 0.12 being the LTS for SSLv2/3 support
+* Rod: are we happy killing this off?
+* Michael: we don’t know how extensively it’s being used?
+* James: pending research into that question we’ll leave this alone, come back if there’s a compelling reason to revert
+
+### doc: Add new working groups [#15](https://github.com/nodejs/node-convergence-archive/pull/15)
+
+* Michael: Benchmarking and Post Mortem Debugging working groups are ready and have started, i18n group needs a bit more work to get off the ground
+* Group didn’t see any reason not to go forward with these groups, they have repos and can be in an “incubating” state for now
+
+
+### Buffer implemented using Uint8Array [#1810](https://github.com/nodejs/io.js/issues/1810)
+
+* Trevor: Buffer using Uint8Array is now working, all applicable tests pass, currently behind a flag:
+* Trevor Questions:
+  - Are we going with v8 4.3 or 4.4?
+  - If we go v8 4.3, do we want to release behind a flag?
+  - we still want an upper kMaxlength Buffer size limit?
+* Ben: Buffer size limit should be safe to remove
+* Rod: 4.3 and 4.4 both contain major breakage for native addons
+* Discussed if we would like to delay 3.0 until v8 4.4
+* Rod: no appetite here for delaying a 3.0 with 4.3, take discussion on that back to GitHub
+* Ben: suggested we release new Buffer impl with a flag to revert to old impl, Jeremiah seconded
+* Discussed how hard it would be to land and review
+* Fedor: how does it work with 32bit numbers?
+* Trevor: It acts the same as before
+
+### \[Discussion\] FFI - Giving Buffer more low-level C functionality [#1750](https://github.com/nodejs/io.js/pull/1750)
+
+* Trevor: concerns about being able to write to buffers and execute arbitrary code
+* Rod: concerned about changing the nature of what Node _is_ and the safety it exposes
+* Ben suggested that we move this new work to an ffi module rather than hanging it off Buffer
+ - Group agreed to take this suggestion back to the issue for discussion
+
+### Chrome 43 released; time for V8 4.3! [#1735](https://github.com/nodejs/io.js/issues/1735)
+
+* Concerns about deps forcing semver-major, the C++ API changes are big enough to warrant this though
+
+### Deprecation Policy [#1704](https://github.com/nodejs/io.js/issues/1704)
+
+* Discussion dividing into two camps - conservative camp and those who want to test the size of the impact on the ecosystem
+* Suggestion (Michael?) that we use LTS releases to determine when things get properly removed
+* Discussed why we want a deprecation policy
+
+### TSC needs to elect a board representative. [#1697](https://github.com/nodejs/io.js/issues/1697)
+
+* Deferred till next meeting - need to nominate and vote someone in to this role and should discuss how we want to structure the role in terms of rotation
+
+### V8 4.4 to remove indexed properties via external data [#1451](https://github.com/nodejs/io.js/issues/1451)
+
+* Nothing to discuss, rolled up in to Buffer discussion earlier
+
+## Next meeting
+
+* June 3rd, 8PM UTC

--- a/meetings/2015-06-03.md
+++ b/meetings/2015-06-03.md
@@ -1,0 +1,166 @@
+# Node.js Foundation TSC Meeting 2015-06-03
+
+## Links
+
+* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-06-03
+* **GitHub Issue**: https://github.com/nodejs/node-convergence-archive/issues/47
+* **Original Minutes Google Doc**: https://docs.google.com/document/d/1sTD0uryasBR15UBzEbJj3oHYtnuN9ZIqVxA2A_-N56E
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting.
+
+### nodejs/io.js
+
+* Add working group state per Project Lifecycle. [#1880](https://github.com/nodejs/io.js/pull/1880)
+* Proposal: Split TSC agenda in to two meetings [#1879](https://github.com/nodejs/io.js/issues/1879)
+* Chrome 43 released; time for V8 4.3! [#1735](https://github.com/nodejs/io.js/issues/1735)
+* TSC needs to elect a board representative. [#1697](https://github.com/nodejs/io.js/issues/1697)
+* Expose `deepEqual` and `deepStrictEqual` in `util`. #1172 [#1177](https://github.com/nodejs/io.js/pull/1177)
+
+## Present
+
+* Rod Vagg (TSC)
+* Mikeal Rogers
+* Shigeki Ohtsu (TSC)
+* Chris Dickinson (TSC)
+* Colin Ihrig (TSC)
+* Julien Gilli (TSC)
+* James Snell (TSC)
+* Michael Dawson (TSC)
+* Bert Belder (TSC)
+* Fedor Indutny (TSC)
+* Jeremiah Senkpiel (TSC)
+* Domenic Denicola
+* Alexis Campailla (TSC)
+* Ben Noordhuis (TSC)
+
+## Quick stand-up
+
+* Rod: working on the build, looking into npm smoke-testing
+* Mikeal: getting foundation legalities and officialities in order
+* Shigeki: working on security issues, reviewing root cert update
+* Chris: working on getting npm static analysis working [estoc](https://github.com/chrisdickinson/estoc)
+* Colin: reviewing prs and issues, doing some libuv work (uv_os_homedir, which landed in libuv 1.6.0)
+* Julien: vacation, nodejs.org downtime postmortem
+* James: working on convergence, triaging joyent/node issues
+* Michael: triaging some joyent/node issues, working on powerpc build and npm testing
+* Bert: not much, looked at some issues, discussing with Saul if libuv should move into the Node Foundation
+* Fedor: reviewed some pull requests and issues, working on some openssl mode
+* Jeremiah: issues, convergence, `_unrefActive` timers work, looking at improving Ben’s binary heap implementation
+* Domenic: vm fixes in v8 integrating patches
+* Alexis: patch for timers firing early, CI convergence work - jenkins hackery
+* Ben: reviewing pull requests, making libuv threadpool more scalable
+* Brian: JS dns resolver
+* Trevor: merged UInt8Array Buffer changes into the next branch, additional ArrayBuffer-related changes and fiddling
+
+## Review of last meeting
+
+### nodejs/node
+
+* \[Converge\] timers: Avoid linear scan in `_unrefActive`. [#23](https://github.com/nodejs/node/issues/23)
+* \[Converge\] child_process argument type checking [#22](https://github.com/nodejs/node/issues/22)
+* \[Converge\] SSLv2/3 disable/enable related commits [#20](https://github.com/nodejs/node/issues/20)
+* doc: Add new working groups [#15](https://github.com/nodejs/node/pull/15)
+
+### nodejs/io.js
+
+* Buffer implemented using Uint8Array [#1810](https://github.com/nodejs/io.js/issues/1810)
+* \[Discussion\] FFI - Giving Buffer more low-level C functionality [#1750](https://github.com/nodejs/io.js/pull/1750)
+* Chrome 43 released; time for V8 4.3! [#1735](https://github.com/nodejs/io.js/issues/1735)
+* Deprecation Policy [#1704](https://github.com/nodejs/io.js/issues/1704)
+* TSC needs to elect a board representative. [#1697](https://github.com/nodejs/io.js/issues/1697)
+* V8 4.4 to remove indexed properties via external data [#1451](https://github.com/nodejs/io.js/issues/1451)
+
+## Minutes
+
+### Add working group state per Project Lifecycle. [#1880](https://github.com/nodejs/io.js/pull/1880)
+
+* Mikeal: making working groups as “core” means they get to elect a TSC seat.
+* Brief discussion about what WG’s should be considered “core” and get a TSC seat.
+* Deferred to GitHub.
+
+### Chrome 43 released; time for V8 4.3! [#1735](https://github.com/nodejs/io.js/issues/1735)
+
+Domenic: things are ready to go. There’s some concern about double-breakage in 4.3 and 4.4.
+
+Jeremiah: what about the maybe changes?
+
+Domenic: the non-Maybe versions are still there, and haven’t been removed yet, either in 4.3 or 4.4 or even 4.5 (which isn’t finalized yet though).
+
+Rod: blocker is whether the double-breakage is real, if not then we should move forward.
+
+Domenic: there’s also the issue of some people in the thread advocating blocking a release on readying the ecosystem.
+
+Rod: we shouldn’t be following the ecosystem and waiting for them to catch up before we release.
+
+Mikeal: it’s more a matter of how we approach these things.
+
+Michael: LTS should help this?
+
+Mikeal: the problem is about major releases and the messaging - currently when people download them lots of stuff is broken.
+
+Domenic called for a vote on a 3.0 release _assuming there is no double-breakage_.
+
+Rod: I need to get the fix for node-gyp in place. Also we should see if we can get nvm to allow testing nightlies so that people can test them more easily (including on Travis).
+
+Jeremiah: when I last talked to Jordan (@ljharb) he wanted to make sure that the mechanism we used for nightlies would also be the mechanism used in the converged project.
+
+Mikeal: well that’s definitely true. So we should be good.
+
+Trevor: do we have a way of measuring uptake?
+
+Domenic/Rod: npm traffic is probably the best metric.
+
+Rod calls for a vote.
+
+Domenic: can we clarify whether we allow minor, covered-by-nan breakages between 4.3/3.0.0 and 4.4/4.0.0, or do we require no breakages at all?
+
+Mikeal: is nan released?
+
+Jeremiah: not yet; it is experimental and they don’t release until we merge next into master
+
+Mikeal: that seems bad
+
+(General agreement that we want nan to release first.)
+
+Trevor: looking at nan they seem to be working to encapsulate changes all the way out to V8 4.6.
+
+Bert: what was the problem with putting nan into core?
+
+Rod/Ben: sometimes V8 makes big changes that cause breaking changes in nan. E.g. isolates, buffer changes, maybes. Until now it’s been just individual APIs, but the 4.3 and 4.4 change has been very big. nan’s promise is just that you can write against a single, possibly-changing API that will support multiple node versions.
+
+### Expose `deepEqual` and `deepStrictEqual` in `util`. #1172 [#1177](https://github.com/nodejs/io.js/pull/1177)
+
+Jeremiah: what do we want to expose from core, there’s pressure from some parts of the community for core to be more isomorphic and support a lot of browser stuff. This issue is specifically about exposing what’s already implemented.
+
+Ben: why not pull it out of core and put it in npm? util has always been about utilities that core uses.
+
+Rod: when you expose something you’re stuck with it forever, minimising surface area should be our goal because the more we have to officially support the slower our release cycle will be.
+
+### Proposal: Split TSC agenda in to two meetings [#1879](https://github.com/nodejs/io.js/issues/1879)
+
+Mikeal: the scope of the TSC responsibilities are too wide, making meeting times go to long. The suggestion is to split up in to “project” related issues and “core” related issues.
+
+Rod: can there be a clear distinction between the issues?
+
+Domenic: assuming nobody wanted to attend two meetings, would there be enough?
+
+Mikeal: yes because there are lots of people that aren’t here who would be in the other group
+
+Rod: I wonder about the timing, e.g. letting the foundation kickoff happen first; it feels a bit premature to split now.
+
+Mikeal: it’s a little premature but that’s because we haven’t onboarded the core working groups to this meeting.
+
+Bert: in favour of the proposal.
+
+_Discussed the pros and cons and agreed to tentatively move forward with experimentation, time slot for the new “project” meeting would either be after the current meeting or the day after that meeting._
+
+### TSC needs to elect a board representative. [#1697](https://github.com/nodejs/io.js/issues/1697)
+
+***Call ended prematurely due to Uberconference difficulties***
+
+## Next meeting
+
+* 
+

--- a/meetings/2015-06-10.md
+++ b/meetings/2015-06-10.md
@@ -1,0 +1,184 @@
+# Node Foundation TSC Meeting 2015-06-10
+
+## Links
+
+* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-06-10
+* **GitHub Issue**: https://github.com/nodejs/node-convergence-archive/issues/53
+* **Original Minutes Google Doc**: https://docs.google.com/document/d/1cn7SKaKYUMYLBiQhE6HAAknnwPabKsYjpOuyQkVikW8
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting.
+
+### nodejs/io.js
+
+* Add working group state per Project Lifecycle. #1880
+* Chrome 43 released; time for V8 4.3! #1735
+* TSC needs to elect a board representative. #1697
+
+### joyent/node
+* Nominating new collaborators to this repository #25481
+* Node should not automatically change rlimits #8704
+* Re-purpose previous joyent/node TSC meeting as LTS working group
+* Releases for logjam - expect new openssl version soon (possibly should be discussed in LTS working group instead)
+
+## Minutes
+
+### Present
+
+* Shigeki Ohtsu (TSC)
+* Colin Ihrig (TSC)
+* Alexis Campailla (TSC)
+* Bert Belder (TSC)
+* Ben Noordhuis (TSC)
+* Julien Gilli (TSC)
+* Mikeal Rogers
+* Michael Dawson (TSC)
+* Domenic Denicola
+* Brian White (TSC)
+* Bradley Meck
+* Trevor Norris (TSC)
+
+### Quick review of the previous meeting
+
+* **Bert**: Discussed adding WG for project life cycle. Don’t remember what the idea was.
+* **Mikeal**: Need to merge the associated PR.
+* **Bert**: Discussed upgrading V8 to 4.3. Some contention, much in favor of doing it. Issue is V8 is changing API in 4.3 and 4.4 again.
+* **Trevor**: Biggest issue is nan 2.0 hadn’t come out yet. There would be a gap in time when no native module would work.
+* **Bert**: Resolution was that we would try to get nan to update asap. If 4.4 wasn’t done yet we would not upgrade to 4.3 yet.
+* **Bert**: Mikeal had proposed to split meeting in two different meetings: one technical, one non technical.
+
+### Standup
+
+* **Shigeki**: preparing for the next OpenSSL update.
+* **Michael**: working on triaging issues, made sure V8 beta/stable build properly on PPC. Internally setup some build to build io.js next on PPC, so that we can hook up build machines asap.
+* **Colin**: mostly just reviewed PRs and triaged issues.
+* **Brian**: mostly triaging issues, looked at some PRs.
+* **Julien**: triaged issues, reviewed PRs. Started documenting Node.js’ release process and CI platform. Also started to document breaking changes between v0.12 and the converged repo between io.js and Node.js.
+* **Alexis**: investigations on native addon WG.
+* **Bert**: not a lot of technical work. Working on libuv changes to make the multi isolate/workers stuff work. PR #396 in libuv.
+* **Ben**: reviewed PRs.
+* **Domenic**: some reviews and tried to gear up for 3.0.
+* **Trevor**: Lot of reviewing and landing of PRs, prototype for lower-level JS API. Worked on async listeners API.
+* **Bradley**: here for rlimits discussion on the agenda.
+* **Mikeal**: launch of the foundation, getting the PR ready and working on nodeconf that starts tomorrow.
+
+### Today’s agenda
+
+#### Add working group state per Project Lifecycle
+
+* **Mikeal**: pretty much resolved, we just need to close the PR.
+
+#### Chrome 43 released; time for V8 4.3
+
+* **Domenic**: not sure if there’s much progress on that. Haven’t seen news from nan.
+* **Bert**: remove tsc-agenda, someone should put back the tag when there’s news.
+
+#### TSC needs to elect a board representative.
+
+* **Mikeal**: thought that we had a resolution, and Bert and Rod would both be on the board for a short time.
+* **Bert**: see if that can stay that way in the long term. Any objection?
+* **Michael**: have we approached other people from the foundation to see if that’s possible?
+* **Bert**: haven’t reached out yet. Who is organizing these meetings?
+* **Mikeal**: Mike Dolan.
+* **Bert**: Will send an email to see if that’s feasible.
+* **Michael**: what about voting?
+* **Mikeal**: we would need to put down just one person who has voting rights.
+* **Michael**: having two present in meetings, only one who has the vote is fine by me.
+* **Bert**: I don’t expect to be any kind of contention, trademark is probably the only one I can think of now.
+* **Mikeal**: It seems that people don’t have a good idea of what will be decided during these meetings, so maybe we can just flip a coin for this short period of time, and then when we know more of what’s discussed in these meetings we can have a vote.
+* **Michael**: maybe have some sort of alternance between two people in the beginning?
+* **Bert**: I think it would still be good to have one person who will always be there.
+* **Bert**: proposed resolution: let’s both (Rod and I) be there and then we’ll reevaluate later.
+
+#### Nominating new collaborators to this repository
+
+See https://github.com/joyent/node/issues/25481.
+
+Main question was: should we add nominated collaborators who are not io.js collaborators too the “collaborators” team in the nodejs organization too?
+
+Decision was that it might be confusing at first, so onboarding of these collaborators will be done first in joyent/node only, but they will conceptually be Node.js collaborators (as in collaborators in the nodejs GitHub organization). Shortly after they will be added as io.js collaborators by people familiar with the onboarding process at io.js.
+
+#### Node should not automatically change rlimits
+
+* **Bradley**: summary is in node v0.10. Node respected soft ulimit for fds. Soft limit is recommended limit, second one called hard limit which is an enforced limit. By default, OSX has a very low soft limit, and that’s the reason why this patch landed. However when running programs, they usually don’t change rlimits, and we started seeing failures after the patch landed. Argument for the side for keeping the patch, you don’t hear people complaining about being out of file descriptors.
+* **Michael**: did patch change only for OSX?
+* **Bradley**: did for all platforms. Hard limit becomes soft, soft limit are erased.
+* **Michael**: fix means you don’t see errors?
+* **Bradley**: yes, but it has undesirable side effects. Traditionally when you limit resources, you set soft limits to what you want your process to be able to get. Node started to ignore those, so we started seeing things like fds leaks not being caught, etc.
+* **Ben**: why wouldn’t you set the hard limit to the soft limit?
+* **Bradley**: This patch completely erases your soft limit, can’t recover it. No option to use soft limits at this point. Cluster would want very high limit, workers would want lower limit. Using soft limit is usually how people do that. You can use hard limits, but once you do that you’re talking about absolute enforcement.
+* **Bert**: proposal is to revert the patch?
+* **Bradley**: couple options. Ideal option to me is to revert the patch. I would expect UNIX programs to leave my settings alone. I would at least expect an option to recover the soft limits. Having some way to pass settings via command line maybe?
+* **Bradley**: either command line flag or environment variable. Problem with command line anything that spawns with something like fork would ignore it.
+* **Bert**: actually happy that the patch landed. Just works solution seems better, I’ve seen so many problems in production. Two concerns: agree this is a bit weird that node changes limits of child processes. Would not be opposed to use an environment variable.
+* **Bradley**: argument will come from sysadmins, not people not familiar with EMFILE and rlimits. Usually you see the EMFILE error, you request to someone to bump this limit and the problem is solved.
+* **Trevor**: what if we added process.resetRlimits and when that process spawns it resets rlimits.
+* **Bradley**: need to pass that to child processes still.
+* **Trevor**: if using cluster, then that seems easy.
+* **Bert**: Don’t like having globals for that kind of stuff, related to multi isolates. Maybe add as an option to child_process.spawn?
+* **Trevor**: how would that help regarding multi isolates environments?
+* **Bert**: Yeah, not suggesting to be able to set different limits per isolate. Ben any opinion?
+* **Ben**: Resetting rlimits when we spawn new process would be fine. Don’t care about environment variable that would make node not touch rlimits.
+* **Domenic**: Does node change system wide rlimits?
+* **Bradley**: that depends on how the node process lifecycle.
+* **Domenic**: Is there any way to ignore rlimits while not changing system wide rlimits?
+* **Bradley**: it’s a per process setting. Want a way to keep limits to get warnings about file descriptors, and a way to recover limits in child processes. I can write a patch for that.
+* **Ben**: Keep in mind you’ll probably need to update libuv in some way. Forking takes places in libuv.
+* **Bert**: summary: node will restore rlimits on spawn.Other thing would be command line switch or environment variable.
+* **Ben**: How are you going to use that?  Are you using sandbox?
+* **Bradley**: Not using sandbox. When I see EMFILE, I can set a warning that notifies me when things go crazy.
+
+##### Resolution
+
+* The current (rlimit-changing) behavior will be maintained.
+* Node/libuv should restore the ulimit for the child processes it spawns.
+* Support for leaving the ulimit untouched by setting an an environment variable will be added.
+* Bradley Meck is going to create patches to node and libuv for this.
+
+#### New OpenSSL version about to be released, with fixed for logjam
+
+* **Michael**: will need a v0.10 and v0.12 release when OpenSSL release comes out.
+
+#### Repurpose previous node.js TSC meeting as LTS WG meeting
+
+* **Julien**: timing might not work for anyone.
+* **Bert**: Rod pinged a bunch of people, haven’t seen a lot of response. Wyatt Preul is involved, you will probably want to reach out to him, Same for ofrobots.
+* **Michael**: want to make sure that everyone is ok with merging LTS meeting with joyent/node TSC meeting.
+* **Julien**: discussion ongoing here: https://github.com/nodejs/LTS/issues/6#issuecomment-109352447.
+
+### Discussion items not on the agenda
+
+#### 3.0 upgrade documentation
+
+* **Trevor**: haven’t seen any doc on how to upgrade to 3.0. Should be put notes about breaking changes there, or somewhere else?
+* **Domenic**: hard part is C++ side changes. Everything else should be handled by semver-major/minor labels.
+
+### Rebasing on top of the 'next' branch (not on the agenda)
+
+* **Trevor**: rebase of next on master is going to be fairly broken. Is there somebody who usually takes those merges?
+* **Ben**: Not sure I understood.
+* **Trevor**: Lots of fixes that went into 2.x will not merge cleanly in next. Some of the fixes are minor. Fix in zlib that uses kMaxLength.
+* **Ben**: what’s the question?
+* **Trevor**: wondering who’s responsible for the merge? Maybe I can help with that?
+* **Ben**: most of the time I do that. I usually create a PR and ask people to give a quick sign off on it.
+
+##### Action items 
+
+* Trevor will document C++ side changes.
+
+#### Workers (multi-isolate) PR
+
+* **Bert**: decided to take a look at the multi isolates patch. I know that Ben tried to review it and went half-way through.
+* **Trevor**: tried twice now and haven’t managed to go all the way through.
+* **Bert**: proposed solution is to just make sure it doesn’t break anything major, put it behind a flag and review it in more details later.
+* **Trevor**: a lot of stylistic issues, and haven’t got any response.
+* **Ben**: petka mentioned he’s quite busy at the moment. Maybe someone could address these comments?
+* **Bert**: ping petka, maybe we can land it in small increments. Do we want it to be perfect before it lands?
+* **Ben**: not comfortable landing code that hasn’t been reviewed.
+* **Trevor**: nice thing is that there’s a lot of tests. Didn’t see anything invasive that would make things difficult later. One change that I don’t understand 100%. I would depend on someone else to give the OK.
+* **Bert**: interesting and valuable change, it needs work to get landed.
+
+## Next meeting
+
+Will be held on June 17th, 1pm PST.

--- a/meetings/2015-06-17.md
+++ b/meetings/2015-06-17.md
@@ -1,0 +1,134 @@
+# Node Foundation TSC Meeting 2015-06-17
+
+## Links
+
+* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-06-17
+* **GitHub Issue**: https://github.com/nodejs/node-convergence-archive/issues/56
+* **Original Minutes Google Doc**: https://docs.google.com/document/d/1d4mAJgm06rpPWLDqhZcxsRnKMrS92Ip4CW2akOyeIL4
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting.
+
+### nodejs/node
+
+* Create a security team [#48](https://github.com/nodejs/node-convergence-archive/issues/48)
+
+### nodejs/io.js
+
+* Nominating Shigeki Ohtsu @shigeki to the TC [#1501](https://github.com/nodejs/io.js/issues/1501)
+* Nominating Brian White @mscdex to the TC [#1500](https://github.com/nodejs/io.js/issues/1500)
+* on working with proposals from the API WG [#1993](https://github.com/nodejs/io.js/issues/1993)
+* zlib: prevent uncaught exception in zlibBuffer [#1993](https://github.com/nodejs/io.js/issues/1811)
+* Proposal: Release Process [#1997](https://github.com/nodejs/io.js/issues/1997)
+
+### joyent/node
+
+* Nominating new collaborators to this repository [#25481](https://github.com/joyent/node/issues/25481)
+
+## Minutes
+
+
+### Present
+
+* Rod Vagg (TSC)
+* Colin Ihrig (TSC)
+* Chris Dickinson (TSC)
+* Michael Dawson (TSC)
+* Mikeal Rogers
+* Steven R. Loomis (TSC)
+* Bert Belder (TSC)
+* Alexis Campailla (TSC)
+* Julien Gilli (TSC)
+* Shigeki Ohtsu
+* Jeremiah Senkpiel (TSC)
+* Brian White
+* Trevor Norris (TSC)
+* Domenic Denicola
+* Fedor Indutny (TSC)
+
+### Review of the previous meeting
+
+* Add working group state per Project Lifecycle
+* Chrome 43 released; time for V8 4.3
+* TSC needs to elect a board representative.
+* Nominating new collaborators to this repository
+* Node should not automatically change rlimits
+* New OpenSSL version about to be released, with fixed for logjam
+* Repurpose previous node.js TSC meeting as LTS WG meeting
+* 3.0 upgrade documentation 
+* Rebasing on top of the 'next' branch (not on the agenda)
+* Workers PR from Petka
+
+### Standup:
+
+* Rod: build, productive work on improving the ci and build convergence, ci now does linting before running the tests, also improving the io.js make file so that less logic for releases is contained in jenkins
+* Colin: reviewing issues and pr’s, landed a cluster patch to not use --debug_port on cluster workers by default
+* Chris: NodeConf, got great feedback there. PR for code coverage incoming soon, spun up the docs WG.
+  * http://neversaw.us/scratch/node-coverage/ – code coverage
+  * https://github.com/nodejs/docs 
+* Michael: Reviewing OpenSSL changes for LogJam; PPC LE & BE work nearly complete, some OpenSSL blockers (EC related)--working towards including PPC in CI
+* Mikeal: running NodeConf and writing up feedback & foundation work
+* Steven: getting back on board
+* Bert: libuv work for multi-worker on Windows (https://github.com/libuv/libuv/pull/396), found a potential libuv/Windows contributor at NodeConf, NF board meeting
+* Alexis: Working on build & CI convergence with Rod, CI can now automatically decide what options to use for different node versions, and porting node-accept-pull-request CI job.
+* Julien: time off, launching nodejs.org updates for NF launch, working on changes for 0.10/0.12 releases, onboarded two new collaborators for joyent/node - https://github.com/nodejs/LTS/wiki/Breaking-changes-between-v0.12-and-next-LTS-release
+* Shigeki: Working on upgrading OpenSSL, the upgrade process is becoming much simpler, landed the CINNIC whitelist
+* Jeremiah: NodeConf - brought back good feedback, helping spin up the Diversity WG, integrating timers heap impl, struggling with bugs
+* Brian: not much, triage & PR review
+* Trevor: reviewing, commenting, merging, PR to next branch allowing passing ArrayBuffers to Buffers constructor
+* Domenic: reviewing, some work with Trevor, discussing release procedure
+* Fedor: Reviewing issues(?), working on http/2 in node-spdy
+
+### Nominating Shigeki Ohtsu @shigeki to the TC [#1501](https://github.com/nodejs/io.js/issues/1501)
+### Nominating Brian White @mscdex to the TC [#1500](https://github.com/nodejs/io.js/issues/1500)
+
+Called for a vote, got +1's for both candidates from each of: Chris, Rod, Bert, Colin, Trevor, Jeremiah, Julien, Michael, Alexis
+
+### on working with proposals from the API WG [#1993](https://github.com/nodejs/io.js/issues/1993)
+
+* Trevor: started discussions back in advisory board before io.js existed, large companies wanted “official Node.js compatibility” at both module and JS layer. Some dissenting voices in Joyent that prevented things proceeding. After io.js happened the formal discussion ended but informal discussion continued, e.g. in https://github.com/nodejs/nan/issues/349, aim at the C++ level is to reduce API turn-over. Companies involved have their own VMs and want to maintain them for their own purposes (e.g. Chakra, JVM).
+* Trevor: interested in starting a WG or piggy-backing Addon API WG.
+* Domenic: would like more clarity on what this thing could be, is it libuv.js? is it a VM abstraction layer?
+* Bert: would be good to scope this work
+* Trevor: there’s one interest group--concerned with binary addons and not having to ship new versions with each new Node release. Another interest group is concerned with something akin to a process.bindings abstraction layer so you could put the Node JS layer on top of whatever runtime chosen.
+* Bert: standardising the process.bindings API might be easiest but standardising the C++ API has more beneifits because it solves the v8-upgrade-breaks-addons problem.
+* Rod: https://github.com/nodejs/nan/issues/373 is an issue in NAN for organising a meeting for the various groups interested in exploring C++ API compatibility, specifically for addons.
+
+### zlib: prevent uncaught exception in zlibBuffer [#1811](https://github.com/nodejs/io.js/issues/1811)
+
+* Trevor: Issue #1811 is potentially CVE-worthy, it’s been fixed but what is the process for going forward with a CVE if necessary?
+* Rod: security@nodejs.org has an expanded team and security@iojs.org redirects there as well. That team should be delegated to for discussion--if you have concerns then email them and let them be responsible for deciding how to proceed.
+* ACTION: Trevor to email summary of potential security concern to security@nodejs.org for further discussion amongst that group. Potentially also backporting to 0.10 and 0.12.
+
+### Proposal: Release Process [#1997](https://github.com/nodejs/io.js/issues/1997)
+
+* Mikeal:
+  - next branch to be released on a more regular timeline
+need to message to users that are on the “next” branch that there is a tradeoff between new V8 (features + perf) and being able to use native modules
+  - bring next to current, current to LTS
+* Domenic:
+  - core of the proposal:
+    - pseudo-LTS
+    - maintain V8 version for ourselves
+    - don’t backport any breaking changes from master, only features and patches
+    - release this with name that implies “use this to work with native modules and features” ???? (CD - lost track here)
+    - active dev happens here
+* Trevor: Naming is confusing; why isn’t it sufficient to say “this release is LTS”?
+* Mikeal: We don’t want LTS to mean “this is stable”, we want it to mean “I can use this for five years”
+* Trevor: But that’s the same thing, isn’t it?
+* Rod: Using the term LTS is counterproductive (leave it to the LTS working group) – it distracts
+* Trevor: one year span before [V8] is merged – that sounds like LTS
+* Domenic: This is a new release channel/train
+* Mikeal: We need “stable for a year” / “new features in V8, no native modules” / “stable for five years”
+  we stick with semver
+  (CD: Mikeal could you fill this out further?)
+* Domenic: We don’t need to move away from semver for the next branch
+Yearly releases pick a version that aligns
+* Mikeal: don’t call it canary, get a codename – increment one, two, three or five over a year – when we merge into master we choose a new name
+* CD: Could not capture entirety of discussion – moved a bit fast for me.
+* Bert: there is no ideal answer here. Would like mikeal and domenic to continue discussion and come back with something to vote on.
+
+## Next meeting
+
+Next week, 2015-06-24

--- a/meetings/2015-07-01.md
+++ b/meetings/2015-07-01.md
@@ -1,0 +1,88 @@
+# Node Foundation TSC Meeting 2015-07-01
+
+## Links
+
+* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-07-01
+* **GitHub Issue**: https://github.com/nodejs/node-convergence-archive/issues/60
+* **Original Minutes Google Doc**: https://docs.google.com/document/d/1TN3Ks0fC4ciY3jeS0VxXxXRkT_dq8-tfs-bWQqZGRoE
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting.
+
+### nodejs/io.js
+
+* Policy for PR blocking? [#2078](https://github.com/nodejs/io.js/issues/2078)
+* International WG
+* lts: strawman LTS cycle [lts#13](https://github.com/nodejs/LTS/pull/13) / Proposal: Release Process [#1997](https://github.com/nodejs/io.js/issues/1997)
+
+## Minutes
+
+### Present
+
+* James Snell (TSC)
+* Bert Belder (TSC)
+* Steven Loomis (TSC)
+* Chris Dickinson (TSC)
+* Mikeal Rogers
+* Trevor Norris (TSC)
+* Brian White (TSC)
+* Jeremiah Senkpiel (TSC)
+
+### Review of the previous meeting
+
+* discussion of stability for internal APIs [#2030](https://github.com/nodejs/io.js/issues/2030)
+* Nominating new collaborators to this repository [#25481](https://github.com/joyent/node/issues/25481)
+* Use something that’s not uberconference ?
+
+### Standup:
+
+* James: continued triaging of joyent/node issues, working on the LTS strawman proposal
+* Bert: not much on node, some minor libuv and installer stuff
+* Steven: Intl WG work
+* Chris: Not too much on node, working on docs tooling
+* Mikeal: working on a conferencing solution / replacement
+* Trevor: webassembly discussion, api wg
+* Brian: not much, triaging io.js issues and PRs
+* Jeremiah: reviewing PRs and issues, more work on `_unrefActive()`
+* Rod: busy week, worked on the build & release procedures. New jenkins job for all the types of release builds. v3.0.0 is now blocked on NAN. It’s a very big job. Node-gyp in `next` now works for rc’s and nightlies, and downloads a tarball of just the headers. First LTS WG meeting was also productive.
+
+
+### Policy for PR blocking? [#2078](https://github.com/nodejs/io.js/issues/2078)
+
+* Steven Belanger tagged this issue: can we come up with a policy for dealing with PRs that block each other?
+* James clarified that this specific issue was about the url parsing changes, there were a couple of PRs that blocked each other
+* Chris: the PRs here are a “hot stove” situation where they all break url functionality so they are not trivial
+* Chris listed some of the blocking issues that are mainly held up because people are too busy so we probably need a way to communicate status to the community
+* James: would like to table this issue until it really becomes a problem
+* Bert: we could introduce some workflows - e.g. if you introduce an issue that is blocked on something else then you could mention that it’s blocked
+* Jeremiah: more relevant to communicate when things are in the pipeline and provide feedback for timelines so people are reasonably blocked but can be unblocked if there is no activity
+* Rod: doesn’t feel like something that needs a policy, perhaps it’s an open source 101 skill
+* Mikeal: the problem is that often people who are blocking each other don’t have context so need shepherding by someone with context.
+* Rod: doesn’t seem like there’s actionable items here, come back when there’s something more concrete to discuss
+* Bert: the workers PR has stalled because of Petka’s lack of time, anything that it’s blocking should just move forward, url changes are unlikely to get in as they are now because they are so _breaking_
+
+### Internationalization WG (Steven)
+
+* https://github.com/nodejs/internationalization (repo)
+* https://github.com/nodejs/internationalization/issues/4 (README)
+* https://github.com/nodejs/internationalization/issues/5 (CFP)
+
+* Steven introduced the work towards getting this set up
+* Steven clarified the scope of the work (this is done in the README), it’s different to outreach and user assistance (i.e. the i18n translation stuff that io.js already has).
+* Jeremiah suggested we name the group after `Intl` so it’s clearer what it’s about.
+* James: It’s about Intl stuff in the code, unicode, REPL dying because of bad unicode
+* Mikeal: We’ve talked about starting a formal translation/language group that unifies all of the independent translation efforts. That’s probably why people are showing up for this group thinking it’s the translation group that we’ve talked about setting up. We should set up that separate group and maybe use `Intl` as the name for this separate group.
+* Bikeshedded naming for a little while.
+* Conclusion: rename as the Intl WG or similar for clarity. (renamed to Intl)
+
+
+### lts: strawman LTS cycle [lts#13](https://github.com/nodejs/LTS/pull/13) / Proposal: Release Process [#1997](https://github.com/nodejs/io.js/issues/1997)
+
+* James walked through the LTS strawman proposal as formulated by the LTS WG
+* Lots of bikeshedding about releases and LTS trivia
+* Mikeal: we can probably move the release discussion to a formal proposal
+
+### Next Meeting
+
+July 8th 2015

--- a/meetings/2015-07-08.md
+++ b/meetings/2015-07-08.md
@@ -1,0 +1,131 @@
+# Node Foundation TSC Meeting 2015-07-08
+
+## Links
+
+* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-07-08
+* **GitHub Issue**: https://github.com/nodejs/node-convergence-archive/issues/64
+* **Original Minutes Google Doc**: https://docs.google.com/document/d/1HuRtu5ZP7ZlrIp756EbZYo4I26v2RY-7CY1pr_3y1nY
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting.
+
+### nodejs/io.js
+
+* Default Unhandled Rejection Detection Behavior [#830](https://github.com/nodejs/io.js/issues/830)
+
+### joyent/node
+
+* Adding a "mentor-available" label [#25618](https://github.com/joyent/node/issues/25618)
+
+## Minutes
+
+
+### Present
+
+* Mikeal Rogers
+* Colin Ihrig (TSC)
+* Ben Noordhuis (TSC)
+* James Snell (TSC)
+* Fedor Indutny (TSC)
+* Bert Belder (TSC)
+* Michael Dawson (TSC)
+* Steven R Loomis (TSC)
+* Alexis Campailla (TSC)
+* Jeremiah Senkpiel (TSC)
+* Julien Gilli (TSC)
+* Chris Dickinson (TSC)
+* Shigeki Ohtsu (TSC)
+* Trevor Norris (TSC)
+* Domenic Denicola
+* Brian White (TSC)
+* Rod Vagg (TSC)
+
+### Review of the previous meeting
+
+* Policy for PR blocking? [#2078](https://github.com/nodejs/io.js/issues/2078)
+ - Resolution was to deal with it on a case-by-case basis for now.
+
+* Internationalization WG (Steven)
+ - Steven Loomis is going to kick off the working group.
+ - Steven: no further responses on the github issue.
+ - James: just need to get started
+
+* lts: strawman LTS cycle [lts#13](https://github.com/nodejs/LTS/pull/13) / Proposal: Release Process [#1997](https://github.com/nodejs/io.js/issues/1997)
+
+
+### Standup:
+
+* Mikeal Rogers: wrote a new confrence call tool for us that uses Twillio
+* Colin Ihrig: Not much, reviewing PRs, triaging issues.
+* Ben Noordhuis: reviewed a lot of PRs, upgraded v8 in `next` and `next+1`.
+* James Snell: Working on the LTS Proposal, triaging issues in joyent/node, investigating stuff for the upcoming openssl fix.
+* Fedor Indutny: fixed node after v8 upgrade. Exposed critical issues.
+* Bert Belder: Not much code, had conversations with Mike Dolan and James Snell about the foundation and organizational issues. Working through a laundry list of libuv PRs blocking the next release.
+* Michael Dawson: Working on getting PowerPC to build on io.js, tested the security fix from last week, joyent/node triage.
+* Steven R Loomis: Worked a bit on the Intl WG, not much else.
+* Alexis Campailla: converged CI, almost done. Dealing with windows installer issues. Expect converged CI to work in a week.
+* Jeremiah Senkpiel: General triaging and reviewing, helped do the release last friday. `_unrefActive` with optimizations with heap timers. At CascadiaJS the next of the week to get people’s feedback.
+* Julien Gilli: Released 0.12.6 last week, working on setting up other people to do joyent/node releases, joyent/node issue triage
+* Chris Dickinson: Working on docs more, have a new tool for docs to make sure the links are correct in a tree of docs, started a collaborator check-in on the io.js issue tracker, hopefully will be weekly.
+Jeremiah: what is that doctool? 
+Chris: “count-docula”, a MDAST-based tool to verify correctness of the docs.
+* Shigeki Ohtsu: Not much on io.js, preparing to update OpenSSL tonight to get the OpenSSL security fix out.
+* Trevor Norris: Investigating the UTF8 decoder security issue and working on the fix. Reviewing PRs and being involved in the W3C Web Assembly working group.
+* Domenic Denicola: Not much on io.js, travelling, stress testing the vm module.
+* Brian White: Triaging issues, working on the javascript http parser more & benchmarking it.
+* Rod Vagg: We should discuss the LTS proposal again since there was lots of work done on that. Working on lots, including the security fix from last friday (writing up a post-mortem for it), getting external people involved to review our security processes.
+
+### Default Unhandled Rejection Detection Behavior [#830](https://github.com/nodejs/io.js/issues/830)
+
+* Domenic: let’s say there was a magic way to detect when an error in an err-back style callback was not handled, what would we do? Print to stderr?
+* Bert: We do have a history of printing things to stderr. We should follow browser semantics if we can, in favor of primnting a warning but nothing else.
+* Discussion about the technicalities of handling unhandledRejections
+* Rod: not sure we should do anything since detecting this is somewhat arbitrary.
+* Domenic: there is a proposal for this that chrome implements behind a flag that comes close to how the unhandledRejection hook in node works
+* Discussion about the technicalities of having a better hook for printing a warning after garbage collection of an unhandled rejection.
+* See this thread for background detail of options in v8: https://code.google.com/p/v8/issues/detail?id=3093#c1
+* Action: nothing now, maybe if v8 adds a hook for when rejections get garbage collected.
+* Domenic: looking at v8, it seems to have most of the hooks, so this may be possible soon.
+
+### Adding a "mentor-available" label [#25618](https://github.com/joyent/node/issues/25618)
+
+* Folks are interested in contributing to larger tasks, need mentors to help them understand the process. Should we add a label?
+* Julien: Many people are interested in making “deeper” contributions, but they need a mentor. Let people add a mentor-available tag so they can locate these.
+* … part of the discussion missing here ...
+* Resolution: let’s try it, one such label has already been added.
+
+### Having more people managing releases for Node.js v0.10.x and v0.12.x
+
+* Julien: I will have less time to do releases; it needs to become more of a team effort.
+* Alexis: in the long term this will be a responsibility of the build team.
+* Julien: unsure how responsibilities will be decided. LTS will need to sign off and build will need to produce the release.
+* Jeremiah: the iojs/current releases are already a group effort. It’s just that the “long-term” v0.10/v0.12 releases fall on few individuals now.
+* Julien: it’s a bit too much to handle for one person. Also people are sometimes unavailable or on vacation. Would like to have a group of about four people.
+* Ben: more contributors recently signed up. I think Sam Roberts might be interested.
+* Julien: would like to have a release management team.
+* Chris: iojs has had the release manager propose other release managers. Open an issue for this.
+* Resolved as such.
+
+### lts: LTS Proposal https://github.com/nodejs/LTS#proposed-lts)/ Proposal: Release Process [#1997](https://github.com/nodejs/io.js/issues/1997)
+
+* James: when are we cutting over to the converged stream? Thinking of late august, first LTS release in October. Is this a good time? Most users won’t start migrating until next year because of the holidays.
+* Julien: what are other projects doing, when do they release?
+* James: looking it into it, some do it in fall. No clear pattern.
+* Alexis: what is the benefit of being on a fixed release schedule?
+* James: benefit is it makes planning easier.
+* Trevor: coming from the enterprise side, not having a predictable release schedule isn’t useful.
+* Steven: ICU and Unicode has announced that there will be a yearly release. It’s been helpful for planning.
+* James: It also ties into our regular release schedule and merging next into master etc. The next-to-master merge defines when we can do an LTS release. This should happen at least twice a year. The LTS is cut just before a merge (major bump), so by the time a LTS is cut it should have been stable for half a year.
+* James: please kick tires on this proposal, get feedback from the user communities you’re connected to wrt the frequency and release date.
+* Rod: the TSC should consider the timeframe, and the requirement that there should be two next-to-master merge yearly.
+* Trevor: how does this fit with a 6-week release schedule on master?
+* James: depends on the schedule.
+* Domenic: I don’t see the problem. Just take a 6 months old release and turn it into an LTS.
+* Rod/James/Trevor: because version numbers. The LTS version number needs to be a continuation of a release version.
+* Rod: fixed date, or part of the month.
+* Chris, Rod: get feedback, comment on the issue 
+
+### Next Meeting
+
+July 15th 2015

--- a/meetings/2015-07-15.md
+++ b/meetings/2015-07-15.md
@@ -1,0 +1,94 @@
+# Node Foundation TSC Meeting 2015-07-15
+
+## Links
+
+* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-07-15
+* **GitHub Issue**: https://github.com/nodejs/node-convergence-archive/issues/67
+* **Original Minutes Google Doc**: https://docs.google.com/document/d/1r8boI4E67Cq7PEsYeIpXkFZM0be4Ww5UDlNr_uXOop0
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting.
+
+### nodejs/io.js
+
+* Intl [#238](https://github.com/nodejs/io.js/issues/238)
+* TC39 representation [#2153](https://github.com/nodejs/io.js/issues/2153)
+
+### Other
+
+* Foundation Discussion
+* lts: [LTS Proposal](https://github.com/nodejs/LTS#proposed-lts) / Proposal: Release Process [#1997](https://github.com/nodejs/io.js/issues/1997)
+
+## Minutes
+
+### Present
+
+* Mikeal Rogers
+* Colin Ihrig (TSC)
+* James Snell (TSC)
+* Fedor Indutny (TSC)
+* Michael Dawson (TSC)
+* Steven R Loomis (TSC)
+* Alexis Campailla (TSC)
+* Jeremiah Senkpiel (TSC)
+* Shigeki Ohtsu (TSC)
+* Trevor Norris (TSC)
+* Domenic Denicola
+* Brian White (TSC)
+* Angela Brown (Linux F)
+* Mike Dolan (Linux F)
+* Laura Kempke (Linux F)
+* Bert Belder (TSC)
+
+### Review of the previous meeting
+
+* Default Unhandled Rejection Detection Behavior [#830](https://github.com/nodejs/io.js/issues/830)
+* Adding a "mentor-available" label [#25618](https://github.com/joyent/node/issues/25618)
+* Having more people managing releases for Node.js v0.10.x and v0.12.x
+* lts: [LTS Proposal](https://github.com/nodejs/LTS#proposed-lts) / Proposal: Release Process [#1997](https://github.com/nodejs/io.js/issues/1997)
+
+### Standup:
+
+* Steven Loomis: Intl WG - https://github.com/nodejs/io.js/issues/2165
+* Mikeal Rogers: Meeting with the Linux Foundation
+* Colin Ihrig: Issues & PRs, met with Julien & Sam for joyent/node release onboarding
+* James Snell: Deep diving on a couple issues, looking into TC39 involvement, LTS feedback
+* Fedor Indutny: some bugs and node-spdy, not too much
+* Alexis Campailla: build-related things to converge the CI, most of the work is done, trying to get the CI working for 0.10. Also speeding up arm builds. +Windows issues.
+* Jeremiah Senkpiel: CascadiaJS Feedback was positive for the project convergence, sick from the cascadiajs cold, not much else.
+* Shigeki Ohtsu: Did the security update for OpenSSL on thursday
+* Domenic Denicola: Not much, working on the unhandled rejection spec.
+* Brian White: Mostly working on the JS Http parser, also working on a JSPerf.com-like tool for testing different node versions from the browser.
+
+### Foundation Discussion (@mikeal leading)
+
+Security policy best-practices
+
+### Intl [#238](https://github.com/nodejs/io.js/issues/238)
+
+Discussion if we can land this into `master` rather than `next`.
+
+Action: Check that there is no objection to landing in `master`.
+
+Steven, Domenic, James: Should be a direct port from 0.12, we can work on making a PR.
+
+### TC39 representation [#2153](https://github.com/nodejs/io.js/issues/2153)
+
+Discussion about the legalities of joining officially and if unofficial representation would be workable.
+
+Action: Domenic will invite Mikeal to check out one of the TC39 meetings.
+
+### lts: [LTS Proposal](https://github.com/nodejs/LTS#proposed-lts) / Proposal: Release Process [#1997](https://github.com/nodejs/io.js/issues/1997)
+
+Mikeal: We are effectively working under the new release proposal ([#1997](https://github.com/nodejs/io.js/issues/1997)) now with how `next` / 3.0.0 is going.
+
+Jeremiah: Only real contested point is how we might version the `next` branch releases.
+
+Domenic: Having multiple release train versionings in confusing.
+
+Action: Mikeal will update the current PR and separate any contention points into new PRs for discussion.
+
+### Next Meeting
+
+July 22nd 2015

--- a/meetings/2015-07-22.md
+++ b/meetings/2015-07-22.md
@@ -1,0 +1,168 @@
+# Node.js Foundation TSC Meeting 2015-07-22
+
+## Links
+
+* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-07-22
+* **GitHub Issue**: https://github.com/nodejs/node-convergence-archive/issues/69
+* **Original Minutes Google Doc**: https://docs.google.com/document/d/1r8boI4E67Cq7PEsYeIpXkFZM0be4Ww5UDlNr_uXOop0
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting.
+
+### nodejs/io.js
+
+* doc: add GPG fingerprint for cjihrig [#2217](https://github.com/nodejs/io.js/pull/2217)
+* Process & Approval for Collab Summit Travel Fund [#2213](https://github.com/nodejs/io.js/issues/2213)
+* TC39 representation for the Node.js Foundation [#2153](https://github.com/nodejs/io.js/issues/2153)
+* Next branch release versioning [#2215](https://github.com/nodejs/io.js/issues/2215)
+
+## Minutes
+
+
+### Present
+
+* Mikeal Rogers
+* Rod Vagg (TSC)
+* Colin Ihrig (TSC)
+* James Snell (TSC)
+* Fedor Indutny (TSC)
+* Michael Dawson (TSC)
+* Steven R Loomis (TSC)
+* Jeremiah Senkpiel (TSC)
+* Brian White (TSC)
+* Ben Noordhuis (TSC)
+* Trevor Norris (TSC)
+* Chris Dickinson (TSC)
+* Mike Dolan (Linux F)
+* Emily Ratliff (Linux F)
+
+### Security Policy Discussion
+
+Emily Ratliff from the LF has joined us to help with our security and disclosure policy. TSC members were sent a briefing prior to the meeting.
+
+Discussed ISO 29147 “Vulnerability Disclosure Overview” and ISO 30111 “Vulnerability Handling Processes Overview”.
+
+
+### Review of the previous meeting
+
+* Foundation Discussion (@mikeal leading)
+* Intl [#238](https://github.com/nodejs/io.js/issues/238)
+* TC39 representation [#2153](https://github.com/nodejs/io.js/issues/2153)
+* lts: LTS Proposal (https://github.com/nodejs/LTS#proposed-lts)[ Proposal: Release Process] [#1997](https://github.com/nodejs/io.js/issues/1997)
+
+### Standup:
+
+* Mikeal Rogers: preparing for the foundation board meeting
+* Rod Vagg: working on 3.0 and release candidates / NAN
+* Colin Ihrig: reviewing issues  & PRs, worked with julien to do releases from joyent/node 0.x branches
+* James Snell: working on smoke-testing npm modules
+* Fedor Indutny: doing so bug fixes, and reviewing PRs
+* Michael Dawson: some joyent/node issue triage, PPC build work
+* Steven R Loomis: some Intl WG work, working on getting the Intl commits from joyent/node into io.js
+* Jeremiah Senkpiel: reviewing issues + prs, doing work on REPL in light of 3.0; fixing bugs in REPL
+* Brian White: working more on the in-browser node.js/io.js benchmarking tool, which is now in a usable state. using it now to test current and future performance improvement techniques for the the js http parser
+* Ben Noordhuis: (no mic)
+* Trevor Norris: did a fix for the buffer implementation for the 3.0 release
+* Chris Dickinson: npm work.
+
+### doc: add GPG fingerprint for cjihrig [#2217](https://github.com/nodejs/io.js/pull/2217)
+
+* Rod +1
+* James +1
+* Fedor +1
+* Michael +1
+* Steven +1
+* Jeremiah +1
+* Brian +1
+* Ben +1
+* Trevor +1
+* Chris +1
+
+Action: make sure Colin’s GPG key setup is correct on the PR, after we can merge and Rod can add Colin’s credentials to the build server.
+
+### Process & Approval for Collab Summit Travel Fund [#2213](https://github.com/nodejs/io.js/issues/2213)
+
+* Mikeal: budget auditing requires that spending be approved by the board - need to approve the budget and the process for expenditure of those funds. Mikeal has a proposal for the process with basic limits and a process for having the TSC approve expenditure beyond that.
+
+
+**Process as outlined**
+
+* TSC approves target budget (max amount to spend on travel) and caps on each type of spend (with the possibility that the TSC can approve a specific spend over if need be).
+* Contributors in need of the fund apply (this will happen in the GitHub thread) but should explicitly state if they need flight, accommodation or both.
+* If the number of contributors in need of the fund exceeds the target budget the TSC will prioritize the list of contributors applying for the fund.
+
+
+Voting on approving the process stated above:
+
+* Rod: +1
+* James: +1
+* Fedor: +1
+* Michael: +1
+* Steven: +1
+* Jeremiah: +1 
+* Brian: +1
+* Ben: +1
+* Trevor: +1
+* Chris: +1
+
+
+Specific proposal for August
+
+* 15K max budget (we had previously talked about 10K but I don't think that is enough)
+* Approve a $900 max spend per person on accommodations.
+* Approve a $500 max spend on domestic travel
+* Approve a $1500 max spend on international travel (if someone has to go over it just requires additional TSC approval)
+
+* Rod: +1
+* James: +1
+* Fedor: +1
+* Michael: +1
+* Steven: +1
+* Jeremiah: +1 
+* Brian: +1
+* Ben: +1
+* Trevor: +1
+* Chris: +1
+
+
+Approval for extra expenditure for @joaocgreis (from Portugal): $1,742.66
+
+* Rod: +1
+* James: +1
+* Fedor: +1
+* Michael: +1
+* Steven: +1
+* Jeremiah: +1 
+* Brian: +1
+* Ben: +1
+* Trevor: +1
+* Chris: +1
+
+Approval for expenditure on @yosuke-furukawa (from Japan) max spend of $2400
+
+* Rod: +1
+* James: +1
+* Fedor: +1
+* Michael: +1
+* Steven: +1
+* Jeremiah: +1 
+* Brian: +1
+* Ben: +1
+* Trevor: +1
+* Chris: +1
+
+### Next branch release versioning [#2215](https://github.com/nodejs/io.js/issues/2215)
+
+* Rod outlined the state of play:
+  - LTS WG moved from “proposal” to “plan” but are still depending on the stable release branch having a clear process
+  - LTS WG discussed a proposal by Trevor for how to handle next/canary/alpha & master & release branches & LTS branches: https://gist.github.com/trevnorris/7620a64b086e95271197
+* Mikeal: it’s more helpful if we think about V8 upgrades as a pull-request to master rather than a separate “next” that has to be separately managed.
+
+Much bikeshedding was had in an attempt to move forward.
+
+Group agreed in general with Trevor’s proposal, will organise further discussions amongst the group of interested parties at another time.
+
+### Next Meeting
+
+July 29th 2015

--- a/meetings/2015-07-29.md
+++ b/meetings/2015-07-29.md
@@ -1,0 +1,89 @@
+# Node.js Foundation TSC Meeting 2015-07-29
+
+## Links
+
+* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-07-29
+* **GitHub Issue**: https://github.com/nodejs/node-convergence-archive/issues/71
+* **Original Minutes Google Doc**: https://docs.google.com/document/d/1FBmDczHD4D8jfffc6A8CW-K9mmT0KI8shG6dm_d3jXI
+* Previous minutes: https://docs.google.com/document/d/1eCETYn44gAOUp0udl22QxqyxrJ0oEeAFRdWHDCIq9V4
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting.
+
+### nodejs/io.js
+
+* Next branch release versioning [#2215](https://github.com/nodejs/io.js/issues/2215)
+* TSC Chair - Election? [#2136](https://github.com/nodejs/io.js/issues/2136)
+
+## Minutes
+
+
+### Present
+
+* Mikeal Rogers
+* Rod Vagg (TSC)
+* Colin Ihrig (TSC)
+* James Snell (TSC)
+* Fedor Indutny (TSC)
+* Michael Dawson (TSC)
+* Steven R Loomis (TSC)
+* Jeremiah Senkpiel (TSC)
+* Shigeki Ohtsu(TSC)
+* Ben Noordhuis (TSC)
+* Trevor Norris (TSC)
+* Chris Dickinson (TSC)
+* Alexis Campailla (TSC)
+* Bert Belder (TSC)
+
+### Review of the previous meeting
+
+* Security Policy Discussion
+* doc: add GPG fingerprint for cjihrig [#2217](https://github.com/nodejs/io.js/pull/2217)
+* Process & Approval for Collab Summit Travel Fund [#2213](https://github.com/nodejs/io.js/issues/2213)
+* Next branch release versioning [#2215](https://github.com/nodejs/io.js/issues/2215)
+
+
+### Standup:
+
+* Mikeal Rogers: Got ready for the board meeting, working to get the new website spun up based on the iojs.org build system
+* Rod Vagg: Finished writing NAN 2.0 documentation
+* Colin Ihrig: Issues & PRs, did the 2.5.0 release (armv6 build had an issue), playing around with the citgm package smoke-testing tool
+* James Snell: Working on citgm (npm package smoke-testing), halfway done writing up the release plan
+* Fedor Indutny: ?
+* Michael Dawson: Triaging joyent/node issues / PRs, looking at AIX build support on the `next` branch, looking at updating some docs
+* Steven R Loomis: Worked on the Intl converge PR [#2264](https://github.com/nodejs/io.js/pull/2264)
+* Jeremiah Senkpiel: Issue and PR review, helping to get someone to start contributing to core
+* Ben Noordhuis: not much, reviewed some PRs this week and did some minor patches
+* Trevor Norris: Just had time to review some issues and respond to PRs
+* Chris Dickinson: Not much, did docs work, trying to document streams (again), and the REPL history-paintext change PR [#2224](https://github.com/nodejs/io.js/pull/2224)
+* Alexis Campailla: Working on CI/Jenkins convergence, and some windows issue triage
+* Shigeki Ohtsu: Working on the updated crypto module for weak ciphers
+* Bert Belder: Not much except started reviewing a VS2015 support PR
+
+#### Next branch release versioning [#2215](https://github.com/nodejs/io.js/issues/2215)
+
+Discussion about the release plan (not yet written up, James Snell is working on that.)
+
+#### TSC Chair - Election? [#2136](https://github.com/nodejs/io.js/issues/2136)
+
+Vote?
+
+* Colin: +1
+* Chris: +1
+* James: +1
+* Fedor: +1
+* Michael: +1
+* Steven: +1
+* Jeremiah: +1
+* Shigeki: +1
+* Ben: +1
+* Trevor: +1
+* Chris: +1
+* Alexis: +1
+* Bert: +1
+
+### Next Meeting
+
+Not happening on August 5th (as it usually would).
+Possibly a (short) TSC meeting will be held during the summit.

--- a/meetings/2015-08-12.md
+++ b/meetings/2015-08-12.md
@@ -1,0 +1,87 @@
+# Node.js Foundation TSC Meeting 2015-08-12
+
+## Links
+
+* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-08-12
+* **GitHub Issue**: https://github.com/nodejs/node-convergence-archive/issues/71
+* **Minutes Google Doc**: https://docs.google.com/document/d/1q2bFjnf0Y23Ljxoze56Pmrbailaj5-UAqIUqIYVhiIk
+* _Previous Minutes Google Doc: <https://docs.google.com/document/d/1FBmDczHD4D8jfffc6A8CW-K9mmT0KI8shG6dm_d3jXI>_
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting.
+
+* Travel assistance amendment (no issue for this)
+* FYI: Collaboration WG: https://github.com/nodejs/collaboration  
+* Summit recap
+* level-set on repo rename
+* Future: “project lifecycle” (Mikeal) - process by which top level projects are added (libuv, node-gyp, etc), (conferences…)
+
+
+## Minutes
+
+
+### Present
+
+* Mikeal Rogers
+* Rod Vagg (TSC)
+* James Snell (TSC)
+* Michael Dawson (TSC)
+* Steven R Loomis (TSC) 
+* Chris Dickinson (TSC)
+* Alexis Campailla (TSC)
+* Brian White (TSC)
+
+### Review of the previous meeting
+
+* Next branch release versioning [#2215](https://github.com/nodejs/io.js/issues/2215)
+* TSC Chair - Election? 
+
+### Standup:
+
+* Mikeal: summit, code & learn project for new collab
+* Rod: Summit, migrating nodejs/io.js to nodejs/node
+* James: convergence, joyent/node PRs
+* Michael: patch for AIX, 0.12 work, Benchmarking meeting
+* Steven: Summit, 1st Intl meeting, Intl convergence work, VS2015 fixes
+* Chris: Summit, Docs repo has taken off, [HTTP lifecycle doc by Bryan English](https://github.com/nodejs/docs/blob/master/src/guides/anatomy-of-an-http-transaction.md)
+* Alexis: Summit, progress on CI convergence, reviewed some PRs.
+* Brian: Triaging and reviewing PRs and Issues.
+
+### Travel assistance amendment (no issue for this)
+
+* Chris Dickinson adding $500 to the travel expenditure 
+* Passed unanimously.
+
+### FYI: Collaboration WG: https://github.com/nodejs/collaboration  
+
+* Steven: new WG coming out of the Summit, Sean (@snostorm) is taking lead on this. One idea under discussion now is to have a multi-timezone meetings for the language working groups.
+* Mikeal: is this going to serve as a collaboration point for the language groups?
+* Steven: https://github.com/nodejs/Intl/issues/9
+* Rod: beyond the language groups, what are the aims of this new group?
+* Steven: trying to address, or having a place to discuss, common items across working groups.
+* James: filling a need to liaise with the other working groups, acting as an intermediary
+
+### Summit recap
+
+* Mikeal: 6 sessions in 2 days, not solid answers to problems but a shared understanding of the common problems, feels like we are on the same page from that
+* Mikeal: bigger sessions: what is the Node API and what is the Node platform? V8 release cycle. Errors and the inconsistencies. Kept coming back to the collaboration WG, which is why it exists. Talked about expanding the collaborator base, idea was to do some collaboration sprints to bring new folks up to speed, https://github.com/nodejs/code-and-learn comes from that idea (there is foundation budget for that).
+* Mikeal: there were extensive notes taken, those are being edited now and will be published into the repo(s) and turned into blog posts.
+
+### level-set on repo rename
+
+* James: what are the remaining things to do - there’s confusion around the naming
+  - Renaming everything in the documentation (README, docs & other misc docs)
+  - Renaming binary
+  - Alexis: finishing convergence work
+* Mikeal: preparing a blog post about what’s happening, will be reviewed and posted soon
+
+### Future: “project lifecycle” (Mikeal) - process by which top level projects are added (libuv, node-gyp, etc), (conferences…)
+
+* Mikeal: the TSC charter states that we will adopt a project lifecycle that will allow us to bring in other _top level projects_. Additionally, the TSC has had to take on board some non-technical work because of its position in the Foundation (voting on expenditure, etc.), a number of TSC members don’t want to be involved in that kind of activity. Have started drafting a new project lifecycle plan which splits off a “Core TSC” that contains the existing TSC members but with a focus on Node.js Core work while the existing TSC will take on board the higher-level foundation work and members can optionally resign if they aren’t interested in that work and we can expand it to non-Core collaborators. https://github.com/nodejs/TSC/tree/lifecycle 
+
+
+### Next Meeting
+
+August 19th
+

--- a/meetings/2015-08-19.md
+++ b/meetings/2015-08-19.md
@@ -1,0 +1,120 @@
+# Node.js Foundation TSC Meeting 2015-08-19
+
+## Links
+
+* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-08-19
+* **GitHub Issue**: https://github.com/nodejs/node/issues/2435
+* **Minutes Google Doc**: https://docs.google.com/document/d/1xsj_4UlrLNxahRvC7SpLtFM3D-Ks6CZEqEM5nyj6bjk
+* _Previous Minutes Google Doc: <https://docs.google.com/document/d/1q2bFjnf0Y23Ljxoze56Pmrbailaj5-UAqIUqIYVhiIk>_
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting.
+
+* Procedure for rolling out node-accept-pull-request [#2434](https://github.com/nodejs/node/issues/2434)
+* Release procedure changes & nominating @sam-github and @jasnell as releasers [#2416](https://github.com/nodejs/node/issues/2416)
+
+## Minutes
+
+
+### Present
+
+* Mikeal Rogers
+* Rod Vagg (TSC)
+* James Snell (TSC)
+* Michael Dawson (TSC)
+* Steven R Loomis (TSC) 
+* Chris Dickinson (TSC)
+* Alexis Campailla (TSC)
+* Brian White (TSC)
+* Jeremiah Senkpiel (TSC)
+* Shigeki Ohtsu (TSC)
+* Trevor Norris (TSC)
+* Domenic Denicola
+* Ben Noordhuis (TSC)
+* Colin Ihrig (TSC)
+* Bert Belder (TSC)
+
+
+### Standup
+
+* Mikeal Rogers: Linuxconf, preparing next board meeting agenda, nailing down the foundation conf
+* Rod Vagg: build work, memory leak testing, progress towards v4 (mainly infra)
+* James Snell: some joyent/node PR triaging, preparing for nodeconf.eu
+* Michael Dawson: nodeconf.eu, some AIX build work, talking to the v8 team about security notifications
+* Steven R Loomis: Intl WG, landed Intl with small-icu by default in nodejs/node
+* Chris Dickinson: first docs WG meeting, working on streams docs (again), working on docs tooling
+* Alexis Campailla: working on ci convergence and jenkins jobs
+* Brian White: not much, looking over issues and PRs, submitted a couple PRs
+* Jeremiah Senkpiel: not so much, working on 0.10, 0.12 -> v4 upgrade docs, 3.1.0 release which should be ready straight after this meeting.
+* Shigeki Ohtsu: little time to work on node right now, joined the LTS meeting to discuss OpenSSL LTS
+* Trevor Norris: reviewing issues and PRs, noticed a bug in asyncwrap
+* Domenic Denicola: issues and PRs, v8 team has a new Project Manager who is more interested in node; communicated our API stability concerns to him
+* Ben Noordhuis: fixed a big memory leak, fixed a regression in windows module loading, reviewing PRs, responding to bug reports
+
+### Review of the previous meeting
+
+* Travel assistance amendment (no issue for this)
+* FYI: Collaboration WG: https://github.com/nodejs/collaboration  
+* Summit recap
+* level-set on repo rename
+* Future: “project lifecycle” (Mikeal) - process by which top level projects are added (libuv, node-gyp, etc), (conferences…)
+
+### Procedure for rolling out node-accept-pull-request [#2434](https://github.com/nodejs/node/issues/2434)
+
+* Discussed some potential concerns, which were alleviated:
+* Jeremiah: Wondered how to land PRs where nits needed to be fixed.
+* Bert: Concerns about Jenkins costantly building the wrong PR in the io.js CI infrastructure.
+* Trevor: asked for a dropdown to pick the reviewers.
+* Bert: asked whether the job would support landing multiple commits. Alexis confirmed this.
+* Alexis: mentioned that there is also an node-accept-commit job that is more low-level and advanced.
+
+### Release procedure changes & nominating @sam-github and @jasnell as releasers [#2416](https://github.com/nodejs/node/issues/2416)
+
+Votes for @jasnell:
+
+* Rod Vagg: +1
+* Michael Dawson: +1 
+* Steven R Loomis: +1
+* Chris Dickinson: +1
+* Alexis Campailla: +1
+* Brian White: +1
+* Jeremiah Senkpiel: +1
+* Shigeki Ohtsu: +1
+* Trevor Norris: +1
+* Ben Noordhuis: +1
+* Colin Ihrig: +1
+* Bert Belder: +1
+
+Votes for @sam-github:
+
+* Rod Vagg: +1
+* Michael Dawson: +1 
+* Steven R Loomis: +1
+* Chris Dickinson: +1
+* Alexis Campailla: +1
+* Brian White: +1
+* Jeremiah Senkpiel: +1
+* Shigeki Ohtsu: +1
+* Trevor Norris: +1
+* Ben Noordhuis: +1
+* Colin Ihrig: +1
+* Bert Belder: +1
+
+No objections to combining the a whole "release team" to handle all release branches including 0.10, 0.12, stable and LTS.
+
+### node-gyp is now in our org [#2379](https://github.com/nodejs/node/issues/2379)
+
+* Rod: node-gyp has a busy issue tracker and has no tests, needs more eyes
+* Ben: Zero tests?
+* Rod: Correct.
+* Domenic: on Windows Chromium’s depot_tools will automatically download VS community edition and put it in the right place. Someone with copious free time could have node-gyp do similar things.
+
+* Discussed maybe looking at `gn` (the eventual replacement for `gyp`)
+
+* Domenic: even v8 still uses gyp, don’t worry about it for a good while until noise about it being deprecated gets louder
+* Rod: issue [#151](https://github.com/nodejs/build/issues/151) in build has a discussion about precompiled native addons. Chime in!
+
+## Next Meeting
+
+August 26th

--- a/meetings/2015-08-26.md
+++ b/meetings/2015-08-26.md
@@ -1,0 +1,112 @@
+# Node Foundation TSC Meeting 2015-08-26
+
+## Links
+
+* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-08-26
+* **GitHub Issue**: https://github.com/nodejs/node/issues/2560
+* **Minutes Google Doc**: https://docs.google.com/document/d/1aB76ClCgdjZUw3p-gHq9j6YwU11zWgJ4pmYPEWk6gjE
+* _Previous Minutes Google Doc: <https://docs.google.com/document/d/1q2bFjnf0Y23Ljxoze56Pmrbailaj5-UAqIUqIYVhiIk>_
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests in the nodejs org prior to meeting.
+
+### joyent/node
+
+* Update README to reflect move to nodejs/node [#25897](https://github.com/joyent/node/pull/25897)
+
+### nodejs/node
+
+* doc: merge CHANGELOG.md with joyent/node ChangeLog [#2536](https://github.com/nodejs/node/pull/2536)
+* (guidance on) rename of "language groups" from iojs-\* to nodejs-\*? [#2525](https://github.com/nodejs/node/issues/2525)
+* Node.js v4 Release Timeline [#2522](https://github.com/nodejs/node/issues/2522)
+
+### nodejs/collaboration
+
+* How to onboard into WG? [#4](https://github.com/nodejs/collaboration/issues/4)
+
+## Minutes
+
+
+### Present
+
+* Rod Vagg (TSC)
+* Brian White (TSC)
+* Steven R Loomis (TSC) 
+* Fedor Indutny (TSC)
+* Bert Belder (TSC)
+* Colin Ihrig (TSC)
+* Ben Noordhuis (TSC)
+* Mikeal Rogers
+* Alexis Campailla (TSC)
+* Trevor Norris (TSC)
+* Shigeki Ohtsu (TSC)
+
+
+### Review of the previous meeting
+
+* Travel assistance amendment (no issue for this)
+* FYI: Collaboration WG: https://github.com/nodejs/collaboration  
+* Summit recap
+* level-set on repo rename
+* Future: “project lifecycle” (Mikeal) - process by which top level projects are added (libuv, node-gyp, etc), (conferences…)
+
+### Standup:
+
+* Rod Vagg: v4 release stuff, got certificates from/for the foundation, new website including CDN offering from CloudFlare
+* Brian White: continuing work on benchmark app for node.js/io.js, triaging, reviewing/answering issues and pull requests.
+* Steven R Loomis: Intl for convergence VS2015
+* Fedor Indutny: http perf improvement PR, reviewing PRS, looking at issue for shared ports for http cluster
+* Bert Belder: busy with work, reviewing libuv PRs and responding to issues
+* Colin Ihrig: Rename from io.js to Node.js, reviewing issues and PRs
+* Ben Noordhuis: Running native addons as part of CI, libuv bugs, reviewing PRs
+* Mikeal Rogers: Website ready for release, working on CloudFlare CDN stuff
+* Alexis Campailla: CI for release, parallelising test runs for ARM, looking at managing dependencies with git
+* Trevor Norris: reviewing PRs and issues
+* Shigeki Ohtsu: reviewing convergence tests for SSLv2/3, working on TLS ALPN features before freeze
+
+### Update README to reflect move to nodejs/node [#25897](https://github.com/joyent/node/pull/25897)
+
+* Alexis: made changes in CI to prepare for this, we’ll keep PRs in original repo, node-accept-pull-request will land changes in new repo as well, mirroring changes in 0.10 and 0.12 across both old and new repos. Still using the old Jenkins for releases for 0.10 and 0.12 right now and that doesn’t depend on repo name & location.
+Target ETA for transition: Monday.
+
+
+### doc: merge CHANGELOG.md with joyent/node ChangeLog [#2536](https://github.com/nodejs/node/pull/2536)
+
+* Rod seeking confirmation from this group that this was _not a bad idea_.
+* Discussion about documentation for people upgrading from older versions of Node and having a linear history. Jeremiah has been working on 0.10 -> v4 documentation.
+
+### (guidance on) rename of "language groups" from iojs-\* to nodejs-\*? [#2525](https://github.com/nodejs/node/issues/2525)
+
+* Steven discussed renaming the language groups
+* Mikeal: some groups are not in a position to make decisions because they are not active but the ones that are should be given the opportunity to agree or disagree to the move rather than us imposing a move on them. We should post an issue in their repos.
+* Steven: we should give them a timeline in issues in their repos
+* Discussed naming, could be “lang” or “community” to make it more clear what they are about.
+* ACTION: Steven to add a proposal to #2525, let TSC/collaborators add comments, later in the week will reach out to each of the groups.
+
+### Node.js v4 Release Timeline [#2522](https://github.com/nodejs/node/issues/2522)
+
+* Rod gave a summary of the proposed release timeline https://github.com/nodejs/node/issues/2522 (and appologised for documenting it as “the” release proposal just for the sake of getting it done). 
+  - “feature freeze” Friday, 28th of August, cut v4.x branch
+  - nodejs.org DNS changeover to new website Monday, 31st of August
+  - release Thursday, 3rd of September
+  - RC builds between website and release
+  - backup release date of Monday, 7th of September if absolutely necessary to punt
+* Discussed the outstanding items in the 4.0.0 milestone: https://github.com/nodejs/node/milestones/4.0.0, some concerning items:
+  - mdb support is late and may not get done, might have to be a semver-minor prior to LTS
+  - vcbuilt.bat needs to use the new build_release target and we have to verify that all builds have Intl enabled - Steven to work with Rod on this
+  - `process.send()` async/sync, Ben said that this is async on all platforms now (was just Windows previously but now it’s cross-platform) but it’s missing a callback so there’s no way of doing back-pressure. No time to add this prior to v4 but could be done as semiver-minor later. Ben agreed to document current behaviour properly in the docs.
+  - `_unrefActive` is in Jeremiah’s hands, he will land the 0.12 changes as the io.js version is terrible. Discussed further perf improvements but agreed to leave those changes till later, ideally till v5 because of the potential for subtle edge-case bugs being introduced.
+
+### How to onboard into WG? [nodejs/collaboration#4](https://github.com/nodejs/collaboration/issues/4)
+
+* Discussed GitHub onboarding mechanics
+
+### V8 embedders unified debugger proposal
+
+* Trevor raised https://github.com/nodejs/node/issues/2546 which is a proposal for a unified debugger for V8 embedders using Chromium DevTools.
+* Discussion ensued, agreed to leave it for GitHub discussion unless/until there is something the TSC actually needs to make a decision about.
+
+### Next Meeting
+
+September 2nd

--- a/meetings/2015-09-02.md
+++ b/meetings/2015-09-02.md
@@ -1,0 +1,418 @@
+# Node Foundation TSC Meeting 2015-09-02
+
+## Links
+
+* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-09-02
+* **GitHub Issue**: https://github.com/nodejs/node/issues/2654
+* **Minutes Google Doc**: https://docs.google.com/document/d/1rXBdtsD9PJTExNXgzNZ9bez9oOjW45kLPjun4zdt0dY
+* _Previous Minutes Google Doc: <https://docs.google.com/document/d/1aB76ClCgdjZUw3p-gHq9j6YwU11zWgJ4pmYPEWk6gjE>_
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests in the nodejs org prior to meeting.
+
+### nodejs/node
+
+* deps: update v8 to 4.5.103.30 [#2632](https://github.com/nodejs/node/pull/2632)
+* Inspecting Node.js with Chrome DevTools [#2546](https://github.com/nodejs/node/issues/2546)
+* Node.js v4 Release Timeline [#2522](https://github.com/nodejs/node/issues/2522)
+* doc: update COLLABORATOR_GUIDE.md [#2638](https://github.com/nodejs/node/pull/2638)
+
+### nodejs/build
+
+* Merge job overwrites metadata [#179](https://github.com/nodejs/build/issues/179)
+
+## Minutes
+
+
+### Present
+
+* Rod Vagg (TSC)
+* Brian White (TSC)
+* Steven R Loomis (TSC) 
+* Fedor Indutny (TSC)
+* Bert Belder (TSC)
+* Colin Ihrig (TSC)
+* Trevor Norris (TSC)
+* James M Snell (TSC)
+* Chris Dickinson (TSC)
+* Jeremiah Senkpiel (TSC)
+
+### Standup
+
+* Rod Vagg (TSC): node v4 prep, new website
+* Brian White (TSC): issue/PR reviewing, working on JS DNS implementation some more
+* Steven R Loomis (TSC): syncing with james, creating text for renaming of language groups (#2525), intl triaging, commenting on joyent/node issues
+* Bert Belder (TSC): indisposed until end of october
+* Colin Ihrig (TSC): reviewing issues/prs
+* Trevor Norris (TSC): prs/issues, finagling the new build pr landing tool
+* James M Snell (TSC): old prs in joyent/node cleaned up (64 remaining, wow), citgm tool updates, child process arguments pr, nodeconf.eu 
+* Michael Dawson (TSC): AIX support PR, some triage with Devin, preparing for NodeConfEU
+* Chris Dickinson (TSC): Static analysis work (ongoing), docs (slowly), npm
+* Jeremiah Senkpiel (TSC): v4 release prep
+* Fedor Indutny (TSC): v8 arraybuffer perf, patch landed on v8; reviewing PRs
+
+
+### Jenkins merge jobs always overwrites PR-URL and Reviewed-By [#179](https://github.com/nodejs/build/issues/179)
+
+Trevor: currently if you submit a job to land a pr, it will always remove all existing metadata and re-apply it based on the info passed to the jenkins build. from convo, good fix is to let old metadata persist & only append new metadata if it’s entered, if no metadata entered, nothing appended
+Issue with current state: current system does not work for cherry-picks onto release branch — will wipe metadata and replace it 
+Goal: solidify with TSC that this is a good path forward
+
+James: absolutely, +1
+
+Jeremiah: clarification on which branches this applies to
+
+Rod: cherry-picks are becoming increasingly difficult on iojs anyway, so the pr landing job may be master-specific
+
+James: no mixing of “with pr tool” and “manually”, things go bad quickly that way
+
+Trevor: cherry-pick PRs are accumulating too many cherry-picks; runnin it through the system manually doesn’t add useful info
+
+Domenic: description of chromium
+ - tests are run after landing
+ - no one is allowed to land commits if the build is broken on a branch
+ - sheriff of the day is responsible for fixing the issue
+ - in practice it’s painful, but it’s important for keeping things sane
+
+Trevor: this would make us better about flaky tests, also, admiration for how sporadically our flaky tests break
+
+Jeremiah: trying to do this now before v4 seems like a bad idea
+
+Rod: we’re smoothing out a little bit; circle back to original topic, we’re kind of talking about the larger issue, let the trial of the tool continue and come back to the discussion later. specifically: ask that metadata not be overridden in a github issue
+
+Domenic: addressing jeremiah’s concern: should we not run the trial while releasing v4?
+
+Trevor: agreement — have felt pain from this as we march to v4
+
+Jeremiah: stuff that gets released to people is in the release branches, if we’re not using the pr tool on that branch, what is the point of using this tool?
+
+Rod: this will become more of a problem as we have more extended and LTS
+
+Domenic: clarification: intent of ci is to make sure tests pass everywhere
+
+Trevor: this tool only runs a subset
+
+Rod: since we branched 3.x there’s 4 commits in the tree that have faulty/missing metadata — like that the pr tool is enforcing this metadata, maybe move to using github status api for telling us whether the metadata is OK
+
+Trevor: clarify: contributors have landed commits that lack metadata?
+
+Rod: yep
+
+Trevor: argh
+
+Jeremiah: github suggested we use the status api
+
+Trevor: status api autoruns?
+
+Rod: you hook it up to webhooks, has in-progress and pass/fail
+
+Trevor: TJ can verify that devs destroy jenkins (multiple force pushes explode the jenkins box with so many jobs)
+
+Rod: we can cancel on force push (or add a “trevor is pushing, wait half an hour to run the tests” exception, har har)
+
+Jeremiah: you can tell if it’s been run on the last commits
+
+Rod: multiple statuses — up to 100? — “this pr is passing on these platforms! this pr has the right metadata. this pr lints well.”
+
+Rod: let’s move on!
+
+James: what’s the action item?
+
+Rod: don’t feel that we should cancel the trial
+
+Trevor: two prs that prevent segfaults because of other flaky tests that have to be reapplied
+
+James: in the 4.x branch do we need to use test-pr job to land commits?
+
+Rod: nope, cherry-pick onto those branches, only use the tool on master
+
+Jeremiah: it’s weird to use it on the unstable branch. I guess we could make it better for release branches in the meantime
+* ci-run middle of hte night us time this has a
+
+Rod: vote for who whether we’d like to put this on hold
+
+Jeremiah: +0 put on hold
+
+Rod: who would like to continue it?
+
+...crickets...
+
+Trevor: give me another day
+
+James: one PR took 8 hours to land last friday
+
+Jeremiah: they take about an hour to land right now
+
+Rod: they are getting quicker, adding raspberrypis to the cluster. good incentive to make node startup time quicker! arm startup times have gone down over the last month or so
+
+Rod: let’s move on
+
+### doc: update COLLABORATOR_GUIDE [#2638](https://github.com/nodejs/node/pull/2638)
+
+Jeremiah: Alexis wanted to put the pr tool into the collaborator guide should punt on this right now notifying collaborators on issues is more effective messaging than the docs
+
+Rod: let’s hold off
+
+### deps: update v8 to 4.5.103.30 [#2632](https://github.com/nodejs/node/pull/2632)
+
+Rod: looking at the possibility of jumping to 4.5 for the v4 release it’s ready to merge. ofrobots has been doing the work, it’s good to go, there are pros and cons whether we stick with 4.4 or 4.5 for this release & associated LTS has anyone done any work on testing NAN?
+
+Bert: what breaks? what are the cons?
+
+Domenic: looking at v8 by code inspection, there are no breakages, just new deprecations — should *in theory* work — I don’t think anyone’s been testing it though
+
+Bert: can this v8 release be supported for LTS? we don’t know if this is better or worse than 4.4? maybe ask goog eng
+
+Trevor: they will say “Stay current”
+
+Bert: I think I agree with them — with no other info, picking the latest version seems best
+
+Michael: Z targets 4.4 — just recently got it fully clean — a move to 4.5 would cause a delay on getting release to community
+
+James: that’s just Z, not PPC, yes?
+
+Rod: how much work?
+
+Michael: going 4.3->4.4 took about a month
+
+Jeremiah: 4.3->4.4 breakage delta was much bigger
+
+Rod: that’s the external API though
+
+Michael: 7-8 patches/week? if we have to upgrade it will be extra work + delay for us
+
+James: if we’re sitll looking at LTS in early-mid oct, it’s going to give us a month to prove out v8 4.5
+
+Domenic: we’ve been proving out 4.5 for 12 weeks
+
+Rod: we’re talking node here, though we’d have google support for an extra month. my concern is: we need v4 out now, latest by monday, this is a quick change and there’s potential for breakage
+
+James: we decided before that we weren’t going to make such a big change so quickly before a release. i agree with rod, but such a big change makes me nervous — making sure that nan et al works with 4.5 is a concern
+
+Jeremiah: we’re not going to be the ones to find the flaws in 4.5; want clarification on nan major/minor/patch?
+
+Rod: minor
+
+Domenic: should require no changes
+
+Rod: benjamin (kkoopa) is on the positive side of this, he wants to see us move to 4.5, and is willing to put in the work to do this
+
+Trevor: not that it matters much, but node has taken a hit from v8 in terms of perf recently, 4.5 has some improvements, fedor wrote an easily backportable patch as well, there are perf advantages
+
+James: it makes me nervous that we’ll have enough time to test things on the node side before LTS — if we’re comfortable saying we have a plan that we think exercises this before going LTS, I’m more ok
+
+Jeremiah: technically we have over a month
+
+Rod: vote
+
+who is leaning sticking to 4.4 
+
+James + michael + steven
+
+4.5:
+
+fedor, colin, jeremiah, brian, chris
+
+Rod: clarifying concerns
+
+Michael: share concerns with james, but also Z
+
+Rod: longer we have to support our own V8, the harder it is, and another 6 weeks of support would be great great
+
+James: I’m -0
+
+Rod: spending some time today testing some existing addons taht have upgraded to nan@2. if there’s breakage, that tells me nan’s not ready, and that should be taken into account
+
+Domenic: if nan’s not ready, we don’t upgrade
+
+Rod: heading for 4.5, but with final go/no-go coming from nan testing; where are you at on this bert?
+
+Bert: I am happy to upgrade if you land it and nothing changes — which sounds like it might be the case (sans deprecation warnings)
+
+Rod: want ben’s opinion, but there may be no chance of that?
+
+Bert: it seems silly to go with a version that is almost already out of support, but OTOH, on the scale of LTS lifetime, 6 weeks is not really significant
+
+I wouldn’t worry too much about actual bugs in v8, about as likely in 4.5 as in 4.4; LTS is not about “no bugs”, it’s about “We support it”
+
+Rod: we want a **solid** release, though
+
+Bert: the LTS will also have a beta for a while, yes?
+
+Rod: the beta period for LTS is the stable line
+
+James: first LTS will have a beta of a little over a month, in the future 6 months
+
+Bert: realistically a month is a longer beta than we’ve ever had before
+
+Rod: 0.12 had a beta of 2 years
+
+{zing} :trollface:
+
+Bert: a beta with a lot of api changes, which is explicitly what we’re not going to do
+
+Bert: we need to move on
+
+Jeremiah: 4.5 brings arrow functions and that will make many people very happy
+
+Rod: it’s a good sales pitch!
+
+Rod: I’ll make the call.
+
+### Node.js v4 Release Timeline [#2522](https://github.com/nodejs/node/issues/2522)
+
+Rod: status update: v4 was to get out by Thurs, slipping on that, monday is the release date, cannot afford to slip any further
+
+Jeremiah: what’s actually slipping other than mdb?
+
+Rod: we’re not going to get mdb into v4, encourage before LTS, but that’s the best we can do, child process argument type checking where are we at on that?
+
+Trevor: it’s not ready
+
+James: working on that PR right now
+
+Rod: great, that feels like a fairly light one, process.send is the other one; ben’s on holiday, where are we at with that pr of his
+
+Jeremiah: multiple people have soft signed off on it
+
+Colin: weren’t there some strange ci failures with it?
+
+Rod: do not know, does someone want to put their hand up for that?
+
+Trevor: what’s the PR number?
+
+Jeremiah: #2620
+
+Jeremiah: Trevor +1’d it
+
+Jeremiah: OH! that’s the one with the weird test failures we could not reproduce the breakage
+
+Rod: this seems like it can be run again and it won’t show flaky tests: maybe we should just re-run it
+
+Trevor: that really sucks when you’re trying to land 3 tests
+
+Rod: test runner should auto-rerun to make sure
+
+Trevor: oh, gotcha
+
+Rod: that’d be really quick for flaky tests
+
+Trevor: I’ve already reviewed and LGTM’d it, I’ll look at running it through the land-ci job
+
+James: looked at it earlier today, nothing concerning stood out 
+
+Rod: no RC’s are out! that’s a problem! we’ve renamed the executable. I wanted to have a period of time where folks could download (with a working node-gyp) — we need this period of time. I’ve been working on that, some bits and pieces to get things to the right place on the server. first build had a broken OS X installer. there are a few yaks yet to shave, so that’s why we can’t get this out by thursday
+
+Rod: steven: could you confirm that 3.x has INTL enabled?
+
+Steven: will look into, take as action item (confirmed!)
+
+Rod: not going to tick that off till we confirm, but I _think_ that one’s done
+
+Rod: how’s everyone with the timeline? rcs ASAP + release on monday
+
+James: sounds reasonable, yes. will take as much time as possible on monday. several of us will be at nodeconf, so that complicates
+
+Rod: I’m using monday in airquotes, it’ll be tuesday for me. other thing: smoke testing, citgm, I’ve been using it, and there are a lot of weird failures, after v4 we’re going to have to switch modes to make the ecosystem happy with it
+
+Rod: let’s move ahead with that plan; nodeconf.eu is going to take up a lot of time for a lot of folk. congrats to everyone that contributed to new website, it seems really smooth
+
+### Inspecting Node.js with Chrome DevTools [#2546](https://github.com/nodejs/node/issues/2546)
+
+Rod: opened by member of v8 team, extracting debugger code from blink and making it so all embedded v8 projects can use it
+
+Trevor: gist is: devtools team is considering pulling inspector out of blink into its own project so we could consume it; domenic can correct me wherever I’m wrong here,
+
+Domenic: “making node work the same as android” able to point chrome dev tools at node processes to debug ‘em
+
+???: only works with chrome
+
+Trevor: OTW API we consume have remained fairly stable, even if the API does change, chrome dev tools is capable of pulling in a previous version, making sure it’s possible to use with LTS releases
+
+OTW wire is generic, consumable by anyone, chrome dev tools is a key consumer, but anyone can consume (new consoles can compete!)
+
+cons:
+
+APIs going to need to be tightly integrated — needs to know about all async events
+  add conditionals to e.g. nextTick + timers
+
+Domenic: add something to MakeCallback?
+
+Trevor: we have to add it to that + on the way back in
+
+Domenic: this is for async stack traces
+
+Trevor: we don’t have to have it
+
+Bert: that’s awesome, because we have to grow a single entry point (opposite MakeCallback)
+
+Trevor: not going touch nextTick/timers, though — need to wrap each (because those APIs don’t roundtrip to C++ for each callback)
+
+Bert: we don’t have to do that immediately though, but eventually it’d be a good idea
+
+Domenic: could also move to microtask for nexttick — integrating with domains sounds hard, then we get those events for us
+
+Trevor: would you be able to do unhandledRejections?
+
+Domenic: we already have this for promises
+
+Rod: if we could use this as a good justification for removing domains, that’d be awesome
+
+Trevor: next point is pro and con: importantly, we’d have to support websockets natively in node
+
+Jeremiah: we could just keep ‘em private
+
+Trevor: that would just anger people
+
+Domenic: you could bundle them and hide them while you’re not clear on the api, iterate and expose later
+
+Rod: that’s a good point
+
+Trevor: the interesting flip to this: they need to be running off the main thread, in a debugger thread — it can all be written in C++
+
+mscdex: any way to avoid websockets?
+
+Trevor: no
+
+Bert: is the protocol really that complicated? I don’t think so — especially sans full HTTP and WSS — just websockets though is probably not difficult
+
+Trevor: necessary because it’s the protocol that chrome dev tools uses
+
+Rod: decision points: are we being asked to get on board?
+
+Trevor: them removing the inspector from blink depends on whether we’ll use it if they do it.
+
+Rod: debugging in node sucks, we are shipping with substandard debugging in v4, we don’t have the contributors + collaborators to make this better, so if we can lean on v8 to do this, I’m +1
+
+debugging is important enough to override “small core”
+
+Bert: we’re not adding the full inspector, _just_ the protocol
+
+Trevor: wasn’t completely clear on how much API we’d need to implement
+
+Domenic: we should get clarification on this
+
+Trevor: if we can implement this in segments — if we’re all +1 on this, we need to create a new isolate, but …
+
+Domenic: would the workers pr solve this?
+
+Trevor: probably overkill. I’m +1 on the debugger
+
+Bert: I propose we don’t vote
+
+{broad assent}
+
+Rod: trevor + domenic: you’ve got enough input
+
+Domenic: only worry is finding someone to devote some of their daytime hours to implement websockets
+
+Rod: nodesource could contribute, related to our interests
+
+Trevor: even if we don’t say yes today, taking inspector out of blink is a complicated process and will take time
+
+Rod: anything else?
+
+### Next Meeting
+
+September 9th

--- a/meetings/2015-09-16.md
+++ b/meetings/2015-09-16.md
@@ -1,0 +1,116 @@
+# Node Foundation TSC Meeting 2015-09-16
+
+## Links
+
+* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-09-16
+* **GitHub Issue**: https://github.com/nodejs/node/issues/2898
+* **Minutes Google Doc**: https://docs.google.com/document/d/1RCR2pGOc2d80NNusaX5DZaktWvHEsDUqfEZP-tvexBk
+* _Previous Minutes Google Doc: <https://docs.google.com/document/d/1rXBdtsD9PJTExNXgzNZ9bez9oOjW45kLPjun4zdt0dY>_
+
+## Present
+
+* Rod Vagg (TSC)
+* Brian White (TSC)
+* Steven R Loomis
+* Fedor Indutny (TSC)
+* Bert Belder (TSC)
+* Colin Ihrig (TSC)
+* Trevor Norris (TSC)
+* Shigeki Ohtsu (TSC)
+* Chris Dickinson (TSC)
+* Jeremiah Senkpiel (TSC)
+* Ben Noordhuis (TSC)
+* Alexis Campailla (TSC)
+* Domenic Denicola
+* Michael Dawson
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests in the nodejs org prior to meeting.
+
+### nodejs/node-v0.x-archive
+
+* Deprecate Array#values() in 0.12.x [#25877](https://github.com/nodejs/node-v0.x-archive/issues/25877)
+* Deprecate smalloc in v0.12 [#25784](https://github.com/nodejs/node-v0.x-archive/issues/25784)
+
+### nodejs/node
+
+* Inspecting Node.js with Chrome DevTools [#2546](https://github.com/nodejs/node/issues/2546)
+* util: Remove p, has been deprecated for years [#2529](https://github.com/nodejs/node/pull/2529)
+
+## Minutes
+
+Due to IBM’s acquisition of StrongLoop, IBM is over the TSC 25% company limit rule. Michael Dawson and Steven Loomis have stepped down from TSC, but they are here as observers.
+
+### Standup
+
+* Rod Vagg: Released 4.0.0, also 3.3.1 maintenance release. Getting the build system ready for building/publishing 0.10 and 0.12 binaries.
+* Brian White: not much, triaging issues and PRs, some work on dns parser
+* Steven R Loomis: tsc resignation for IBM/SL merge, some issue triage, working on a more robust download for ICU (ICU server was overloaded, fixed to ICU again redirects to sourceforge, discussed longer term discussions) 
+* Fedor Indutny: v8’s ArrayBuffer fixes, reviewing PRs, fixing issues
+* Bert Belder: very few reviews/issue comments. Some libuv work on rwlocks.
+* Colin Ihrig: not much, some issue tracker work
+* Trevor Norris: Trying to make things (including Buffers) faster, some issue/PR review
+* Shigeki Ohtsu: Just a few reviews of issues.
+* Chris Dickinson: Working on shoving static npm analysis data into a database, slowly    
+* Jeremiah Senkpiel: NodeConf.eu, issues and PRs, 4.1.0 release
+* Ben Noordhuis: only PR review and responding to bug reports, a patch or two upstreamed to v8
+* Alexis Campailla: ARM cross-compile for CI. Misc fixes for VS 2015 / Win10
+* Domenic Denicola: some issue and PR review, talking with v8 team
+* Michael Dawson: landed the build updated for AIX, also updating the tests for AIX where necessary. Looking into PPC failures. Working on getting us hooked into v8 security notifications.
+
+### Previous meeting’s agenda
+
+* Jenkins merge jobs always overwrites PR-URL and Reviewed-By [#179](https://github.com/nodejs/build/issues/179)
+* doc: update COLLABORATOR_GUIDE [#2638](https://github.com/nodejs/node/pull/2638)
+* deps: update v8 to 4.5.103.30 [#2632](https://github.com/nodejs/node/pull/2632)
+* Node.js v4 Release Timeline [#2522](https://github.com/nodejs/node/issues/2522)
+* Inspecting Node.js with Chrome DevTools [#2546](https://github.com/nodejs/node/issues/2546)
+
+### Deprecate Array#values() in 0.12.x [#25877](https://github.com/nodejs/node-v0.x-archive/issues/25877)
+
+### Deprecate smalloc in v0.12 [#25784](https://github.com/nodejs/node-v0.x-archive/issues/25784)
+
+Jeremiah: Are these things that we think we can do? Should we go ahead with that? Is it a good idea to deprecate these things?
+
+Ben: How are we going to deprecate? Literal `util.deprecate`?
+
+Jeremiah: Probably?
+
+Trevor: They’re already floating a patch
+
+Rod: I’m fine with deprecating smalloc
+
+Trevor: Is there a deprecation cycle between LTS? I’m not sure how this would work? (i.e., if we deprecate now, LTS -> LTS upgraders will not see a deprecation warning.)
+
+Rod: Maybe punt to LTS WG? It could be quite a lot — it could be that we decide between stable versions to remove things (or we’re forced to), do we backport the deprecation to LTS?
+
+Jeremiah: I think it should be only for things we’re _forced_ to remove 
+
+Action: Punt to LTS WG
+
+### Inspecting Node.js with Chrome DevTools [#2546](https://github.com/nodejs/node/issues/2546)
+
+Trevor: Have an 80% understanding of the work needed: WebSocket support in core (though not necessarily exposed publicly), API injection points. Are we ok with including web sockets support one way or another?
+
+Rod, Domenic, others: +1
+
+### util: Remove p, has been deprecated for years [#2529](https://github.com/nodejs/node/pull/2529)
+
+Discussion of Buffer “raw{s,}” encoding as well — undocumented, deprecated, inconsistently implemented in core.
+
+Action: Remove util.p (Jeremiah to respond.)
+
+Bert: Perhaps we should bulk remove?
+
+Rod: util.p is relatively trivial, has a deprecation warning, etc.
+
+Jeremiah: Brought this up because these things have been deprecated forever. util.exec has been deprecated for a while, as well.
+
+Trevor: raw/raws are deprecated in name only, no warnings, but C++ layer does not know about them (falls back to utf8) — maybe should be removed as a bugfix, because it does not work consistently.
+
+Action: Chris to list “least used stuff” (with apologies for how longs its taken!)
+
+### Next Meeting
+
+September 23

--- a/meetings/2015-09-30.md
+++ b/meetings/2015-09-30.md
@@ -1,0 +1,161 @@
+# Node Foundation TSC Meeting 2015-09-30
+
+## Links
+
+* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-09-30
+* **GitHub Issue**: https://github.com/nodejs/node/issues/3126
+* **Minutes Google Doc**: https://docs.google.com/document/d/1RkLAWTIrhD3BTB2rs9_FahWI0C7lt9F8xnQXaueJPIE
+* _Previous Minutes Google Doc: <https://docs.google.com/document/d/1RCR2pGOc2d80NNusaX5DZaktWvHEsDUqfEZP-tvexBk>_
+
+## Present
+
+* Rod Vagg (TSC)
+* Brian White (TSC)
+* Chris Dickinson (TSC)
+* James Snell (TSC)
+* Michael Dawson
+* Ben Noordhuis (TSC)
+* Steven R Loomis
+* Bert Belder (TSC)
+* Alexis Campailla (TSC)
+* Domenic Denicola
+* Seth Thompson
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests in the nodejs org prior to meeting.
+
+### nodejs/node
+
+* Discussion: LTS & v5 release planning [#3000](https://github.com/nodejs/node/issues/3000)
+* Inspecting Node.js with Chrome DevTools [#2546](https://github.com/nodejs/node/issues/2546)
+
+### nodejs/TSC
+
+* Umbrella Program [#2](https://github.com/nodejs/TSC/pull/2)
+
+## Minutes
+
+### Standup
+
+* Rod Vagg (TSC) - Lots! Pass.
+* Brian White (TSC) - DNS PR (querying NSS modules like mDNS works now, continuing work on other getnameinfo/getaddrinfo compat issues)
+* Chris Dickinson (TSC) - Static Analysis
+* James Snell (TSC) - Review of the HTTP module, going in depth with spec compliance 
+* Michael Dawson - AIX, contributing changes from IBM repos, node-gyp, all related to getting native modules working on AIX, submitted PR to core, benchmarking — bare metal machine for benchmarking group, backporting test fix to 0.12, FIPS-compat work on the test suite, getting hooked into v8 security reporting
+* Ben Noordhuis (TSC) - Review PRs, bug reports, fixed 1-2 bugs, sent a few patches upstream to V8 and gyp, fixed a few bugs in node-gyp.
+* Steven R Loomis - Review PRs, bug reports. Looking into alternatives to packaging full ICU data. Might be able to `npm install` ICU data.
+* Bert Belder (TSC) - 
+* Alexis Campailla (TSC) - working on Node-serialport on Windows in Jenkins, looking into native module build service
+* Domenic Denicola - v8-extras are starting to appear in Chrome, maybe use them in Node for startup performance. 
+
+### Review of previous meeting
+
+* Deprecate Array#values() in 0.12.x [#25877](https://github.com/nodejs/node-v0.x-archive/issues/25877)
+* Deprecate smalloc in v0.12 [#25784](https://github.com/nodejs/node-v0.x-archive/issues/25784)
+* Inspecting Node.js with Chrome DevTools [#2546](https://github.com/nodejs/node/issues/2546)
+* util: Remove p, has been deprecated for years [#2529](https://github.com/nodejs/node/pull/2529)
+
+### Discussion: LTS & v5 release planning [#3000](https://github.com/nodejs/node/issues/3000)
+
+(Chris: apologies, I did a bad job here.)
+
+Ben: Plan is to ship the first LTS release with v8 4.5, not 4.6
+
+Rod: Yes.
+
+Ben: Is there a pressing reason to do so?
+
+Rod: LTS comes off the v4.x branch, we committed to not bump V8 in stable releases.
+
+Ben: It basically means that the first LTS release is going to ship with an outdated release.
+
+James: Yes, we knew this was a strong possibility.
+
+Michael: The model is that we give the community time to catch up. In the future that’s 6 months, so we’re never going to be on a supported version.
+
+Ben: V8 moves quickly. If we stick with 4.5, we’re going to have to manage a bigger delta between our copy and upstream.
+
+James: Yes, this was always going to be the case. We’re committed to supporting the V8 for 36 months.
+
+Ben: Yes, my point is that we could be starting with a smaller delta.
+
+Rod: One of the reasons we had this LTS delay on 4 is to shake out some of these concerns, like the buffer changes. Normally this shakeout will be 6 months, but this time it’s only been a month.
+
+Alexis: Is v5 going to be LTS also?
+
+Rod: We are having discussions about the overlap between v5 and v6, whether there’ll be a strict cutoff or some overlap. No decision yet. That’ll happen in April. It sounds like most folks are leaning towards
+making the two releases (v4 LTS + v5) independent — option 1 [here](https://github.com/nodejs/node/issues/3000#issuecomment-144026295).
+
+Ben: We still haven’t come up with a way to maintain V8 going forward.
+
+James: We do need a good process there, you are absolutely right about that.
+
+Rod: I vote for IBM to hire someone dedicated to this. (Laughter)
+
+Michael: I can’t promise that at this point.
+
+Rod: As the delta increases between versions this becomes more concerning.
+
+James: make sure this is on the LTS WG agenda for next week.
+
+Rod: We tried to tackle this once before, came up with job description but nothing concrete.
+
+Michael: We stopped short of telling the foundation that this is a position that we need to staff.
+
+James: I would agree. We’re at the point where bringing someone in at the foundation level is probably a good idea.
+
+Rod: Noted. OK. We’ve got resolution there.
+
+Michael: James: Make sure it’s on the LTS agenda for going back to the foundation for resources.
+
+Rod: LTS is meeting this Monday (issue 43 on the repo). There’s some discussion around codenames and how to expose LTS info. We’ve committed to first week of October for LTS releases, so timing is going to be a little awkward with 4.1.2 coming out monday. Version 5 will be shipping when we have a stable V8, presumably mid-to-late october (1-3 weeks with no stable release line.)
+
+Rod: We’ll be pulling in semver minor and patch changes, we’ll continue to have bugfix releases for version 4,
+
+### Inspecting Node.js with Chrome DevTools [#2546](https://github.com/nodejs/node/issues/2546)
+
+Rod: Trevor is lead on this, but isn’t present. Does anyone else have any updates?
+
+Ben: Wasn’t the last contentious issue putting WS in core? I think we agreed that if it’s not exposed to user-land, it's fine.
+
+Alexis: (discussion of another WS issue)
+
+Bert: we decided on this
+
+Ben: We agreed that if it was internal, non-exposed to core, 
+
+(Talk about native deps for WS, buffer-util can be )
+
+Ben: if this is a private dependency, we don’t need it to be fast, so we don’t necessarily need the native deps.
+
+Chris: (Hopped into discussion from minute-taking, hence the bad minutes)
+https://github.com/nodejs/node/pull/1202 - add mask/unmask
+https://github.com/nodejs/node/pull/1319 - add utf8 validator
+
+### Umbrella Program [#2](https://github.com/nodejs/TSC/pull/2)
+
+Ben: it’s basically a template for describing projects that are under the umbrella of the node foundation. It doesn’t look that controversial to me.
+
+Rod: it also doesn’t look that complete.
+
+Ben: Indeed. I suggest we discuss next week when mikeal is on the call. Seems like a rubber-stamp LGTM to me.
+
+Rod: We should think about what projects we want to introduce to the organization, including what happens to competition in the ecosystem when we pull in things (like build tools)
+Domenic: This is for things like libuv, yes?
+
+Rod: There are already npm projects knocking on the door. One such project is request. It has its own org right now, but could work under the auspices of the node foundation. However it exists in an ecosystem where there is competition — is it okay for us to bless one project over others? NAN is sort of in the same position, it _could_ have competition. Another example is the npm client possibly. If the foundation were in a position to take npm would we even want it?
+
+### renaming of “language groups” from iojs-\* to nodejs-\* [#2525](https://github.com/nodejs/node/issues/2525)
+
+Steven: Looking for buyoff on this.
+
+Ben: Seen the approach and it looks good.
+
+Rod: You should take this as “you have authority to move ahead”.
+
+Steven: Will do.
+
+### Next Meeting
+
+October 7th

--- a/meetings/2015-10-07.md
+++ b/meetings/2015-10-07.md
@@ -1,0 +1,102 @@
+# Node Foundation TSC Meeting 2015-10-07
+
+## Links
+
+* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-10-07
+* **GitHub Issue**: https://github.com/nodejs/node/issues/3126
+* **Minutes Google Doc**: https://docs.google.com/document/d/1LIrTCdTUjKtb_GGecrJ3Es0rPOpVdpkV5kefJ_p5FGU
+* _Previous Minutes Google Doc: <https://docs.google.com/document/d/1RkLAWTIrhD3BTB2rs9_FahWI0C7lt9F8xnQXaueJPIE>_
+
+## Present
+
+* Rod Vagg (TSC)
+* Brian White (TSC)
+* Steven Loomis (observer)
+* Trevor Norris (TSC)
+* Shigeki Ohtsu (TSC)
+* Ben Noordhuis (TSC)
+* Mikeal Rogers (observer)
+* Michael Dawson (observer)
+* Seth Thompson (observer)
+* Jeremiah Senkpiel (TSC)
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests in the nodejs org prior to meeting.
+
+### nodejs/node
+
+* WG: Considering a new HTTP WG [#3214](https://github.com/nodejs/node/issues/3214)
+* lib,test: deprecate _linklist [#3078](https://github.com/nodejs/node/pull/3078)
+* Discussion: LTS & v5 release planning [#3000](https://github.com/nodejs/node/issues/3000)
+* Compiling node v4.0.0 with OpenSSL 1.0.1 fails [#2783](https://github.com/nodejs/node/issues/2783)
+* Inspecting Node.js with Chrome DevTools [#2546](https://github.com/nodejs/node/issues/2546)
+
+### nodejs/TSC
+
+* Umbrella Program [#2](https://github.com/nodejs/TSC/pull/2)
+
+## Minutes
+
+### Standup
+
+* Rod Vagg: 4.1.2 release, security procedures surrounding that
+* Brian White: Working on javascript dns resolver, regular PR + Issue work.
+* Steven Loomis: Working on ICU 56 Release. TC 39 & emca spec work for Intl WG. Working on Intl build issues.
+* Trevor Norris: Focused on fixing async_wrap, writing tests and preparing for it to become more official
+* Shigeki Ohtsu: No works for node project, I spent all time to my internal works.
+* Ben Noordhuis: Nothing to report—the usual
+* Mikeal Rogers: Looking into stalled Wgs and seeing how to help out. Working on the umbrella program. Lots of conference things.
+* Michael Dawson: Added a benchmarking machine to the CI, working on some tests issues. Working on PPC for the CI.
+* Seth Thompson: Working on v8 4.7, scheduled soon
+* Jeremiah Senkpiel: vacation, some issue catch-up
+
+### Review of previous meeting
+
+* Discussion: LTS & v5 release planning [#3000](https://github.com/nodejs/node/issues/3000)
+* Inspecting Node.js with Chrome DevTools [#2546](https://github.com/nodejs/node/issues/2546)
+* Umbrella Program [#2](https://github.com/nodejs/TSC/pull/2)
+* renaming of “language groups” from iojs-\* to nodejs-\* [#2525](https://github.com/nodejs/node/issues/2525)
+
+
+### WG: Considering a new HTTP WG [#3214](https://github.com/nodejs/node/issues/3214)
+
+* Discussed the HTTP WG based on James’ comments @ https://github.com/nodejs/node/issues/3234#issuecomment-146293038
+* Generally positive, only concerns are regarding decision making power—TSC may not want to hand that off as this is not quite like Streams (in that few people grok the code!) and there are philosophical questions to be resolved about HTTP that the TSC should be involved in.
+
+### lib,test: deprecate _linklist [#3078](https://github.com/nodejs/node/pull/3078)
+
+* Userland modules exist that could be used instead
+* Ben suggested straight removal, Jeramiah raised the matter of process that we have committed to adding a warning before removal, so we could remove in v6 but probably shouldn’t in v5
+* No disagreement with moving forward for deprecation
+
+### Discussion: LTS & v5 release planning [#3000](https://github.com/nodejs/node/issues/3000)
+
+* Recap of the latest LTS meeting [LTS#43](https://github.com/nodejs/LTS/issues/43)
+* Aim to have LTS / v4.2.0 out tomorrow, backup date of Monday if we miss that. LTS starts then for v4.x, v5.x has to wait until V8 4.6 to be stable mid to late October.
+
+### Compiling node v4.0.0 with OpenSSL 1.0.1 fails [#2783](https://github.com/nodejs/node/issues/2783)
+
+* Shigeki, Ben: It would be quite hard to support 1.0.1 since we are using 1.0.2 APIs.
+
+* Discussion on the possible difficulty of using 1.0.2 on varied Linux distros
+
+* ubuntu wily (not released) seems to use 1.0.2 - work has been done to package.  1.0.2 is only in Wily - https://launchpad.net/ubuntu/+source/openssl/1.0.2d-0ubuntu1 - https://answers.launchpad.net/ubuntu/+source/openssl/+question/263725 - “My guess is that we will see openssl 1.0.2 from Ubuntu 15.10 onwards (or eventually only starting with 16.04)”
+
+* Concern that allowing 1.0.1 would result in a substandard (insecure?) & untested binary.
+
+* Some discussion about the fact that we don’t test building with shared / static dependencies
+
+* feedback to issue: No appetite to do the work from the TSC, maybe someone could do it but we wouldn’t support.
+
+### Inspecting Node.js with Chrome DevTools [#2546](https://github.com/nodejs/node/issues/2546)
+
+_skipped discussion_
+
+### Umbrella Program [#2](https://github.com/nodejs/TSC/pull/2)
+
+_skipped discussion_
+
+## Next Meeting
+
+October 14th, 2015

--- a/meetings/2015-10-14.md
+++ b/meetings/2015-10-14.md
@@ -1,0 +1,121 @@
+# Node Foundation TSC Meeting 2015-10-14
+
+## Links
+
+* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-10-14
+* **GitHub Issue**: https://github.com/nodejs/node/issues/3363
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1tVPxA4Y3n3dmICJFZN2vK93PXjCaUQ-eiN2mvt7zqbE>
+* _Previous Minutes Google Doc: <https://docs.google.com/document/d/1LIrTCdTUjKtb_GGecrJ3Es0rPOpVdpkV5kefJ_p5FGU>_
+
+## Present
+
+* Rod Vagg (TSC)
+* Domenic Denicola (observer)
+* Brian White (TSC)
+* Steven Loomis (observer)
+* James Snell (TSC)
+* Michael Dawson (observer)
+* Ben Noordhuis (TSC)
+* Jeremiah Senkpiel (TSC)
+* Trevor Norris (TSC)
+* Alexis Campailla (TSC)
+* Mikeal Rogers (observer)
+
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests in the nodejs org prior to meeting.
+
+### nodejs/node
+
+* V8 security reporting [#3348](https://github.com/nodejs/node/issues/3348)
+* doc: add information about Assert behavior and maintenance [#3330](https://github.com/nodejs/node/pull/3330)
+* WG: Considering a new HTTP WG [#3214](https://github.com/nodejs/node/issues/3214)
+* Discussion: LTS & v5 release planning [#3000](https://github.com/nodejs/node/issues/3000)
+* Compiling node v4.0.0 with OpenSSL 1.0.1 fails [#2783](https://github.com/nodejs/node/issues/2783)
+
+### nodejs/TSC
+
+* Umbrella Program [#2](https://github.com/nodejs/TSC/pull/2)
+
+
+## Minutes
+
+### Standup
+
+* Rod Vagg: Not quite as involved, took a bit of time off. Getting back up to speed on build
+* Domenic: Nothing this week
+* Brian: PRs & Issues
+* Steven: Worked on getting ICU 56.1 out and into v4.2.0 LTS, working on making the ICU [install better](https://github.com/nodejs/node-v0.x-archive/issues/8996#issuecomment-89411193). Also shepherding iojs-\* rename to nodejs-\* [#2525](https://github.com/nodejs/node/issues/2525)
+* James: Worked on the 4.2.0 and 4.2.1 releases. Working on the cgitm smoke-testing tool and http WG.
+* Michael: Worked on adding pLinux to the CI. Looking into running the tests on fips-compliant mode. Investigated some AIX issues.
+* Ben: PRs & Issues, doing some work on the debugger and memory bugs in libuv
+* Jeremiah: PRs & Issues, working on resolving the timers in beforeExit bug: https://github.com/nodejs/node/pull/2795
+* Trevor: Helped Jeremiah with the beforeExit thing, worked on PRs and Issues. Looking into AsyncWrap improvements.
+* Alexis: Looking into a native module build service. Worked on the Ci a bit.
+* Mikeal: Worked on the Umbrella Program proposal. Helping set up the Node.js Interactive conference.
+
+
+### Review of previous meeting
+
+* WG: Considering a new HTTP WG [#3214](https://github.com/nodejs/node/issues/3214)
+* lib,test: deprecate _linklist [#3078](https://github.com/nodejs/node/pull/3078)
+* Discussion: LTS & v5 release planning [#3000](https://github.com/nodejs/node/issues/3000)
+* Compiling node v4.0.0 with OpenSSL 1.0.1 fails [#2783](https://github.com/nodejs/node/issues/2783)
+* Inspecting Node.js with Chrome DevTools [#2546](https://github.com/nodejs/node/issues/2546)
+* Umbrella Program [#2](https://github.com/nodejs/TSC/pull/2)
+
+
+### V8 security reporting [#3348](https://github.com/nodejs/node/issues/3348)
+
+Michael: Proposal is to add one or more TSC members to the V8 security list. Not all issues will actually be V8 issues, but there shouldn’t be too many.
+
+* Concerns about too many issues
+
+Michael: Let’s go back and ask if a handfull means only 4-5 a week.
+
+Mikeal: Part of the Umbrella Program is to make a top-level security group that all security issues are funneled through. This group may not need to be TSC members.
+
+Ben: How would this group know an issue is relevant to us?
+
+Rod: We are talking about a Chromium security list, so we would probably need someone with enough knowledge to filter out which issues affect us.
+
+Mikeal: They would only be an initial filter.
+
+Rod: Some chromium issues will not be recognizable as V8 issues without prior understanding.
+
+Rod & others: Suggest to add Ben and Fedor to add to the Chromium/V8 security list.
+
+Discussion about the current Security repo / group, and current mailing lists
+
+### doc: add information about Assert behavior and maintenance [#3330](https://github.com/nodejs/node/pull/3330)
+
+Discussion about what assert is intended to do, and how we want to deal with additions and breaking changes in the future.
+
+Discussion about the stability index in the docs.
+
+Resolution: Lock the assert module. Possibly re-evaluate in the future. Close existing open PRs/issues against it after landing doc change.
+
+
+### WG: Considering a new HTTP WG [#3214](https://github.com/nodejs/node/issues/3214)
+
+James: having scheduling problems for an initial hangout but are getting a lot of interest from outside of core, including Doug Wilson and Eran Hammer.
+
+Discussion about the WG’s goals and how we should possibly think about handing over authority of the http module to this WG in the future. (At charter time or later on)
+
+### Discussion: LTS & v5 release planning [#3000](https://github.com/nodejs/node/issues/3000)
+
+James: recommended that we adopt a general rule that commits must go through at least one stable release before going into an LTS. Exceptions to this are security problems and changes that can’t go on to stable.
+
+### Compiling node v4.0.0 with OpenSSL 1.0.1 fails [#2783](https://github.com/nodejs/node/issues/2783)
+
+Conclusion was that this would be difficult and would result in a build that had some features disabled. The TSC is not going to undertake this work and would have reservations officially supporting a build that cripples some crypto features. However, pull requests for this work are welcome and would be considered.
+
+### Umbrella Program [#2](https://github.com/nodejs/TSC/pull/2)
+
+Mikeal sought a vote from the TSC to adopt the Project Lifecycle document and the Core TLP document.
+
+Resolution: there were no abstentions from voting and no disagreement amongst TSC members present, additional TSC members have registered their +1 on the PR so the motion is passed.
+
+## Next Meeting
+
+October 21st, 2015

--- a/meetings/2015-10-21.md
+++ b/meetings/2015-10-21.md
@@ -1,0 +1,214 @@
+# Node Foundation Core Technical Committee (CTC) Meeting 2015-10-21
+
+## Links
+
+* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-10-21
+* **GitHub Issue**: https://github.com/nodejs/node/issues/3464
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1ad8Xlza_B-iWexdlAd1Z5muzBy_HH88t_iSD31OUepA>
+* _Previous Minutes Google Doc: <https://docs.google.com/document/d/1tVPxA4Y3n3dmICJFZN2vK93PXjCaUQ-eiN2mvt7zqbE>_
+
+## Present
+
+* Rod Vagg (CTC)
+* Brian White (CTC)
+* Steven R. Loomis (observer)
+* James Snell (CTC)
+* Michael Dawson (observer)
+* Chris Dickinson (CTC)
+* Ben Noordhuis (CTC)
+* Jeremiah Senkpiel (CTC)
+* Trevor Norris (CTC)
+* Alexis Campailla (CTC)
+* Mikeal Rogers (observer)
+* Shigeki Ohtsu (CTC)
+* Seth Thompson (observer)
+* Bert Belder (CTC)
+* Fedor Indutny (CTC)
+## Agenda
+
+Extracted from **tsc-agenda** labelled issues and pull requests in the nodejs org prior to meeting.
+
+### nodejs/node
+
+* governance: add new collaborators #VIII [#3472](https://github.com/nodejs/node/issues/3472)
+* detect "full-icu" module [#3460](https://github.com/nodejs/node/issues/3460)
+* WG: Considering a new HTTP WG [#3214](https://github.com/nodejs/node/issues/3214)
+* node: deprecate public access to `process.binding` [#2768](https://github.com/nodejs/node/pull/2768)
+
+## Minutes
+
+### Review of previous meeting
+
+* V8 security reporting [#3348](https://github.com/nodejs/node/issues/3348)
+* doc: add information about Assert behavior and maintenance [#3330](https://github.com/nodejs/node/pull/3330)
+* WG: Considering a new HTTP WG [#3214](https://github.com/nodejs/node/issues/3214)
+* Discussion: LTS & v5 release planning [#3000](https://github.com/nodejs/node/issues/3000)
+* Compiling node v4.0.0 with OpenSSL 1.0.1 fails [#2783](https://github.com/nodejs/node/issues/2783)
+* Umbrella Program [#2](https://github.com/nodejs/TSC/pull/2)
+
+### Standup
+
+* Rod Vagg: index.tab and index.json updates (nodejs.org/dist/index.*) including an “lts” field, also made consistent directories for ancient Node tarballs with shasums files so nvm and other tools can simplify their access. v5 and other build yak shaving.
+* Brian White: usual triaging and PR and Issues commenting, not much else
+* Steven R. Loomis: Intl meeting, "full-icu" npm module [will be away until Nov 11 meeting, Unicode conf/Unicode-TC]
+* James Snell: Working on localization for the node runtime [#3413](https://github.com/nodejs/node/pull/3413)
+* Michael Dawson: Working through PPC and AIX PRs and issues, LTS WG discussions, Benchmarking WG, working with Stefan on agenda items for API WG meeting.
+* Chris Dickinson: was busy with vacation and conferences, but looking into the WhatWG Streams spec, next up is static analysis server
+* Ben Noordhuis: The usual. Looking into make the debugger better. The test suite is in bad shape
+* Jeremiah Senkpiel: issue and PR work — going back through the backlog now, helping with v5 release + npm@3
+* Trevor Norris: flurry of AsyncWrap PRs, trying to get it to a point where people could more reliably use it, it can’t be hidden forever.
+* Alexis Campailla: Sick, traveling; CI progress on flakiness, some progress on native module build service
+* Mikeal Rogers: Foundation resources for v5 release: PR folks wrote a blog post, expectation setting, make sure enterprises are still using LTS, if you’re a dev here’s what to be excited about, etc.
+* Shigeki Ohtsu: Worked semver-major fix to limit DH key size [#1831] (https://github.com/nodejs/node/pull/1831) and some works for root certs.
+* Seth Thompson: Security mailing list stuff went through this week, working on v8 side of things to create a new version of the octane benchmark, excited about the benchmarking WG
+* Bert Belder: nothing
+* Fedor Indutny: reviewing PRs, helped fix a beforeExit bug, fixing yet another V8’s ArrayBuffer issue
+  - Discussed the ArrayBuffer issue in detail
+
+* (Aside: Shigeki and Fedor were asked to look at [#3406](https://github.com/nodejs/node/issues/3406) - “p1/p2” issue )
+
+### governance: add new collaborators #VIII [#3472](https://github.com/nodejs/node/issues/3472)
+
+- Discussed onboarding.
+
+- Action: Jeremiah to schedule and run another onaboarding, Chris to tune in.
+
+### detect "full-icu" module [#3460](https://github.com/nodejs/node/issues/3460)
+
+Stems from conversation from the 0.X days about whether Node should ship other languages separately.
+
+This is a module published on npm as an alternative to shipping with Node proper.
+
+Whether node can detect a full-icu install in a special place (node_modules/full-icu, global/node_modules/full-icu)
+
+Nathan7 commented with a concern about coupling npm to node
+
+Currently have to start node with ICU_DATA_PATH=some/path/to/file
+
+Rod: Couple it to `execPath`
+
+James: globally installed could install into a well known global location
+
+Rod: Does this have to be done at startup?
+
+Stephen: Yes. V8 has to have the data available before starting.
+
+James: Happens right after parsing args
+
+Rod: Could use HOME?
+
+Stephen: Could use NODE_PATH?
+
+Rod: Trying to move away from NODE_PATH
+
+Ben: Might just bite the bullet and include ICU?
+
+Stephen: I would like that, but I am sympathetic to folks running on OpenWRT
+
+Ben: I can see that, but all this installing in special paths leaves a lot of margin for error.
+
+James: Full ICU will double the size of the Node binary. Hard pill to swallow.
+
+Rod: We could offer alternative downloads?
+
+Stephen: Two downloads would work as well. We could do this all from build infra.
+
+Bert: I would not be in favor of that. We end up with “oh my module doesn’t work” “oh you didn’t download the right flavor of Node”
+
+Jeremiah: It’s going to make it confusing no matter what
+
+... [I missed this]
+
+Chris: could we offer better error messages?
+
+Rod: it peeks through in a lot of places — the ICU object, strings, etc. Maybe best to leave to module authors? Include a process.versions.icu object?
+
+James: small-icu is the default build running locally — CI doesn’t run with ICU enabled?
+
+Trevor: even if small-icu is there, it means less data, but not less build time. I would like to see how that affects the raspberry pi’s build time.
+
+Ben: we could avoid rebuilding ICU on rasppis
+
+Stephen: or use a precompiled ICU
+
+Jeremiah: Assumes an internet connected machine
+
+Rod: If we go with small-icu we should make it available
+
+Ben: should we add it to the repo?
+
+Alexis: I think so, it’s causing problems
+
+[???]: It’s about 80mb
+
+Rod: How big is it?
+
+Stephen: The source size & binary size was comparable to Node.
+We could have a non-standard source checked in.
+
+Mikeal: we could use the large file storage stuff GH just added.
+Stephen: 25mb uncompressed, 130mb for source tree
+
+Mikeal: if we say “you need ICU to build”  we need to make it available
+
+Trevor: How’s this going to work with bouncing between branches?
+
+Alexis: What about keeping it as text?
+
+Ben:
+
+Steven: We have a 25mb compressed zip of source, that itself contains a 25mb compressed zip. We could strip that down — what would it take to delete the tests, etc — a subset
+
+Mikeal: so could we just install this 25mb file?
+
+Rod: This adds a dep on Git LFS
+
+Mikeal: Let’s try to solve one problem at a time — fix downloading, not making the default
+
+Rod: I’m happy with how the CI does it
+
+…
+
+Stephen: The first time you hit something ICU-based it loads it.
+
+Rod: I’m just wondering if this could be turned into a proper npm module.
+
+Stephen: I’m not sure — it looks pretty deeply enmeshed into V8
+
+Seth: I don’t have answers off the top of my head on that one, I responded on the thread; we don’t currently have a priority to mess
+around with localization. If there’s a design doc that proposes cleaning things up we’d be interested
+
+James: Resource bundle mechanism — [Note: didn’t get all of this] “using the same startup sequence as Intl.. so needs to be configured at start time” (https://github.com/nodejs/node/pull/3413 uses ICU’s resource bundle mechanism, which uses the same init path as the core data. ICU does not allow multiple initializations.
+
+Alexis: If the only reason we’re trying to package it is to use npm to install it, maybe we’re complicating this unnecessarily
+
+Rod: On the iojs side we decided not to go with ICU. It’s in core because it has to be initialized before v8 is started, my question is this something that could be changed upstream in v8? Ideally this should not be in core.
+
+Steven: It didn’t look like it could be split off easily.
+
+Chris: JS proxies
+
+Steven: Possible, but _very_ tricky
+
+[Moving conversation to GH]
+
+
+### WG: Considering a new HTTP WG [#3214](https://github.com/nodejs/node/issues/3214)
+
+HTTP WG first meeting is tomorrow at 1pm Pacific, nothing to discuss yet
+
+### node: deprecate public access to `process.binding` [#2768](https://github.com/nodejs/node/pull/2768)
+
+Lots of discussion, focused on `process.binding('natives')`. Summary: We should at least try to make it read-only first. Ben said he would follow up with a PR.
+
+### node: make listen address configurable [#3316](https://github.com/nodejs/node/pull/3316)
+
+Fedor: Ben suggested commandline argument to submit hostname and port. Fedor concerned about the amout of code required to parse and separate the two parts of the option. Would be better to have a separate argument for hostname.
+
+Discussion about usability vs simplicity of code.
+
+Quick vote on whether to move forward with the PR in its current form, no objections.
+
+## Next Meeting
+
+October 28th, 2015

--- a/meetings/io.js/2014-10-09.md
+++ b/meetings/io.js/2014-10-09.md
@@ -1,0 +1,61 @@
+- Contribution Policy was merged last week.
+
+- Concerns about https://github.com/node-forward/node/issues/2 have been brought
+  up, it effects almost every line and will make merges with Joyent
+  unnecessarily painful in the short term. The consensus was to put it on the
+  back burner.
+
+- It's a little difficult to work in the fork at the moment:
+  - It's hard to contextualize what to fix without having a release in mind
+  - We'll start doing source-only releases ASAP so that we can create a work
+    scope.
+  - Someone will be in charge of keeping their head around and driving each
+    release. This should probably rotate, Bert will take on the first one with
+    the goal of releasing before the end of the month.
+  - For now tagging will create a GitHub "release." Eventually the build infra
+    can attach binary installers to that GitHub release.
+  - It's hard to keep a list of issues that are being tackled from the backlog
+    in joyent's repo
+  - Bert will maintain a list of TODO checkbox items in a GitHub Issue for a
+    release the references the PRs and Issues in Joyent's repo. We'll also be on
+    the lookout for other tools that might make this easier.
+
+- The build stuff is coming up a lot and the discussion about how releases work
+  should include someone from the build project.
+
+- Invite whoever is leading the build effort (current @rvagg) to the TC meeting
+  to participate (non-voting).
+
+- Eventually we'll need a better support structure where community members can
+  triage issues and respond to all the incoming requests.
+  - @mikeal created a "community" group and a repo for larger community issues.
+    Once there is some momentum there we can bring problems like this to the
+    community but the repo we currently control write access to doesn't have all
+    of the issues in it so this can wait.
+  - @indutny suggested a bot that auto-responds. @isaacs thought an
+    autoresponder was a little inhuman. It was agreed that the best thing to do
+    is have a bot that comments on the issue *once a tag is added* that is
+    specific to that tag and run in concert with humans tagging issues.
+  - @piscisaureus really wants to find a way for him to tell if someone already
+    looked at an issue so that him, trevor, ben, and fedor don't independently
+    look at every issue.
+
+- @indutny wants to get a newer v8 in. this work is slated to be finished for
+  the first release.
+  - @trevnorris mentioned that there are some new features in v8 that we may
+    want to use to replace certain parts of node down the road.
+
+- @trevnorris and @isaacs want a "commit script" that people can run which
+  automates a lot of the manual cleanliness we currently require for all commits.
+  v8 has as simliar one. this will be written in javascript by @isaacs and
+  @trevnorris .
+
+- When pulling in joyent/node commits we should use no-fast-forward commits.
+
+- If people want to talk to the TC in a more "chatty" way we should use the
+  `#node-forward` IRC channel on freenode. We need to add logging.
+
+- The video of TC meetings doesn't include the chat so we need to be aware of
+  that when using it during the calls.
+
+Video of the call is https://www.youtube.com/watch?v=fNW_tu2QnpA

--- a/meetings/io.js/2014-10-15.md
+++ b/meetings/io.js/2014-10-15.md
@@ -1,0 +1,44 @@
+# node-forward TC Meeting 2014-10-15
+
+## Agenda
+
+* Openssl upgrade / openssl 1.0.1j, disabling SSL3 support
+* Status of the build system & release automation
+* https://github.com/node-forward/node/pull/14 - refine TC percentage rules - CONTRIBUTING.md
+* Items preventing node-forward from releasing v0.12.
+* Node Forward release cycle/schedule.
+* (Maybe discuss v8 3.29 in node-forward vs 3.28 in joyent/node, and merging them? ...just a suggestion) 
+* Performance situation
+* Node Forward website, non-core stuff, help repo.
+
+## Links
+
+* **Google Hangouts Video**: https://www.youtube.com/watch?v=aRBuu2m5xbI
+* **Original Minutes Google Doc**: https://docs.google.com/a/vagg.org/document/d/18l01PO2Rb3OZXWMcIkZ_sU4f1JKP2LKOwjuiENkg37M
+
+## Minutes
+
+### Present
+
+* Rod Vagg (facilitator, build representative)
+* Mikeal Rogers (facilitator)
+* Ben Noordhuis (TC)
+* Bert Belder (TC)
+* Fedor Indutny (TC)
+* Trevor Norris (TC)
+
+### Discussion
+
+* Fedor: **OpenSSL upgrade to 1.0.1j done in a branch**, build bots reporting OK, ready to merge. SSLv3 disabled completely in joyent/node 0.12 because the protocol is broken--attack comes from downgrade request from TLS to SSLv3. 0.10 has a runtime flag to enable it via process arguments (`--enable-ssl3`).
+* Rod (representing the build group): tried Jenkins and BuildBot. Neither are great, but right now they’re working on getting something to work now, although eventually they’d like a great build system. There are build bots running for most platforms right now, except OS X (but there’s commitment from voxer to sponsor machines). Building branches works, but PRs doesn’t. This week some basic useful stuff should be available.
+  - https://github.com/graydon/bors - rust
+  - Benchmarks? Make a CI target just for benchmarks so we can track it over time. Not run on every PR, perhaps manually triggered, perhaps time triggered. http-simple? Fedor: large nightly benchmarks would be nice. Start with Linux, a single consistent box running the suite (doing a release too).
+* **Refine TC percentage**: pull node-forward/node#14. TC is short two people without Joyent & is small. 2 of 6 people are from Strongloop. #14 allows changing to 33% to allow the current TC to not be in violation for the time being and then change it back to 20% when we can. Consensus has been relatively easy, no votes have been needed thus far so there isn’t much concern.
+* **Release cycle**: time based releases? node-forward discussion have strong consensus for a desire to move to semver and also a quicker release cycle.
+ - **General agreement on semver**, minor releases backward-compatible, major releases can break.
+  - Discussion on **native API compatibility**, NAN or NAN-like or something more brave like having ABI compatibility. Ben: “You can’t forecast the future, the abstraction will break”.
+  - **Supporting old versions**: deal with it when the project has “prior releases”. Defer discussion on exactly the model until the project is ready to make proper releases. Move discussion to GitHub.
+* **V8 3.29**, Fedor: joyent/node has 3.28, node-forward/node has 3.29. Trevor & Fedor agreed to put 3.29 in joyent/node pending agreement with TJ.
+* **node-forward website**, Mikeal: there is a website, http://nodeforward.org/ 
+  - Forrest suggests a help repo to replace what the mailing list works, he has offered to help support that.
+

--- a/meetings/io.js/2014-10-29.md
+++ b/meetings/io.js/2014-10-29.md
@@ -1,0 +1,33 @@
+* Update on Build
+ * @rvagg is working on getting the builds consistently green
+   before moving on to more complicated things.
+* @issacs brought up the Joyent Advisory board
+ * Some confusion out there about Node Forward vs. Advisory Board
+ * @mikeal updated the messaging on the website to be clearer
+ * The website has clearer calls to action for the community
+* Libuv move
+ * The libuv contributors want to move to the libuv org.
+ * @mikeal will email @indutny and other libuv contributors to ask them
+   to log an issue about this on their repo for transparency and so that
+   this is not a surprise to Joyent
+* Update on "release buckets"
+ * doesn't make sense while we're private, we'll wait until it is public again
+* `node-forward/node` going public
+ * when we made the repo private it was messaged as only being for "four weeks"
+ * "four weeks" is up on November 8th
+ * someone on the Advisory Board needs to remind Joyent of this in the
+   next advisory board meeting so they aren't suprised by it even though
+   it was communicated to them when it was first made public.
+ * @mikeal will work on the messaging in the README to make it clear this is
+   a "soft" fork and not a "hard" fork.
+ * ramifications of going public will be discussed in next week's TC meeting as
+   well
+* @mikeal proposed a change in TC meeting process
+ * it's impossible to schedule all the timezones involved in every meeting
+ * every Monday create a "Weekly TC Agenda" Issue people can contribute to
+ * the TC members who care about that Agenda will state they want to be in the
+   meeting
+ * @mikeal will work to schedule the TC members who care for a hangout
+* people are using and liking gitter
+ * we'll consider moving from IRC to gitter once the repo is public again
+ * yes, gitter has IRC integration (you can login to gitter from an IRC client)

--- a/meetings/io.js/2014-12-10.md
+++ b/meetings/io.js/2014-12-10.md
@@ -1,0 +1,139 @@
+# io.js TC Meeting 2014-12-10
+
+## Agenda
+
+Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+
+* @chrisdickinson nomination to TC https://github.com/nodejs/io.js/issues/51
+* Move readable-stream to iojs org and make authoritative source for io.js to pull _from_ https://github.com/nodejs/io.js/issues/55
+* Deprecate domains https://github.com/nodejs/io.js/issues/66
+* Decide how to go forward with caine https://github.com/nodejs/io.js/issues/117
+*  Is it io.js, IO.js, or something else? https://github.com/nodejs/io.js/issues/118
+* Build automation update
+* extending options from a prototype
+https://github.com/nodejs/io.js/issues/62
+* Separate I/O tests from simple, so simple tests can be run in parallel
+* Statement / stance from TC on exposing a Promises API https://github.com/nodejs/io.js/issues/11
+
+## Links
+
+* **Google Hangouts Video**: https://www.youtube.com/watch?v=otE4IRMVUMo
+* **GitHub Issue**: https://github.com/nodejs/io.js/issues/112
+* **Original Minutes Google Doc**: https://www.youtube.com/watch?v=otE4IRMVUMo
+
+## Minutes
+
+### Present
+
+* Rod Vagg (facilitator, build representative)
+* Ben Noordhuis (TC)
+* Bert Belder (TC)
+* Chris Dickinson (nominee to TC)
+* Fedor Indutny (TC)
+* Trevor Norris (TC)
+
+
+### @chrisdickinson nomination to TC
+
+https://github.com/nodejs/io.js/issues/51 
+
+**Unanimous decision to add Chris to TC**
+
+### Move readable-stream to iojs org and make authoritative source for io.js to pull _from_
+
+https://github.com/nodejs/io.js/issues/55 
+
+* Chris expressed concerns on doing this, but a -0 for now, give it a go and see how it works
+* Discussed the potential difference with joyent/node
+* Trevor discussed concerns about the tight coupling of streams to core
+* Rod talked about organisational and community concerns
+* No -1’s on moving the source of authoritative code and moving readable-stream into iojs
+* Need to experiment with the flow: code, issues, docs, etc.
+* **Consensus reached on moving readable-stream to iojs and flipping the authoritative code and doc flow**
+* Chris and Rod to work on the process in GitHub
+
+### Deprecate domains
+
+https://github.com/nodejs/io.js/issues/66 
+
+* Trevor: domains are horrible but we don’t have a good alternative yet
+* Ben: +1 on removal but don’t have a good story on what to tell people to use
+* Bert: -1, would rather clean up docs to be honest about how it doesn’t do what it was hoped to
+* Trevor: domains inhibit progress because of their invasiveness
+* Discussed how to document concerns etc.
+* Discussed https://github.com/nodejs/io.js/pull/15 which adjusts the domain.run() API
+* Agreed:
+  - Accept PR #15
+  - **Document that domains are on the way out: soft deprecation** (no util.deprecate())
+
+### Decide how to go forward with Caine (bot)
+
+https://github.com/nodejs/io.js/issues/117 
+
+* Fedor talked about _what_ caine is and _why_ it exists: too many emails from the repo, want to set up a system where relevant people are pulled into particular issues rather than having to subscribe to the repo for all notifications
+* Chris: primary concern with having an automated bot is the incoming experience for users (like having a join bot on IRC)
+* Discussed notifications / labels / etc.
+* Bert discussed using a “new” label for triage--automatically add to incoming issues and remove when the issues have been looked at / dealt with by a contributor.
+* Trevor voted to **move the discussion to GitHub**
+
+
+### Is it io.js, IO.js, or something else?
+
+https://github.com/nodejs/io.js/issues/118 
+
+* Ben: lowercase is “objectively superior” (j/k)
+* No disagreements, the name is “io.js”
+* Ben: binary name suggestion “iojs” with symlink to “node”, lots of discussion in https://github.com/nodejs/io.js/issues/43
+* **No disagreements, binary name will be “iojs”**
+* Ben: how do we handle it on Windows? .bat file (problems with arg forwarding), small .exe
+* Agreed to open a new issue to discuss Windows compat (Ben)
+
+### Build automation update
+
+Rod gave a summary of build project status:
+ - Containerized build system is being improved by an active team in the https://github.com/nodejs/build-containers repo, on target to enable automatic PR tests and status reports back to GitHub (will likely just be Linux distros for the forseeable future)
+ - Next step is to enable committers to be able to trigger full builds across the build cluster
+ - Aiming for more automation for a mid-January release, have concerns about Windows and OSX signing and the need for signing keys and how complex they are.
+ - Chris Lea is working towards nightly builds for .deb-based systems (RHEL / Fedora based systems could come later but the assumption is that people running those systems are _less_ likely to want nightlies)
+ - https://github.com/nodejs/io.js/issues/13 is an ARM build failure that still needs attention to have ARM part of the build mix and not constantly fail (see https://jenkins-node-forward.nodesource.com for some ARM failures)
+
+
+### Extending options from a prototype
+
+https://github.com/nodejs/io.js/issues/62 
+
+* Chris is asking for input
+* Ben: we’re currently only looking at the object’s own properties, and ignoring properties on the prototype.
+* Fedor: in general there’s no reason to explicitly check whether properties are on the object or on the prototype chain.
+* Ben: **continue in the issue tracker**
+* Bert: be consistent. Slightly agree with fedor.
+
+### Separate I/O tests from simple, so simple tests can be run in parallel
+
+* Fedor: discussed the possibility of moving out net and possibly fs tests so the rest can be parallelized. There may be problems with many of the fs tests because they use fixtures.
+* Fedor: **agreed to try it out**
+* Bert: preference for the “tests” target to run the current test target
+
+### Statement / stance from TC on exposing a Promises API
+
+https://github.com/nodejs/io.js/issues/11 
+
+* Rod: can we come up with some kind of statement from the TC regarding the possibility of adding a Promises API to core, even if it’s vague
+* Bert: there’s a convergence of functionality around Promises that are making them more useful in conjunction with other ES6/ES7 features, TC should be _open_ to adding a Promises API in the future
+* Trevor: would like to simplify the current API so that it’s easier to extend and add abstractions on the top
+* Ben: when simplifying, it would be good to have a target for how the simplification can be used, Promises could be one of those
+* Bert: It would be weird for Node to go its own path if the rest of the JS ecosystem were to go that way
+* Rod & Bert: suggested a statement along the lines of: **Promises doesn’t make sense right now, so it’s not going to happen in the short-term, but the TC is open to change as things evolve in ES6 and ES7 and practical issues are worked out, TC is open to  experimentation, a _callback API is unlikely to ever go away_**
+* Ben: a +0
+* Trevor: pending practical concerns
+* Fedor: a -0
+* Chris: +0
+
+
+### Working with nvm, nvmw and similar installation managers
+
+https://github.com/nodejs/io.js/issues/40 
+
+* Ben: suggested a dist.iojs.org for hosting binaries
+* Ben: suggested a release.txt
+* Rod: **leave it up to the build team to work out the mechanics of releases and release.txt and/or release.json and come back to TC for approval or adjustments prior to formal release** (i.e. no need to bikeshed on this here right now)

--- a/meetings/io.js/2014-12-17.md
+++ b/meetings/io.js/2014-12-17.md
@@ -1,0 +1,91 @@
+# io.js TC Meeting 2014-12-17
+
+## Links
+
+* **Google Hangouts Video**: https://www.youtube.com/watch?v=7s-VJLQEWXg
+* **GitHub Issue**: https://github.com/nodejs/io.js/issues/163
+* **Original Minutes Google Doc**: https://docs.google.com/document/d/1PoqGfxpfTFKv5GcKmhMM2siZpPjT9Ba-ooBi-ZbYNi0
+
+## Agenda
+
+Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+
+* Bundle tick processor with iojs #158 https://github.com/nodejs/io.js/issues/158
+* Release Cycle Proposal #168 https://github.com/nodejs/io.js/issues/168
+* Module search security #176 https://github.com/nodejs/io.js/pull/176 
+* Dealing with feature requests 
+
+## Review of last meeting
+
+* Move readable-stream to io.js and flip authoritative flow of code, docs and issues
+* Soft deprecation of domains, accept PR #15 as last feature addition
+* Caine, discussion continued on GitHub
+* Project name is “io.js”, binary name is “iojs”
+* Extending options from prototype, discussion continued on GitHub
+* Promises statement for issue #11
+* Working with nvm, etc.
+
+## Minutes
+
+### Present
+
+* Bert (TC)
+* Chris (TC)
+* Trevor (TC)
+* Isaac (TC)
+* Rod (build, facilitator)
+
+### Bundle tick processor with iojs #158 
+
+https://github.com/nodejs/io.js/issues/158
+
+* Bert: important because it’s tied to the version of V8, not practical to put it in npm because one is needed for each version
+* Isaac: this is minimal and shouldn’t set a standard for just adding more stuff to core (i.e. keep core minimal), so +1
+
++1 from Isaac, +1 from Bert, **no disagreement amongst group, consensus has been reached on bundling a tick processor with releases.**
+
+### Release Cycle Proposal #168 
+
+https://github.com/nodejs/io.js/issues/168
+
+* Bert & Isaac discussed how this feeds into the ability to have frequent releases. Discussed semver plays into this.
+* Rod: consensus seems to be around having stability, predictability, lead-time but more frequent releases.
+* **Bert: Move discussion to #168. Still premature to discuss here.**
+
+### Module search security #176
+
+https://github.com/nodejs/io.js/pull/176 
+
+* Limiting node_modules search path to $HOME as a top-level
+* Isaac ~ -1 on this because EACCES already happens when you don’t have permission
+* Isaac and Bert bikeshedded Windows C:\ writability and security on Windows. i.e. if someone can install code on a shared system above where a node application is running (e.g. C:\) then you could have untrusted code run by your application.
+* Isaac: this PR is only addressing projects running in the home directory.
+* Rod: module system is locked-down, TC needs to come to consensus that this is a _security_ issue and therefore warrants breaking it.
+* Chris: `useradd node_modules` is a situation this could be a problem
+* Isaac: not convinced this is a security problem, even the `useradd` situation requires root access on a system.
+* Bert: this is an academic issue, it may _feel_ wrong but that doesn’t mean it’s strictly a security issue.
+* Isaac: proposed the issue be closed as not a security issue.
+* **No consensus that this is a security issue. Move discussion back to GitHub, potentially close issue, potentially bringing discussion back here. Encourage users to bring examples of real problems.**
+
+
+### Dealing with feature requests
+
+* Bert: asking for discussion about what to do with feature requests that come up but aren’t clearly something that are wanted.
+* Bert: should we put a time limit on feature requests? Would like some guidelines for how to deal with these.
+* Chris: have already been putting a 4-6 day window before closing them. If there is no code then it’s easier to close. If there is code then there could be more discussion.
+* Isaac: this is a broader problem about the roadmap-setting process.
+* Rod & Isaac: It’s up to someone on TC (or elsewhere) to start coming up with a roadmap, or at least start the discussion.
+* **Agreed to start a GitHub discussion on roadmap and soliciting feedback from the community.**
+* Rod: in an open model, it’s up to TC and those with commit access to take the initiative to just close things, given enough warning and chance for discussion and better arguments.
+* Isaac: builtins (like Blog of FileReader) are TC39 / WhatWG groups out there that are doing this at the language & V8 level and we pull from there. It should be straightforward to close those issues.
+* Bert: the roadmap shouldn’t be about locking down the dev process and tightly limiting scope of what’s added.
+* **Agreed that feedback to all contributors (including TC), regarding closing issues: close issues that are instinctively bad and worth closing (close can be undone), anything potentially controversial can be flagged with a “will close” but give ~ 1 week for discussion, disagreement, lobbying etc.**
+
+
+### Logos
+
+* **Agreed that the release is the only _technical_ blocker from the TC’s perspective to a logo, so deferring discussion till then. Encourage interested parties from discussing this further on GitHub issue #37.**
+
+### Next meeting
+
+* Bert proposed 2014-12-30 as next meeting time

--- a/meetings/io.js/2014-12-30.md
+++ b/meetings/io.js/2014-12-30.md
@@ -1,0 +1,95 @@
+# io.js TC Meeting 2014-12-30
+
+## Links
+
+* **Google Hangouts Video**: http://www.youtube.com/watch?v=O60sOsesjOo
+* **GitHub Issue**: https://github.com/nodejs/io.js/issues/211
+* **Original Minutes Google Doc**: https://docs.google.com/document/d/1KLfX2MZQbVSIaD2lBVqOFK0Kap4uFz9cTGihnpTuvPE
+
+## Agenda
+
+Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+
+* sys: Remove after 3 years of deprecation #182 https://github.com/nodejs/io.js/pull/182
+* module: force require('process') to return a reference to process #206 https://github.com/nodejs/io.js/pull/206
+* File copyright policy #216 https://github.com/nodejs/io.js/pull/216
+* Rename v0.12 to v1.0.0 https://github.com/nodejs/io.js/issues/218
+* Merge strategy (v0.10 and joyent/node)
+
+## Minutes
+
+### Present
+
+* Rod (build, facilitator)
+* Ben (TC)
+* Bert (TC)
+* Chris (TC)
+* Fedor (TC)
+* Trevor (TC)
+
+### sys: Remove after 3 years of deprecation #182 
+
+https://github.com/nodejs/io.js/pull/182
+
+* Ben: what sort of strategy to take? Deprecated only in the docs but no warning. Looking for an official deprecation policy.
+* Bert: suggest we could properly deprecate but not a good case for removing it completely, Chris agreed
+* Fedor: suggested a policy that removal of deprecated features should be done where there is a maintenance overhead, but otherwise if there is little/no cost then "who cares"
+* Discussed a deprecation message on `require(‘sys’)`
+  * Ben: -0
+  * Fedor: +1
+  * Chris: +1
+  * Trevor: -0
+  * Bert: +1
+* No disagreement to adding a deprecation message, **ask initial PR submitter to change to just adding a message**
+
+### module: force require('process') to return a reference to process #206
+
+https://github.com/nodejs/io.js/pull/206
+
+* #157 has a long discussion on this: https://github.com/nodejs/io.js/issues/157
+* Chris: +1 on a PR adding this
+* Trevor: it just returns a global, no point
+* Bert: not the way that JS adds new features; discussed the new Intl addition to joyent/node, in favor of making more things requirable rather than adding new globals all the time
+* Tangential discussion on the Intl object being added in joyent/node
+* Collected votes:
+  * Bert: +0
+  * Ben: +0.5
+  * Trevor: -0
+  * Fedor: +1
+  * Chris: +1
+* **Ben to handle the merge / resolution**
+
+
+### File copyright policy #216
+
+https://github.com/nodejs/io.js/pull/216
+
+* Rod asked if there are any strong opinions about how to handle this
+* **Group agreed that Rod will take this issue and seek legal advice to find a way forward**
+
+### Rename v0.12 to v1.0.0
+
+https://github.com/nodejs/io.js/issues/218
+
+* Trevor: concerns about 1.0 vs 1.x branch naming with maintaining semver releases while also doing LTS, 1.x effectively becomes master until a 2.0 comes along.
+* Bert: -1
+* Ben: +1
+* Chris: +1
+* Fedor: +1
+* Trevor: 0
+
+Action: **Rename to "v1.x", Ben agreed to make the change**
+
+
+### Merge strategy (v0.10 and joyent/node)
+
+* _Much_ discussion about merge strategies, patches, branches, etc.
+* Agreed to merge regularly
+* **Bert agreed to monitor the situation and propose a merge strategy when the time is right**
+
+### Next meeting
+
+* Agreed to meet again on the 7th of January UTC
+* Agreed to have mini-stand-up at the beginning of each meeting
+
+

--- a/meetings/io.js/2015-01-07.md
+++ b/meetings/io.js/2015-01-07.md
@@ -1,0 +1,154 @@
+# io.js TC Meeting 2015-01-07
+
+## Links
+
+* **Google Hangouts Video**: http://www.youtube.com/watch?v=hWDSToC9EV8
+* **GitHub Issue**: https://github.com/nodejs/io.js/issues/230
+* **Original Minutes Google Doc**: https://docs.google.com/document/d/1j7Sdui5DqHE8GZHxuoAaoIQ4jlntacZI285OCfVa-Eo
+
+## Agenda
+
+Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+
+* Invite Colin Ihrig to the TC #223 https://github.com/nodejs/io.js/issues/223
+* File copyright policy #216 https://github.com/nodejs/io.js/issues/216
+* Doc: clarified & split up contribution docs #233 https://github.com/nodejs/io.js/pull/233
+* Governance: Add new Collaborators #234 https://github.com/nodejs/io.js/issues/234
+* deps: upgrade v8 to 3.31.74.1 #243 https://github.com/nodejs/io.js/pull/243
+* Build
+* Intl - defaults
+* Merge v0.10
+* npm upgrade _(did not get to this)_
+
+## Minutes
+
+### Present
+
+* Bert (TC)
+* Ben (TC)
+* Chris (TC)
+* Fedor (TC)
+* Isaac (TC)
+* Colin (for voting as addition to TC)
+* Mikeal
+* Rod (facilitator)
+
+### Mini stand-up
+
+* ben: integrating tick processor, rename binary to “iojs”, upgrade v8, and plenty of libuv features/bug fixes.
+* bert: libuv: readdir on windows, build with clang, plan for next unstable libuv, use similar ev loop impl on windows as unix first tentative patches available for review.
+* chris: streams - solving failure on v1.x branch for npm, zlib patch breaks stuff, streams visualization stuff doc/writeup of node streams and whatWG streams
+* fedor /few-dir/: no updates, working on non-iojs stuff and holidays
+* colin: triaging issues in io.js and joyent/node.  helping with merge of 0.12 to 0.10
+* isaac: no io.js, vacation
+* mikeal: nada
+* rod: build build build ci ci ci.  re-did all the build slaves on Jenkins, introduced a bunch more.  Ansible scripts for linux machines (CentOS 5,6,7, Ubuntu all LTS + Current 14.10 +32bit versions, 2 ARM v7s one virtual one physical, 2 of each Windows 2012,2008, a couple interim OS X machines more permanent ones coming from Voxer soon).  https://github.com/nodejs/build Still lacking specific Jenkins setup and secrets.  Working on release process.
+    mikeal: issue re release?
+    rod: not yet, a lot of little bugs to get CI working consistently.  No grand plan for what’s in release yet.
+
+
+### Review of last meeting
+
+* sys: Remove after 3 years of deprecation #182 
+* module: force require('process') to return a reference to process #206
+* File copyright policy #216
+* Rename v0.12 to v1.0.0
+* Merge strategy (v0.10 and joyent/node)
+
+### Invite Colin Ihrig to the TC #223 
+
+https://github.com/nodejs/io.js/issues/223
+
+Asked for vote
+
+Passed unanimously
+
+Some discussion about TC member addition process
+
+### File copyright policy #216
+
+https://github.com/nodejs/io.js/issues/216
+
+* Rod: got feedback from NodeSource GC on this, recommendation is to keep the copyright but removal of the license notice is acceptable
+* Mikeal & Isaac: removing the copyright should be OK because we have full git record of who made & edited the file, it’s a PITA
+* Asked for vote on removing copyright and license from the top of each source file, moving it a single top level file. **Nobody objected**.
+* Agreed to table further discussion on modifying the license and copyright.
+* isaacs will submit PR to remove license blocks from files.
+
+### Doc: clarified & split up contribution docs #233 
+
+https://github.com/nodejs/io.js/pull/233
+
+* Rod: discussed changes introduced in #233, this is in TC because there are some minor modifications to the governance structure. Recommended that we deal with further changes to governance as a separate discussion.
+* Fedor: remove caine block from CONTRIBUTING.md
+* Mikeal: take PR as is, move the rest to further discussion & PR
+* No objections, agreed to move changes to governance and other adjustments such as moving docs into the docs dir to separate pull requests.
+* Isaacs and Chris will review and +1 the PR.
+
+### Governance: Add new Collaborators #234 
+
+https://github.com/nodejs/io.js/issues/234
+
+Rod discussed the generation of the list of proposed collaborators. 
+
+Long discussion:
+
+* Isaacs, Chris, Bert suggest throttling new contrib additions to 5/week, bump up to 10/week if it goes well, etc.
+* Ben 50/50 on “add everyone now” or “throttle new additions”
+* Bert to review list and see if there’s any contributors that seem we should not add.
+* Other TC members can review list this week.
+* Two issues to vote on at next TC meeting
+  - Issue 1:
+    a. Add everyone
+    b. Add everyone except some that are not added
+  - Issue 2:
+    a. Create a queue of people to add, throttle per week
+    b. Add immediately
+
+### deps: upgrade v8 to 3.31.74.1 #243 
+
+https://github.com/nodejs/io.js/pull/243
+
+* Ben: clean compile, apparently a clean upgrade. It does break postmortem support so Ben removed it completely. Asked who was using it.
+* Ben: adds new features:
+ - numeric literals
+ - string methods
+ - block scoping
+ - classes (strict mode)
+ - object literal extensions
+ - template literals.
+* Fedor: Voxer using postmortem support, so it’s not just Joyent. Would prefer to fix it.
+* No disagreement about merging this.
+* Ben and Fedor to take discussion about details to GitHub.
+
+### Build & release
+
+Rod rambled on about build & release:
+
+* Lots of minor test failures to take care of and make sure there are no serious blockers: https://jenkins-iojs.nodesource.com/job/iojs+any-pr+multi/
+* is osx 32-bit necessary? group agreed to leave it out.
+* binary naming: Ben currently taking care of renaming, Bert will help out with a solution for windows
+* release blobs:
+  - source
+  - windows 32, 64
+  - osx 64-bit, built on 10.10 - specify minimum requirement in XCode (apparently)
+  - linux, centos 5, libstdc++ static - Ben says we shouldn't have to, although Rod found it necessary when built with Debian Weezy, give Ben access to CentOS box to try it out
+  - linux armv7 (built on Ubuntu 14.04) (perhaps armv6 for rpi, but compile should not hold up a release--drop in later?)
+  - Windows bare files, Bert explained the files currently released in nodejs.org/dist/*/
+    - node.lib downloaded by node-gyp for compile
+    - node.pdb contains debug information (may not be needed, not used by the group, perhaps someone asked for it?), leave it out
+    - node.exe is useful where an .msi is a problem to run (no admin access)
+    - Rod proposed to move to a .zip for these for 32 and 64, but this may be a problem to get ready for release, discuss further with Bert
+* Version number - all agreed to go with 1.0.0, but it should be clearly labeled as an initial “beta”-type release for the project.
+* Website for blog/announce/news, Rod proposed Mikeal take responsibility for now until we find a better owner / team, Mikeal agreed.
+* Dist folder structure
+ - Agreed to keep iojs.org/dist/ to mirror nodejs.org/dist, other things via symlinks and html hyperlinks.
+ - Maybe have a iojs.org/downloads/v1/1.0.0/… and perhaps a text/html thing with links to each relevant release
+
+* Bert: Node still merging in 0.10 to 0.12, is there anything that should be merged in 0.10 that we really need?
+* intl: Bert kind of hates this patch.  joyent/node is moving towards building with small icu, you get intl object, but only supports english.  CAN build with another icu to add other intls. Bert to open an issue to discuss further. May leave out ICU completely from 1.0.0.
+
+
+### Next meeting
+
+* Bring a day forward to bless a release, i.e. 2015-01-13

--- a/meetings/io.js/2015-01-13.md
+++ b/meetings/io.js/2015-01-13.md
@@ -1,0 +1,101 @@
+# io.js TC Meeting 2015-01-13
+
+## Links
+
+* **Google Hangouts Video**: http://www.youtube.com/watch?v=Z0KHYPlFI3E
+* **GitHub Issue**: https://github.com/nodejs/io.js/issues/300
+* **Original Minutes Google Doc**: https://docs.google.com/document/d/1HDUayYxTjolYZhu_hGm9hc-6MGAwWrHlNGT2Zo708ck
+
+## Agenda
+
+Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+
+* File copyright policy #216 https://github.com/nodejs/io.js/issues/216
+* governance: Add new Collaborators #234 https://github.com/nodejs/io.js/issues/234
+* The state of ES6 on io.js _(re V8 upgrade policy)_ #251 https://github.com/nodejs/io.js/issues/251
+  Quick recap:
+  - Whether if it is ok to release 1.0.0 with V8 3.31.74 minus ES6 Classes and Object Literals Extensions, considering that the initial version of io.js will be "beta" quality and probably the stable version will coincide with the stable release of V8 3.31 (~6 weeks), which will have these features reinstated.
+  - How to handle V8 updates with semver so that if the same issue arised with a different timing it could mean a bump to 2.0.0.
+  - Community suggestions:
+    * Different version naming (e.g. 1.x+v8beta, 1.x+v8dev, 1.x+v8canary)
+    * Avoid BC by moving from tip-of-stable-Chrome-branch to the next tip-of-stable-Chrome-branch (~6 weeks release cycle)
+  - How do nightly builds fit into the process.
+* 1.0.0 release checklist https://github.com/nodejs/io.js/issues/302
+
+## Minutes
+
+### Present
+
+* Trevor (TC)
+* Chris (TC)
+* Ben (TC)
+* Bert (TC)
+* Rod (facilitator)
+
+### Mini stand-up
+
+* Ben: 1.0.0 work
+* Bert: 1.0.0 work (and other things)
+* Chris: Docs mainly, made a new repo for it
+* Trevor: Stuff
+* Rod: tons of 1.0.0 release prep work, tidying up test slaves, preparing fresh release slaves and configuring release builds & installers
+
+### Review of last meeting
+
+* Invite Colin Ihrig to the TC #223 https://github.com/nodejs/io.js/issues/223
+* File copyright policy #216 https://github.com/nodejs/io.js/issues/216
+* Doc: clarified & split up contribution docs #233 https://github.com/nodejs/io.js/pull/233
+* Governance: Add new Collaborators #234 https://github.com/nodejs/io.js/issues/234
+* deps: upgrade v8 to 3.31.74.1 #243 https://github.com/nodejs/io.js/pull/243
+* Build & release (& Intl)
+
+
+### File copyright policy #216 
+
+https://github.com/nodejs/io.js/issues/216
+
+Rod: prepared a proposed new LICENSE file, needed for release, adds a new license block for io.js at the top, shifts the Joyent copyright block down but still acknowledges their claim on inherited work. https://github.com/nodejs/io.js/pull/294
+
+Group agreed to merge for now until a better (or more legally appropriate) solution is proposed.
+
+### governance: Add new Collaborators #234 
+
+https://github.com/nodejs/io.js/issues/234
+
+Rod asked if we should punt to next meeting since the group was small and we’re 1.0.0 obsessed.
+
+Group agreed.
+
+### The state of ES6 on io.js _(re V8 upgrade policy)_ #251 
+
+https://github.com/nodejs/io.js/issues/251
+
+Rod: this is about V8 version matching and V8 version stability. We’re going live with 3.31.
+
+Discussion with the V8 team suggests that 3.31 is probably not appropriate because of stability concerns. We have already had to disable class support because the V8 team announced their intention to disable it in the next release anyway.
+
+Group agreed to stick with 3.31, too late to do otherwise. Come up with a more solid stability policy later.
+
+### v1.0.0 release checklist
+
+https://github.com/nodejs/io.js/issues/302
+
+* Rod will land LICENSE change after meeting
+* Bert spoke about the v0.10 and the things that remain unmerged
+  - abort on uncaughtException for domains not landed, so may be missed; feature used by Hapi / Walmart Labs for postmoretem debugging
+  - private buffer object patch not landed, repl will crash if you do this currently
+  - sslv2 & sslv3 fixes -- we have agreed to disable these completely
+  - re timers slowness - Bert and Ben don’t like the 0.10 fix, need to find our own - not landing in 1.0.0, probably our own fix in 1.0.1
+* Bert spoke about node.exe, has code for it but it’s crashy, could release with a symlink for 1.0.0. Asked for input on the approach.
+* Discussed node-gyp - Ben to PR node-gyp (and maybe land a modified version in io.js codebase) for iojs.org/dist/vx.y.z/... for source tarball.
+  - discussed process.versions.iojs property, https://github.com/nodejs/io.js/issues/269 - group agreed to do nothing on this. Rod to find discussion or create issue to have discussion on this.
+  - discussed visual assets not being in the repo, currently copied by CI manually into src, Rod to land a PR with them
+* Rod: Changelog, we don’t have one.
+  - https://github.com/joyent/node/wiki/API-changes-between-v0.10-and-v0.12
+  - Rod: is it a blocker? Ben: not per-se but very good to have.
+  - Rod: proposed to come up with something on GitHub and ask for people to take work. Trevor will do Buffer, Chris streams, Bert child processes.
+
+
+### Next meeting
+
+* Back to normal schedule next week

--- a/meetings/io.js/2015-01-21.md
+++ b/meetings/io.js/2015-01-21.md
@@ -1,0 +1,166 @@
+# io.js TC Meeting 2015-01-21
+
+## Links
+
+* **Google Hangouts Video**: http://www.youtube.com/watch?v=OUoWlIshY9s
+* **GitHub Issue**: https://github.com/nodejs/io.js/issues/509
+* **Original Minutes Google Doc**: https://docs.google.com//document/d/1yOS17cUt7QUHJXxdVmEpS1ZS_N32HMO9QTHb2qL-KHk
+
+## Agenda
+
+Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+
+* Invite Domenic Denicola to the TC Meetings (https://github.com/nodejs/io.js/issues/403)
+* Governance: Add new collaborators (https://github.com/nodejs/io.js/issues/234)
+* Stabilization and Release Cycles and Process (https://github.com/nodejs/io.js/issues/405)
+  * also: the state of ES6 on io.js (re: V8 upgrade policy) (https://github.com/nodejs/io.js/issues/251)
+* doc: bump punycode api stability to ‘stable’ (https://github.com/nodejs/io.js/issues/470)
+* Working group reports
+ * Streams
+ * Website
+* ICU
+
+## Minutes
+
+### Present
+
+* Bert (TC)
+* Ben (TC)
+* Chris (TC)
+* Colin (TC)
+* Fedor (TC)
+* Isaac (TC)
+* Mikeal
+* Rod
+* Domenic
+
+### Mini stand-up
+
+* Bert: Release, polish, Windows installer, Windows XP, ICU
+* Ben: Fixing bugs, reviewing PRs, maintenance
+* Chris: Cleaning up points where core reaches in to private state of streams, TLS bug with New Relic
+* Colin: Reviewing PRs, moving vars to ES6 consts
+* Fedor: Commenting, working on replacement for GYP, written in C: https://github.com/indutny/pyg
+* Isaac: npm stuff, some streams discussing
+* Mikeal: Website WG, social media accounts, facebook, G+, etc. 
+* Domenic: Changelog & Release, clarifying V8 stuff
+* Rod: Release, etc.
+
+### Review of last meeting
+
+* File copyright policy #216 
+  - LICENSE file
+* governance: Add new Collaborators #234 
+  - Deferred to this meeting
+* The state of ES6 on io.js _(re V8 upgrade policy)_ #251 
+  - Only discussed V8 upgrade policy, re 3.31 vs 3.30
+* 1.0.0 release checklist
+
+
+### Invite Domenic Denicola to the TC Meetings
+
+(https://github.com/nodejs/io.js/issues/403)
+
+Enough agreement on GitHub and in private communications amongst TC. **Done.**
+
+### Governance: Add new collaborators 
+
+(https://github.com/nodejs/io.js/issues/234)
+
+* Mikeal: Proposed Chris leads an onboarding process, do a Hangout with a group of people from the original list who are willing to go through the process and take them in the first week and iterate from there.
+* Bert: +1 for an onboarding process, more interested in handing out voting rights to a larger group.
+* Mikeal: Would rather separate the voting rights issue from adding contributors, make a separate issue for this with ideas and come back to it at next meeting.
+* Ben: is an onboarding process necessary? New contributor should pick it up fairly quickly.
+* Chris: How we review code and deal with issues (cultural things) is hard to get across with just a written process.
+* Isaac: Basically apprentice model for joyent/node but faster and more inclusive. Some brief instruction on how to do things.
+* Mikeal: adding collaborators gives us an informal voting process, +/-1s on issues with the “collaborator” badge
+* Bert: would like to widen and formalise the voting process
+* Mikeal: wants to tackle the issue by bringing org to the roadmap repo, will bring Bert in on the process
+
+Discussed whether onboarding should be mandatory.
+
+Proposal: **take anyone proposed that +1s in that thread, mandatory onboarding process by Chris, limited by how many he can take.**
+
+Passed
+
+
+### Stabilization and Release Cycles and Process 
+
+(https://github.com/nodejs/io.js/issues/405)
+
+#### V8
+
+* Mikeal:
+  - how to align with V8 process and increase collaboration
+  - semver + V8 introduces some challenges
+* Domenic: V8 is synced to Chrome releases, Beta should ship with the version that ships with release
+* Ben: is the proposal to stick with stable V8 release that’s in stable Chrome?
+* Domenic: ideally some “beta” version of io.js that uses a Beta V8
+* Mikeal: we need more releases to get experience with this, assumption is that at some point we say “this is stable” and have a stable and unstable branch.
+* Discussed current release patterns, how they map to minor/patch
+* Domenic: we are in a “danger zone”
+* Mikeal & Domenic discussed how you might achieve a “canary”
+* Bert: proposal:
+  - io.js track stable V8, bump minor and possibly major as required
+  - have a pre-release that tracks the Beta
+* Domenic: would like to keep V8 version upgrades as a separate concern to other experimental additions to io.js, decouple from io.js releases / semver?
+* Ben: happy with stable proposal, want to move discussion on unstable to an issue for further discussion.
+* Action: **Ben file an issue to discuss how unstable works**
+* **Agreement: V8 should track stable**
+
+#### Logo
+
+* Discussed logo-per-release
+* Mikeal: we need a versatile logo to use across all web / social presences. Having a logo to designate a release would be good.
+* Mikeal: ideally website team would like JSON file containing release info to be checked in to the website repo upon completion.
+
+#### Releases
+
+* Rod: patch releases should be frequent, there have been 4 so far, it seems to be working well but we should monitor
+* Domenic: frequent releases should be normal, patch & minor should just be part of the normal process
+* Bert: would be good to have API change notes into the git log
+* Discussed further about how to deal with API changes minor/major, unstable branches, etc.
+* **Agreement: patch and minor releases are merged as part of normal business, a release then is either a patch or minor bump depending on what was merged.**
+* Move discussion about tagging vs git log recording for patch/minor/major to GitHub.
+* **Punt on discussions about who can release and how that happens**
+* **Punt on discussions about synchronizing with important ecosystem projects (NAN, node-gyp, nvm, etc.)**
+
+
+
+### also: the state of ES6 on io.js (re: V8 upgrade policy) 
+
+(https://github.com/nodejs/io.js/issues/251)
+
+Part of previous discussion
+
+### doc: bump punycode api stability to ‘stable’ 
+
+(https://github.com/nodejs/io.js/issues/470)
+
+* **Agreement**
+
+### Working group reports
+
+* Mikeal and Chris to semi-formalise the model
+* Mikeal: 6 people actively engaged and growing, “could not be going better”
+* Chris: streams group has initial set of members, some discussions going on, first meeting pending
+  * initial set of members: https://github.com/nodejs/readable-stream/issues/97#issuecomment-70399923
+* Rod:
+  - The Docker sub-group is going great and has even got the docker-iojs images accepted as the official Docker "iojs" images.
+  - Other "build" efforts are all release-focused for now, trying to streamline the process to make it possible to have multiple people able to cut releases.
+
+
+### ICU
+
+* Bert:
+  - joyent/node has small-icu enabled by default making `Intl` work
+  - can get it working but it makes the binary twice as big (~8M more)
+* Domenic: ideally we would track browsers and just include it
+* Ben: V8 adds ICU by default but you need to opt-out, which we do
+* Action: **Invite Steven Loomis to the next TC meeting to discuss further**
+
+
+### Next meeting
+
+* 28th January 2015
+

--- a/meetings/io.js/2015-01-28.md
+++ b/meetings/io.js/2015-01-28.md
@@ -1,0 +1,179 @@
+# io.js TC Meeting 2015-01-28
+
+## Links
+
+* **Google Hangouts Video**: http://www.youtube.com/watch?v=k27NObxy0ps
+* **GitHub Issue**: https://github.com/nodejs/io.js/issues/565
+* **Original Minutes Google Doc**: https://docs.google.com/document/d/1IIfubVivCORgP0nQfo8Mf4gXhwBrndRm9cwmNGBXmtE
+
+## Agenda
+
+Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+
+*  governance: Add new Collaborators [#234](https://github.com/nodejs/io.js/issues/234) / feedback and more contribs / @chrisdickinson
+*  Stabilization and Release Cycles and Process [#405](https://github.com/nodejs/io.js/issues/405) / further discussion / @iojs/tc
+  -  doc: add releases document detail release cycle [#630](https://github.com/nodejs/io.js/issues/630) / proposal from @chrisdickinson
+*  dgram: implicit binds should be exclusive [#325](https://github.com/nodejs/io.js/issues/325) / minor version bump / @bnoordhuis
+*  buffer: implement `iterable` interface [#525](https://github.com/nodejs/io.js/issues/525)  / minor version bump / @bnoordhuis
+* replace util.isType() with typeof [#607](https://github.com/nodejs/io.js/issues/607) / general use of util.is*() in core re perf
+* docs: lower the maximum stability level to "stable" [#633](https://github.com/nodejs/io.js/pull/633)
+* maintain our own package registries for io.js related packages [#640](https://github.com/nodejs/io.js/issues/640#issuecomment-71882645)
+* Working Groups PR [#599](https://github.com/nodejs/io.js/pull/599)
+* Remove “unstable” from messaging [#108](https://github.com/nodejs/website/issues/108)
+
+## Minutes
+
+### Present
+
+* Ben (TC)
+* Bert (TC)
+* Chris (TC)
+* Colin (TC)
+* Fedor (TC)
+* Isaac (TC)
+* Mikeal
+* Rod
+
+Apologies from:
+
+* Trevor (TC)
+* Domenic
+
+### Mini stand-up
+
+* Ben: Reviewed/landed pull requests, fixed bugs, the usual
+* Bert: Same as Ben, but not as much
+* Chris: On-boarding stuff
+* Colin: 
+* Fedor: working on pyg (gyp alternative in C)
+* Rod: ARMv6 builds, fixing persistent bug on Ubuntu 10.04, yay!
+* Isaacs: Only doing npm CEO stuff
+* Mikeal: social media stuff for io.js, PR, roadmap, feedback from Big Cos.
+
+### Review of last meeting
+
+* Invite Domenic Denicola to the TC Meetings (https://github.com/nodejs/io.js/issues/403)
+* Governance: Add new collaborators (https://github.com/nodejs/io.js/issues/234)
+* Stabilization and Release Cycles and Process (https://github.com/nodejs/io.js/issues/405)
+  * also: the state of ES6 on io.js (re: V8 upgrade policy) (https://github.com/nodejs/io.js/issues/251)
+* doc: bump punycode api stability to ‘stable’ (https://github.com/nodejs/io.js/issues/470)
+* Working group reports
+ * Streams
+ * Website
+* ICU
+
+### governance: Add new Collaborators
+
+[#234](https://github.com/nodejs/io.js/issues/234) / feedback and more contribs / @chrisdickinson
+
+* Chris: Onboarded 2 groups of 4 new collaborators last week. (first group: @vkurchatkin, @micnic, @seishun, @brendanashworth, second group: @evanlucas, @Fishrock123, @Qard, @thlorenz)
+  - 30 min summary of how everything works, gov, git, etc.
+  - took exit poll to get reactions
+  - notes here: https://gist.github.com/chrisdickinson/80df88b9089c19e0459e
+* Rod: how do we iterate?
+* Chris: Do it again next week with ~4 more
+* Discussed timezones and how that works
+
+### Stabilization and Release Cycles and Process
+
+[#405](https://github.com/nodejs/io.js/issues/405) / further discussion / @iojs/tc
+
+***Also:*** doc: add releases document detail release cycle [#630](https://github.com/nodejs/io.js/issues/630) / proposal from @chrisdickinson
+
+Moved straight to Chris’ proposal:
+
+* Chris discussed thoughts in his proposal @ https://github.com/nodejs/io.js/issues/630
+* Mikeal: would rather not have a static number/list of supported versions, let that be dynamic as people & companies step up to help support them
+* Ben: “stable” and “next” would be easiest to reason about
+* Chris: “dev” is for ad-hoc semver releases, replaces nightlies with a better train system.
+* Chris: branches will be “master” - development happens here, maintain “v1.x”, “v2.x” etc. for major releases. Ideally LTS would be from major versions.
+* Fedor asked about communication to users and how much fragmentation this would cause
+* Ben: how do you keep the delta between dev and stable from getting too big
+* Chris: at most there would be a 2-week lag between something hitting dev and something going out on stable
+* Bert: suggested that we need a better batching mechanism, particularly for breaking changes, so we’re not constantly bumping major.
+
+### dgram: implicit binds should be exclusive 
+
+[#325](https://github.com/nodejs/io.js/issues/325) / minor version bump / @bnoordhuis
+
+* Ben: this is about minor version bump, that’s been decided and we’re doing a 1.1.0 so this is being merged and released
+
+### buffer: implement `iterable` interface
+
+[#525](https://github.com/nodejs/io.js/issues/525)  / minor version bump / @bnoordhuis
+
+* Ben: same as previous issue, resolved
+
+### replace util.isType() with typeof 
+
+[#607](https://github.com/nodejs/io.js/issues/607) / general use of util.is*() in core re perf
+
+* Bert: find with direct comparisons and checks where it makes sense (undefined, simple stuff)
+* Isaac: hate it all, they are difficult to inline so manually inline--pick one and use it across all
+* Colin: working on a PR to do the replacement already
+* Chris volunteered to PR a style-guide into docs
+* Isaac: better linter would be great
+
+### Doc-tool - Should we merge with the joyent/node version?
+
+* Isaac: Robert Kowalski reached out to me to ask about this.
+  - Seems silly to have two nearly-identical tools for this.
+  - Delegate to doc working group?
+  - Suggested that he just pick one from io.js or joyent/node and send a PR for that
+* Mikeal: Website WG is meeting next week, will pull in Robert to that discussion
+
+### docs: lower the maximum stability level to "stable" 
+
+[#633](https://github.com/nodejs/io.js/issues/633)
+
+* General disagreement about this
+* Mikeal suggested moving things that are likely to change into vendored packages (like streams)
+* Motivation was to set some things (frozen/locked) as unchangable because they would break too much stuff
+* Bert: we effectively have 4 levels: strict-deprecation, soft-deprecation, moving, pretty-much-done
+* Mikeal: proposed punting this for a few weeks
+* Isaac: the labels are useful for guiding people on where best to contribute and where to not bother
+
+### maintain our own package registries for io.js related packages
+
+[#640](https://github.com/nodejs/io.js/issues/640)
+
+* Mikeal: each distro (Homebrew, Debian, etc.) has their own conception of “stable”, suggestion is to maintain them under io.js and instruct people how to do this. e.g. using our own custom Homebrew end-point and instruct people how to use it with `brew`. Also could bring in complicated packages from the community.
+* Mikeal: Should come under the Build WG for now, ideally a single repo where external projects can put in a single PR to update their stuff.
+
+### Working Groups PR 
+
+[#599](https://github.com/nodejs/io.js/issues/599)
+
+* Mikeal introduced his proposal: if you’re going to do the work in a WG then you can spin that up as a separate concern
+* Ben asked for clarification about whether WGs get a free-pass in core
+  - Mikeal: no, they are isolated from core
+* Rod: clarification about relationship to TC
+  - TC has charter-revocation powers, beyond that they don’t have control over the activities of a WG
+* Consensus reached, Mikeal will put in the suggested fixes (in the PR) into the docs and merge
+
+### Remove “unstable” from messaging
+
+[#108](https://github.com/nodejs/io.js/issues/108)
+
+* Remove “unstable” from the website but not say it’s “stable”
+* Bert: big +1, use semver, don’t try and message something else, only concern is the version of V8 we are using
+* Discussed V8 4.1 and how “stable” it is
+
+### Node.js and io.js should not break each other (no, they shouldn't)
+
+[#631](https://github.com/nodejs/io.js/issues/631)
+
+Rod brought this up for quick discussion and draw attention to TC members for possible input.
+* Mikeal suggested that this should be taken to the website WG for better documentation
+
+### Working group reports
+
+* Streams
+ - first WG meeting this week
+* Website
+ - meeting next week
+
+### Next meeting
+
+* 4th of February
+

--- a/meetings/io.js/2015-02-04.md
+++ b/meetings/io.js/2015-02-04.md
@@ -1,0 +1,107 @@
+# io.js TC Meeting 2015-02-04
+
+## Links
+
+* **Google Hangouts Video**: http://www.youtube.com/watch?v=k27NObxy0ps
+* **GitHub Issue**: https://github.com/nodejs/io.js/issues/509
+* **Original Minutes Google Doc**: https://docs.google.com/document/d/1IIfubVivCORgP0nQfo8Mf4gXhwBrndRm9cwmNGBXmtE
+
+## Agenda
+
+Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+
+* assert: don't compare object `prototype` property [#636](https://github.com/nodejs/io.js/pull/636) _and_  assert: introduce `deepStrictEqual` [#639](https://github.com/nodejs/io.js/pull/639) / @vkurchatkin
+* Release PGP key strategy and policy [#709](https://github.com/nodejs/io.js/issues/709)
+* If time: vm bugs? [#548](https://github.com/nodejs/io.js/issues/548), [joyent/node#9084](https://github.com/joyent/node/issues/9084)
+## Minutes
+
+### Present
+
+* Ben (TC)
+* Bert (TC)
+* Chris (TC)
+* Colin (TC)
+* Fedor (TC)
+* Isaac (TC)
+* Trevor (TC)
+* Mikeal
+* Domenic
+* Rod
+
+### Mini stand-up
+
+* Bert: Lots of commenting, still working on ICU, investigating binary size and memory size minimisation, playing with transforming the data to C
+* Chris: Integrating ESLint, held first Streams WG meeting
+* Colin: Issues and codez, removed all util.is type functions
+* Isaac: “Real job” stuff
+* Domenic: Streams WG
+* Mikeal: Starting Tracing WG, lots of org stuff, roadmap work, early feedback from reaching out to companies is that there is concern about version number conflict between io.js and Node, and debugging/tracing.
+* Trevor: moving house, tracing
+* Rod: build collaboration stuff
+
+### Review of last meeting
+
+*  governance: Add new Collaborators [#234](https://github.com/nodejs/io.js/issues/234) / feedback and more contribs / @chrisdickinson
+*  Stabilization and Release Cycles and Process [#405](https://github.com/nodejs/io.js/issues/405) / further discussion / @iojs/tc
+  -  doc: add releases document detail release cycle [#630](https://github.com/nodejs/io.js/issues/630) / proposal from @chrisdickinson
+*  dgram: implicit binds should be exclusive [#325](https://github.com/nodejs/io.js/issues/325) / minor version bump / @bnoordhuis
+*  buffer: implement `iterable` interface [#525](https://github.com/nodejs/io.js/issues/525)  / minor version bump / @bnoordhuis
+* replace util.isType() with typeof [#607](https://github.com/nodejs/io.js/issues/607) / general use of util.is*() in core re perf
+* docs: lower the maximum stability level to "stable" (https://github.com/nodejs/io.js/pull/633)
+* maintain our own package registries for io.js related packages (https://github.com/nodejs/io.js/issues/640#issuecomment-71882645)
+* Working Groups PR (https://github.com/nodejs/io.js/pull/599)
+* Remove “unstable” from messaging (https://github.com/nodejs/website/issues/108)
+* Node.js and io.js should not break each other (no, they shouldn't)
+* Working group reports
+
+
+### assert: don't compare object `prototype` property _and_  assert: introduce `deepStrictEqual` / @vkurchatkin 
+@vkurchatkin questions:
+
+* the future of assert module;
+* relationship between assert and CommonJS Unit Testing spec;
+* particular #636 bug;
+* what "deep equality" means and how it should deal with prototypes;
+* [#639](https://github.com/nodejs/io.js/pull/639) proposal
+
+* Isaac: CommonJS is gone & dead, good ideas have to stand on their own
+* Mikeal: assert probably shouldn’t be in core
+* Isaac: it’s useful for testing Node itself and useful for runtime asserts
+* Rod asked if anyone had any objections to the changes because perhaps Validmir should just be given a blessing to go ahead and improve it.
+* Domenic: medium risk, low reward, perhaps slate this for a 2.0 release.
+* Lots of discussion about the technical merits
+* Ben: the `a.prototype !== b.prototype` is clearly a bug in the initial implementation, it should have been checking `__proto__`
+* Rod: new deepStrictEqual() does that check properly
+
+
+Conclusion: accept both of
+
+- [#636](https://github.com/nodejs/io.js/pull/636)
+- [#639](https://github.com/nodejs/io.js/pull/639)
+
+(Contrast #636 with [#621](https://github.com/nodejs/io.js/pull/621), which is a more ambitious change and probably not a good idea.)
+
+1. deepEqual = No prototype checking
+2. deepStrictEqual = proper prototype checking
+Passed without objection
+
+### Release PGP key strategy and policy / @rvagg
+
+[#709](https://github.com/nodejs/io.js/issues/709)
+
+* Rod summarised how the current release key strategy works and is documented on the README. Asked for feedback on:
+  - Which keyserver(s) to use
+  - Whether to go with a master/sub key design for the project
+* No strong opinions, nothing actionable here
+
+### VM bugs? [#548](https://github.com/nodejs/io.js/issues/548) / @domenic
+
+[joyent/node#9084](https://github.com/joyent/node/issues/9084)
+
+* Domenic introduced #548, some odd VM bugs that seem to be V8 bugs, 
+* Isaac encouraged Domenic to follow this up with the V8 team to get feedback on how this works
+
+### Next meeting
+
+* Skipping a week due to Node Summit
+* Feb 18th 2015

--- a/meetings/io.js/2015-02-18.md
+++ b/meetings/io.js/2015-02-18.md
@@ -1,0 +1,129 @@
+# io.js TC Meeting 2015-02-18
+
+## Links
+
+* **Public YouTube feed**: http://www.youtube.com/watch?v=jeBPYLJ2_Yc
+* **Google Plus Event page**: https://plus.google.com/events/ccrkam8uup1k8qbo0fmcea0n2v4
+* **GitHub Issue**: https://github.com/nodejs/io.js/issues/509
+* **Original Minutes Google Doc**: https://docs.google.com/document/d/1JnujRu6Rfnp6wvbvwCfxXnsjLySunQ_yah91pkvSFdQ
+
+## Agenda
+
+Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+
+* util: fixed behavior of isObject() [#822](https://github.com/nodejs/io.js/issues/822) / @chrisdickinson / major version release
+* Translate installers for OS X and Windows [#819](https://github.com/nodejs/io.js/issues/819) / @rvagg / maintenance overhead
+* lib: fix process.send() sync i/o regression [#774](https://github.com/nodejs/io.js/issues/774) / @bnoordhuis
+* Implement unhandled rejection tracking [#758](https://github.com/nodejs/io.js/issues/758) / @rvagg / how can we help this land
+* Logo / Brand Treatment
+[website/181](https://github.com/nodejs/website/issues/181) @ mikeal
+https://www.behance.net/gallery/23269525/IOJS-logo-concept
+* Stability Policy/Statement & Roadmap
+[#725](https://github.com/nodejs/io.js/issues/725) / @mikeal
+[roadmap/14](https://github.com/nodejs/roadmap/issues/14) / @mikeal
+
+## Minutes
+
+### Present
+
+* Bert (TC)
+* Chris (TC)
+* Colin (TC)
+* Isaac (TC)
+* Trevor (TC)
+* Mikeal
+* Domenic
+* Rod
+* Apologies for Ben and Fedor
+
+### Mini stand-up
+
+* Bert: NodeSummit and company stuff, Windows io.js stuff
+* Chris: styleguide work, wrangling ESLint, slow week
+* Colin: busy with work, porting joyent/node work to io.js
+* Domenic: having fun with VM stuff in jsdom, have a release coming soon
+* Rod: not as much as usual, preparing for 1.3.0
+* Isaac: Node Summit, npm stuff
+* Mikeal: i18 groups, >160 new people doing translations, press inquiries because of Node Foundation news, lots of website stuff (i18n & build), roadmap and stability
+* Trevor: Some critical stuff on joyent/node, work, moving house
+
+### Review of last meeting
+
+* assert: don't compare object `prototype` property _and_  assert: introduce `deepStrictEqual` / @vkurchatkin 
+* Release PGP key strategy and policy / @rvagg
+* VM bugs? [#548](https://github.com/nodejs/io.js/issues/548) / @domenic
+
+### util: fixed behavior of isObject() [#822](https://github.com/nodejs/io.js/issues/822) / @chrisdickinson / major version release
+
+* Chris: Requires semver-major, what’s the vibe on bumping major at this stage?
+* Chris: isObject() would now return true when checking for functions
+* Mikeal: interested in separating “things that break” and “API breakage”
+* Chris: consider this a “fix” but is also an API change that could break people’s downstream code
+* Isaac: probably want to put off a 2.x release until we have more substantial changes, not to wait for 2 years but have some time frame, like 6 months
+* Bert: messaging is off for a 2.0 bump just for this
+* Domenic: versions shouldn’t mean the same as they used to, major version bumps should be more casual
+* Rod: are we stopping saying that this is compatible with “Node”?
+* Mikeal: compatible with past-Node, not joyent/node 0.12+ because we have no control over that
+* Mikeal: release channels - standard semver & canary which is everything else
+* Chris: +1 for release channels, but not so much on substance of the proposal.
+* Rod: concerned about the emotional energy we’re still investing in version numbers when we should be just doing semver
+* Mikeal: ignore version numbers, have a “canary” type branch and start releasing on that until we’re confident to merge back in
+* Chris: difference between Mikeal’s proposal and the original proposal is having a “canary” branch that stuff gets merged in to and eventually is merged in to master, original proposal merged new stuff in to master and used the time delay as “canary” (like Chrome)
+* Rod: proposal is to tag this issue as a milestone for now and punt until we have more substantive changes - no disagreements, passed
+
+### Translate installers for OS X and Windows [#819](https://github.com/nodejs/io.js/issues/819) / @rvagg / maintenance overhead
+
+* Rod: concern here is the maintenance overhead in keeping all of the translations in sync, are we happy to have that headache in core?
+* Mikeal: let English be the default and let the translation teams be responsible for watching for changes and making updates as appropriate
+* Bert: installer framework is largely out of our control for how the mechanics of translations and fallbacks work, -1 on this because it’s just an installer and there are probably better targets for translation
+* Mikeal: the translation teams will prioritise for themselves what gets translated.
+* Domenic: enable the community as long as it doesn’t add friction
+* Bert: if there is no technical issue then OK with landing this, the responsibility for translation will have to be with that community
+* Resolution: allow this to land unless there are going to be technical blockers to future installer changes needing to wait for translations to be updated
+
+### lib: fix process.send() sync i/o regression [#774](https://github.com/nodejs/io.js/issues/774) / @bnoordhuis
+
+* Ben’s issue, punt till next meeting, note in “known issues” for releases
+
+### Implement unhandled rejection tracking [#758](https://github.com/nodejs/io.js/issues/758) / @rvagg / how can we help this land
+
+* Rod: Brought to TC to get some more engagement and help get this landed unless there are any major objections
+* Domenic: PR looks good, it’s mainly a matter of code quality, doesn’t add any default handlers which is a good incremental way of adding this
+* Trevor discussed concerns about how V8 runs the events, synchronously vs on the micro-task queue
+* Trevor: OK with the change because there is almost no overhead if you’re not using Promises or this event, concerned about the disconnect between the V8 API vs what we expect it to be--the PR compensates for V8 behavior.
+* Domenic: user-exposed semantics of this PR are good
+* Mikeal: concerned about behavior change in the future leading to a 
+* Rod: proposed resolution is to give the TC’s blessing to that PR for it to land when everyone in there is happy with it
+  - No objections
+
+### Logo / Brand Treatment
+[website/181](https://github.com/nodejs/website/issues/181) @ mikeal
+https://www.behance.net/gallery/23269525/IOJS-logo-concept
+
+* Mikeal discussed the proposed website changes and logo choice @ https://www.behance.net/gallery/23269525/IOJS-logo-concept
+* Some discussion about choice of logo, no strong opinions on design
+* Rod: may be best to let the website group make this choice because they are more qualified from a design perspective
+* Chris: design group could be asked to come up with a few options and present them for selection
+* Mikeal: design by committee sucks, everyone knows this
+* Chris: can we come up with some standards and assert them ack to designers - such as number of colors, needs to look good at 16x16 all the way up
+* Rod: maybe this group isn’t qualified to even do that, perhaps push it on to the WG
+* Discussion on the process of selecting a logo and brand treatment
+* Agreed to delegate to the website WG to make this decision
+
+### Stability Policy/Statement & Roadmap
+[#725](https://github.com/nodejs/io.js/issues/725) / @mikeal
+[roadmap/14](https://github.com/nodejs/roadmap/issues/14) / @mikeal
+
+* Mikeal: none of this is fixed in stone, we can change it in the future if we decide it won’t work
+ - one change still to go in is that the wording on stability should be that “we won’t remove an API”
+ - people are terrified that we’re going to break compatibility and go off in new directions, this is a way of dealing with that
+* Bert: concerned about this being a reflection of the way we work rather than enforcing new behaviors
+* Discussion around breaking / removing APIs and how firm this policy is going forward
+* Rod asked for specific things that need to be resolved now vs punting to a later meeting
+* Mikeal: https://github.com/nodejs/roadmap/commit/190690a1b5f206c22f64adc3d29d10c4b08cb8cd
+* Group discussed presentations, no major objections so the blessing was given for Mikeal to move forward with ratifying that, expect further discussion on the broader topic next meeting.
+
+### Next meeting
+
+* Next week, 25th Feb 2015
+

--- a/meetings/io.js/2015-03-04.md
+++ b/meetings/io.js/2015-03-04.md
@@ -1,0 +1,164 @@
+# io.js TC Meeting 2015-03-04
+
+## Links
+
+* **Public YouTube feed**: http://www.youtube.com/watch?v=vxX2CkFPEtk
+* **Google Plus Event page**: https://plus.google.com/events/c9ijr7edl14im7dspk5njktmjq4
+* **GitHub Issue**: https://github.com/nodejs/io.js/issues/1053
+* **Original Minutes Google Doc**: https://docs.google.com/document/d/1RoIE68l8B2iWLdEPM7ApSN2FxFDd3OY0wfTeqUh-K9w
+
+## Agenda
+
+Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+
+* lib: fix process.send() sync i/o regression [#774](https://github.com/nodejs/io.js/issues/774) / @bnoordhuis
+* iojs: introduce internal modules [#848](https://github.com/nodejs/io.js/issues/848) / @chrisdickinson / @trevnorris / (@vkurchatkin)
+* url: significantly improve the performance of the url module [#933](https://github.com/nodejs/io.js/issues/933) / @mikeal
+* Ship websockets in core [#1010](https://github.com/nodejs/io.js/issues/1010) / @piscisaureus
+* RFC: upgrade to V8 4.2? [#1026](https://github.com/nodejs/io.js/issues/1026) / @bnoordhuis
+* Colin resigning from TC [#1056](https://github.com/nodejs/io.js/pull/1056)
+
+## Minutes
+
+### Present
+
+* Ben (TC)
+* Bert (TC)
+* Chris (TC)
+* Domenic
+* Fedor (TC)
+* Mikeal (meeting lead)
+* Isaac (TC)
+* Trevor (TC)
+* Rod
+
+### Mini stand-up
+
+* Ben: PRs, bugs, perf improvements, same old awesome Ben
+* Bert: talking, child process bugs, looking further in to Windows bugs that are still outstanding, no coding
+* Chris: reviewing PRs, onboarding Julian, Christian, Brian, Robert, Ben. Code for core module discovery / use in packages in npm.
+* Domenic: Streams work WHATWG sync with io.js streams ideas.
+* Fedor: fixing bugs, PRs
+* Isaac: coding for fun, node-tap rewrite, global/window alias discussions, node_modules flattening, Windows stuff. Looking in to TLS issues for io.js and 0.12, TLS over Pound causes problems, possibly OpenSSL problem.
+* Mikeal: Website and Evangelism WG work, lots of new collabs and work, getting things in sync
+* Rod: Releases, Windows bug / Jenkins drama, ARMv8 support
+* Trevor: Buffer.indexOf(), nextTick perf improvement
+
+
+### Review of last meeting
+
+* util: fixed behavior of isObject() [#822](https://github.com/nodejs/io.js/issues/822) / @chrisdickinson / major version release
+* Translate installers for OS X and Windows [#819](https://github.com/nodejs/io.js/issues/819) / @rvagg / maintenance overhead
+* lib: fix process.send() sync i/o regression [#774](https://github.com/nodejs/io.js/issues/774) / @bnoordhuis
+* Implement unhandled rejection tracking [#758](https://github.com/nodejs/io.js/issues/758) / @rvagg / how can we help this land
+* Logo / Brand Treatment
+[website/181] https://github.com/nodejs/website/issues/181 @ mikeal
+https://www.behance.net/gallery/23269525/IOJS-logo-concept
+* Stability Policy/Statement & Roadmap
+[#725](https://github.com/nodejs/io.js/issues/725) / @mikeal
+[roadmap/14](https://github.com/nodejs/roadmap/issues/14) / @mikeal
+
+
+### Colin resigning from TC [#1056](https://github.com/nodejs/io.js/pull/1056)
+
+
+### lib: fix process.send() sync i/o regression
+[#774](https://github.com/nodejs/io.js/issues/774) / @bnoordhuis
+
+* Ben: @orangemocha did some work on Windows for libuv, unsure if this helps.
+* Bert: process.send() has been made sync on *nix because otherwise it’s a breaking change, but on Windows it’s always been async so changing it to sync would also be a breaking change. So the situation is crazy.
+* Isaac: ideal is that they behave the same and behave well
+* Discussion about whether this would be a breaking change or a bugfix
+* Bikeshed, moving to GitHub
+* Bert: proposed that we revert Unix behaviour and leave Windows as it is
+* Ben: current fix adds blocking on Windows
+
+
+### iojs: introduce internal modules
+[#848](https://github.com/nodejs/io.js/issues/848) / @chrisdickinson / @trevnorris / (@vkurchatkin)
+
+Chris: lets us have modules that can’t be required from outside of core. I’m in favor; it’s a nice insurance policy, especially in light of the stability policy that we will try not to make any breaking changes to the JavaScript API.
+
+Mikeal: this doesn’t change the existing pseudo-internal modules to become truly internal, right?
+
+Chris: correct, that is separate.
+
+Domenic: but, doing that operation would be a good thing to do in a major version bump.
+
+Isaac/Mikeal: yes, but don’t do that for `util._extend`, too many people use it.
+
+Chris: *gives example of how this would have been helpful for a recent refactor*
+
+Ben: how will the test suite test internal functions from then on?
+
+Chris: there would be a flag, e.g. --allow_internal_modules.
+
+Mikeal: I like it.
+
+Bert: I like it too. However I am concerned about products that do monkeypatching; would that still be possible?
+
+Chris: I think so, as long as they monkeypatch the public APIs…
+
+Ben: not sure that’s quite sufficient…
+
+Domenic: seems like a pure win because it allows you not to have to put everything in one file to keep things private.
+
+### url: significantly improve the performance of the url module
+[#933](https://github.com/nodejs/io.js/issues/933) / @mikeal
+
+This will get rolled in to the major version issue Chris is putting together.
+
+### Ship websockets in core
+[#1010](https://github.com/nodejs/io.js/issues/1010) / @piscisaureus
+
+Bert: I’m not sure I believe in this any more; the major reason I wanted this was that building native addons is terrible, but people brought up that the native part of the web socket implementations only do some bitwise buffer stuff and so we could probably just add *those* to core.
+
+Discussion of how we should probably just add more Buffer methods to core.
+
+Bert: there’s another aspect of this. At some point Node was really modern, but we’ve fallen behind. We can’t even get HTTP/2 or web sockets, we’re in trouble.
+
+Domenic: we’ve learned a lot over the last few years that pushes us to userland code instead of in core. But we need to have some things be “official.”
+
+Trevor: I would like the infrastructure for HTTP/2 to be similar to HTTP/1, with http-parser etc.
+
+Ben: is there any reason HTTP/2 couldn’t be done in pure JS?
+
+Discussion of http-parser and current HTTP/1 implementation strategy and speed.
+
+Bert: I think as a TC what we should say is “we would like to support HTTP/2, but want to see some userland ideas first.” We don’t need to actually start implementation progress right now.
+
+Ben: does anyone on the TC want to write a userland HTTP/2 module?
+
+Discussion of how Fedor already has a SPDY implementation.
+
+Trevor: are we going to do TLS-only HTTP/2?
+
+Mikeal: we probably don't want to, because our HTTPS is not as fast as terminators.
+
+Conclusion:
+We should start an issue in NG about the core modules/modernity stuff.
+We should publicly state that we’re interested in supporting HTTP/2 in the related issue thread, although we’re not sure about implementation strategy and want to see experiments.
+
+### RFC: upgrade to V8 4.2?
+[#1026](https://github.com/nodejs/io.js/issues/1026) / @bnoordhuis
+
+* Ben: V8 4.1 has gone gold/stable so we should probably upgrade by un-floating a revert we placed on top of it. I propose we revert that revert, so that we get 4.1-as-shipped-in-Chrome. [#952](https://github.com/nodejs/io.js/pull/952) for details on the floating revert.
+* Domenic: do we have clarity about ABI vs. API implications for io.js major version?
+* Ben: ABI change means everyone has to recompile their add-ons so we should bump the minor.
+* Fedor: this feels more like a major version?
+* Domenic: do we consider forcing people to run “npm rebuild” a breaking change?
+* Chris: I think I agree that users should not expect to have to rebuild within the same major version.
+* Mikeal: how often does a V8 ABI change happen *after that V8 gets into stable Chrome*?
+* Domenic: not sure, but would suspect not often at all. Maybe we should check with V8.
+* Ben: yes, not often.
+* Fedor: having a call with V8 might be helpful.
+* Mikeal: if it doesn’t happen, then we won’t end up in this situation again.
+
+Conclusion:
+
+Work with V8 team to make sure this doesn’t happen again
+Add “un-revert” to the growing list of issues that would trigger a minor version bump.
+
+### Next meeting
+
+* 

--- a/meetings/io.js/2015-03-18.md
+++ b/meetings/io.js/2015-03-18.md
@@ -1,0 +1,92 @@
+# io.js TC Meeting 2015-03-18
+
+## Links
+
+* **Public YouTube feed**: http://www.youtube.com/watch?v=tQwVcuYCiZ4
+* **Google Plus Event page**: https://plus.google.com/events/cneon2drmol62u4drm8aegjnrkk
+* **GitHub Issue**: https://github.com/nodejs/io.js/issues/1187
+* **Original Minutes Google Doc**: https://docs.google.com/document/d/1It6PTEBQ7OjW8P88hCLoXvcWKA3Q8dY2eYEHIF6FvS4
+
+## Agenda
+
+Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+
+* [#1134](https://github.com/nodejs/io.js/pull/1134) Add Docker working group
+* [#1140](https://github.com/nodejs/io.js/pull/1140) Revert stream base / @piscisaureus / merge policy questions
+* [#1130](https://github.com/nodejs/io.js/pull/1130) Nominating Jeremiah Senkpiel @Fishrock123 to the TC
+* [#1077](https://github.com/nodejs/io.js/pull/1077) Pass args to process.nextTick() / @trevnorris
+
+## Minutes
+
+### Present
+
+* Ben (TC)
+* Bert (TC)
+* Chris (TC)
+* Fedor (TC)
+* Trevor (TC)
+* Rod
+
+### Mini stand-up
+
+* Ben: reviewing bugs, fixing pull requests
+* Bert: debugging Windows issues (related to #1005), working on a more helpful CI dashboard
+* Chris: working on tools to inspect amount of ecosystem breakage that changes cause
+* Fedor: working through PayPal leak issue, working on net.socket() changes
+* Rod: ..
+* Trevor: misc PRs, process.nextTick(), timer bug
+
+### Review of last meeting
+
+* lib: fix process.send() sync i/o regression [#774](https://github.com/nodejs/io.js/issues/774) / @bnoordhuis
+* iojs: introduce internal modules [#848](https://github.com/nodejs/io.js/issues/848) / @chrisdickinson / @trevnorris / (@vkurchatkin)
+* url: significantly improve the performance of the url module [#933](https://github.com/nodejs/io.js/issues/933) / @mikeal
+* Ship websockets in core [#1010](https://github.com/nodejs/io.js/issues/1010) / @piscisaureus
+* RFC: upgrade to V8 4.2? [#1026](https://github.com/nodejs/io.js/issues/1026) / @bnoordhuis
+* Colin resigning from TC [#1056](https://github.com/nodejs/io.js/pull/1056)
+
+### [#1134](https://github.com/nodejs/io.js/pull/1134) Add Docker working group
+
+* Rod: originally conceived to be a “sub-WG” of Build WG but this makes sense because there is little overlap with the Build team or skills required for the Build team.
+* Rod: this group is already maintaining official Docker images or io.js located at https://github.com/nodejs/docker-iojs which are also the “official” Docker images for io.js.
+
+### [#1140](https://github.com/nodejs/io.js/pull/1140) Revert stream base / @piscisaureus / merge policy questions
+
+* Bert: in favour of stream_base now and don’t want it reverted given the fixes that have been made. The real problem was the introduction of a major change that lead to a lot of breakage and a lot of fix commits. Proposed that we have a “ng” (or similar) branch with releases for testing before merging.
+* Chris: agree that we need a canary policy of some kind to deal with this
+* Bert: feature flags are a good way of dealing with this and letting them test changes
+* Ben: time-based releases like Rust and Chrome
+* Fedor: main problem is that we didn’t have enough tests for this feature when it was merged.
+* Rod: there’s awkwardness around releasing given that we only have one tip and we can’t cut patch releases once we have semver-minor changes are merged.
+* Trevor: should have semver-minor branches where patch fixes go in and minor changes go in to master/whatever.
+* Discussion about git process
+* Discussion about semver
+* Discussion about minor/patch and what it communicates
+* Discussion about test coverage
+* Rod asked OpenSSL fix: agreed to punt on a release until OpenSSL fix has been released and go immediately after that.
+
+### [#1130](https://github.com/nodejs/io.js/pull/1130) Nominating Jeremiah Senkpiel @Fishrock123 to the TC
+
+* Rod: there was some off-record discussion about TC membership process related to #1130 and #1131.
+  - Neither individual was asked and it would be good to at least have it passed by them first
+  - Would be good to have a smooth on-boarding mechanism to bringing someone on to meetings before officially making them TC, agreed to invite Jeremiah to next TC _if_ he’s interested in being involved.
+  - Generally agreed that increasing the size of the TC is a good thing (minus the meeting-overhead added by more people)
+
+### [#1077](https://github.com/nodejs/io.js/pull/1077) Pass args to process.nextTick() / @trevnorris
+
+* Trevor: passing arguments / context through process.nextTick() in core is common and would be significantly faster if we use a setArgs() feature.
+* Chris: needed in readable-stream
+* Discussed API concerns and how underscored methods still become defacto in userland
+* Chris: could land the internal-module PR and use a Symbol for setArg
+* Trevor: major speed increase comes from flattening the call-structure, there’s no additional stack entries for passing arguments. Particularly in crypto, nextTick() is called a lot.
+* Rod: we need perf numbers from a user-experience perspective, perhaps that will make it more compelling to merge or perhaps it will make this look trivial that it’s not worth the cost of introducting ugly API
+* Trevor: will go off and come back with numbers
+
+### Major version bump
+
+* Ben: proposed making a new integration branch to merge all of the semver-minor features, plus a V8 upgrade, we can start pushing out nightly-style releases for playing around and punt the decision on _how_ to do a major release down the road a little.
+* Group agreed, Rod agreed to help come up with a release mechanism for nightlies to couple with this.
+
+### Next meeting
+
+* 25th March 2015

--- a/meetings/io.js/2015-04-01.md
+++ b/meetings/io.js/2015-04-01.md
@@ -1,0 +1,107 @@
+# io.js TC Meeting 2015-04-01
+
+## Links
+
+* **Public YouTube feed**: http://www.youtube.com/watch?v=B1pTT60E73M
+* **Google Plus Event page**: https://plus.google.com/events/cneon2drmol62u4drm8aegjnrkk
+* **GitHub Issue**: https://github.com/nodejs/io.js/issues/1311
+* **Original Minutes Google Doc**: https://docs.google.com/document/d/1iEzSiQpB3me-x1R0_FzlMtGuPmgxR2x7NMITp779690
+
+## Agenda
+
+Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+
+* reconciliation update (Mikeal and Bert)
+* doc: add NAN WG [#1226](https://github.com/nodejs/io.js/issues/1226)
+* Proposal: Authorise @Fishrock123 to create releases [#1225](https://github.com/nodejs/io.js/issues/1225)
+* governance: Raise the bar for changes in membership and governance policy  [#1222](https://github.com/nodejs/io.js/issues/1222)
+* Nominating Rod Vagg @rvagg to the TC [#1134](https://github.com/nodejs/io.js/issues/1131)
+
+## Minutes
+
+### Present
+
+* Ben (TC)
+* Bert (TC)
+* Chris (TC)
+* Domenic
+* Fedor (TC)
+* Jeremiah
+* Mikeal
+* Trevor (TC)
+* Rod
+
+### Mini stand-up
+
+* Ben: rewriting the timers module
+* Bert: making it possible to rename node.exe/iojs.exe (made it into 1.6.3); governance documents for Node Foundation
+* Chris: building a UTF-8 consumer that can validate/skip invalid glyphs; working on a tool around control flow analysis
+* Domenic: not much io.js related
+* Fedor: rewrote io.js in Go, deciding whether it should be go.io or io.go
+* Jeremiah: managing issues, reviewing PRs, investigating timers bugs
+* Mikeal: io.js charter / Linux foundation work
+* Trevor: looking into beforeExit/timer unref/uv_loop_alive interactions; Node API compliance working group docs (not io.js ... might be fed into the Foundation)
+* Rod: released 1.6.3; GitHub DDOS and CI errors/timeouts are frustrating
+
+### Review of last meeting
+
+* [#1134](https://github.com/nodejs/io.js/pull/1134) Add Docker working group
+* [#1140](https://github.com/nodejs/io.js/pull/1140) Revert stream base / @piscisaureus / merge policy questions
+* [#1130](https://github.com/nodejs/io.js/pull/1130) Nominating Jeremiah Senkpiel @Fishrock123 to the TC
+* [#1077](https://github.com/nodejs/io.js/pull/1077) Pass args to process.nextTick() / @trevnorris
+* Major version bump
+
+
+### Reconciliation update (Mikeal and Bert)
+
+* Mikeal: getting close to a really good position where the governance structures can be merged between io.js and joyent/node. New working group structure and relationship with “TSC”. People can engage @ https://github.com/joyent/nodejs-advisory-board/ with active PRs @ https://github.com/joyent/nodejs-advisory-board/pull/30 & https://github.com/joyent/nodejs-advisory-board/pull/33
+* Bert: discussed why this is good for io.js:
+  - io.js still has a very low profile, merging would be good for everyone
+  - budget from corporate backers, including the ability to travel
+* Mikeal: added to those comments: institutional backing would be very helpful at this stage
+* Ben: current PR seems to give the board more influence than originally suggested
+* Mikeal: the intent is the board is not to make technical decisions, the TSC is
+* Trevor: counterpoint example is IBM maintaining their own fork of V8 so they may want influence on the release process
+* Mikeal: they will be taken care of by an LTS schedule
+* Bert: IBM agrees that there should be a fast-moving tip and they just use an LTS. Board could also assert influence by way of a corporation threatening to withdraw backing.
+
+### doc: add NAN WG [#1226](https://github.com/nodejs/io.js/issues/1226)
+
+* Rod: discussed proposed move of rvagg/nan and rvagg/node-addon-examples to iojs to be governed by an “Addons API Working Group”
+
+Bert: +1
+Chris: +1
+Fedor: +1
+Ben: +1
+Trevor: +1
+
+### Proposal: Authorise @Fishrock123 to create releases [#1225](https://github.com/nodejs/io.js/issues/1225)
+
+* No disagreement, lots of +1s, good to go
+
+### governance: Raise the bar for changes in membership and governance policy [#1222](https://github.com/nodejs/io.js/issues/1222)
+
+* Mikeal: the PR is a bit stale because of a miscount, just want to make sure that there are no concerns with this even though it may not end up being required given the movements with the TC.
+* Rod: requested that we not hold up progress in io.js pending movement on the JNAB / Foundation process and we should treat that as a separate thing that may or may not happen.
+* Bert: happy with the changes but can’t +1 because of the TC company proportion counting
+* Mikeal: just a miscount, needs to be changed, wanted to test if people are OK with this once we have more people on the TC. Main point was to flush out any concerns about raising the bar.
+* Ben: suggested that it become 2 PRs, make the 2/3rds thing a separate issue.
+
+### Nominating Rod Vagg @rvagg to the TC [#1134](https://github.com/nodejs/io.js/issues/1131)
+
+* Rod: fine with this
+* Discussed meeting facilitation, agreed that it wasn’t a strictly defined role but it would be good to share it around a bit.
+
+Bert: +1
+Chris: +1
+Fedor: +1
+Trevor: +1
+Ben: +1
+
+### Open to QA from IRC
+
+_Nothing clear to discuss, but we’ll keep trying this_
+
+### Next meeting
+
+* 8th April 2015

--- a/meetings/io.js/2015-04-08.md
+++ b/meetings/io.js/2015-04-08.md
@@ -1,0 +1,184 @@
+# io.js TC Meeting 2015-04-08
+
+## Links
+
+* **Public YouTube feed**: http://www.youtube.com/watch?v=OjlK8k10oyo
+* **Google Plus Event page**: https://plus.google.com/events/c1c3234uog6svplgrapqucb557k
+* **GitHub Issue**: https://github.com/nodejs/io.js/issues/1369
+* **Original Minutes Google Doc**: https://docs.google.com/document/d/1EsDjfRGpVKFABH4LcNXNxsAsBTnHsU-i5cehmAcp1A8
+
+## Agenda
+
+Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+
+* [#1101](https://github.com/nodejs/io.js/pull/1101) http: allow HTTP to return an HTTPS server / @silverwind / the use of a `tls` option to trigger `https` module functionality
+* [#1301](https://github.com/nodejs/io.js/pull/1301) Util(.is*) Deprecations / @Fishrock123 & @brendanashworth / [this comment](https://github.com/nodejs/io.js/pull/1301#issuecomment-90829575) asking for an opinion from the TC on how to move forward
+* Discuss https://github.com/jasnell/dev-policy [[comment by @mikeal]](https://github.com/nodejs/io.js/issues/1369#issuecomment-90955688)
+* Discuss / Review the `require(‘.’)` situation [[comments by @silverwind and @Fishrock123]](https://github.com/nodejs/io.js/issues/1369#issuecomment-90933134)
+
+
+### Present
+
+* Bert (TC)
+* Domenic
+* Trevor (TC)
+* Ben (TC)
+* Fedor (TC)
+* Jeremiah
+* Mikeal
+* Chris (TC)
+
+### Review of last meeting
+
+* reconciliation update (Mikeal and Bert)
+* doc: add NAN WG [#1226](https://github.com/nodejs/io.js/issues/1226)
+* Proposal: Authorise @Fishrock123 to create releases  [#1225](https://github.com/nodejs/io.js/issues/1225)
+* governance: Raise the bar for changes in membership and governance policy.  [#1222](https://github.com/nodejs/io.js/issues/1222)
+* Nominating Rod Vagg @rvagg to the TC  [#1134](https://github.com/nodejs/io.js/issues/1131)
+
+### Quick stand-up
+
+* Ben: fixing bugs, reviewing PRs. Looked into adding `Generator.prototype.return()` in V8, but more complicated than expected (crashes and can’t figure out why). Fedor might help.
+* Bert: working on a CI status dashboard. Reviewing a patch that makes Node use Chakra instead of V8 (!)
+* Chris: worked on a patch to add a UTF8 consumer to utils, for the purposes of eventually adding UTF8 validation as well as being able to externalize buffer-strings. Talked about standardizing destroy() behavior on streams
+* Domenic: Not much on io.js, reviewed some dev policy stuff especially with regard to V8
+* Fedor: bugs and PRs
+* Jeremiah: bugs and PRs and 1.6.4 release
+* Mikeal: worked on dev policy for the foundation, continuing to iterate; distilling feedback from worried-about-reconciliation thread, but had to lock it in the end with links to other places to address such things.
+* Trevor: code reviews
+
+## Minutes
+
+### [#1101](https://github.com/nodejs/io.js/pull/1101) http: allow HTTP to return an HTTPS server
+
+***@silverwind / the use of a `tls` option to trigger `https` module functionality***
+
+Jeremiah: two options we have (that we’ve discussed) are a tls option, or just auto-detect if you provide appropriate options.
+
+Ben: why is this a TC issue?
+
+Jeremiah/Domenic: three or four weeks without consensus.
+
+Mikeal: related to issue in NG, where you could pass options to listen() instead of createServer().
+
+Chris/Jeremiah: there is a PR for it in joyent/node; not merged yet.
+
+Fedor: to me the problem is `http.request` vs. `https.request`.
+
+Mikeal: (advocates for .listen again)
+
+Trevor: -1 for doing it .listen; it’s too complicated internally; there is lots of weirdness going on here already.
+
+Fedor: would be harder to share a server among workers in a cluster.
+
+DD: but this particular PR is just a simple change to allow you to avoid having to decide between require('http') vs. require('https').
+
+Bert: I kind of like the version where you put the options in listen().
+
+Ben: what happens when iojs is compiled without TLS support?
+
+**Conclusion**: punt on this. Initial feedback is that if we were to go down this route, we would slightly prefer the explicit tls option; however, there needs to be a discussion about the listen() idea, and also about compilation without TLS.
+
+### [#1301](https://github.com/nodejs/io.js/pull/1301) Util(.is*) Deprecations
+
+***@Fishrock123 & @brendanashworth / [this comment](https://github.com/nodejs/io.js/pull/1301#issuecomment-90829575) asking for an opinion from the TC on how to move forward***
+
+Bert: what’s the point?
+
+Trevor: that we won’t really fix bugs in these.
+
+Mikeal: this is just in the docs?
+
+Ben: also util.deprecate to log a warning
+
+Mikeal: that just sounds annoying
+
+Trevor: it’s supposed to be; fix your code
+
+Mikeal: yeah but it’s not always your code…
+
+Bert: we already have two levels of deprecation, warning and not warning
+
+Domenic: however we only use the latter for domains, since we don’t have an alternative for them
+
+Mikeal: can we do staged deprecations, marking things in the docs for one major release cycle, then in the next major release cycle start warning
+
+Domenic: could we add an option to show the deprecation warnings for people who are contentious?
+
+Mikeal: I don’t think anyone would actually turn that on…
+
+Chris: I might be able to run my tooling over all of npm to detect uses
+
+Bert: we need a better strategy in general for moving things out of core. The reason we want to deprecate these is that we don’t really want to fix it because that would be backward incompatible, so this is really too big to be in core. Any ideas for making these better? Maybe if you install a module called util it can take precedence over the one in node? So then we can release the fixed one on npm?
+
+Mikeal: that does sound better than versioning core modules … we hit a flag that lets you replace the core one with a new one. Over time we’ll be able to get data.
+
+Bert: there were some talks about doing this in browsers?
+
+Domenic: not really, nobody wants to ship two versions.
+
+**Conclusions: mark util.isXYZ deprecated in the docs, but do not show a warning in the console this version**
+
+### [Dev Policy](https://github.com/jasnell/dev-policy)
+
+Chris: looking good to me, on the right path, some minor issues still being worked out. E.g. around using priority tags and ways to funnel work to smaller number of contributors in joyent/node vs. just adding more contributors as we do.
+
+Jeremiah: Node has a CI Jenkins PR integration thing that they are in favor of using
+
+Domenic: honestly anything that prevents people from committing things that turn the build red would be awesome…
+
+Bert: agree.
+
+Bert: there’s an issue about version numbers
+
+Mikeal: if we merge, it’ll be a 2.0.0, and we’ll bring in the backward incompatible changes we’ve been sitting on for a while
+
+Mikeal: more on this tomorrow, audio will be public after it happens (due to technology being used it won’t be live). Please review dev policy beforehand.
+
+### Isaac
+
+Ben: Isaac doesn’t seem to be involved anymore. What do we do when a TC member goes AWOL?
+
+Mikeal: well, we cancelled two meetings he was ready to attend, and then he went on vacation for two weeks, so AWOL isn’t quite the right characterization… But yeah, he’s not doing too much. We can just ask if he wants to be there, or we can vote it off.
+
+Bert: I asked him and didn’t get an extremely clear answer; we’ll probably get more clarity when he’s back from vacation. I would not suggest throwing him off right now.
+
+Ben: yeah, there’s no urgency, just…
+
+Bert: yes, but I agree that if you’re on the TC you should show up to meetings
+
+Fedor: what if we made votes exponentially decay in power based on attendance…
+
+### `require('.')`
+
+Mikeal: if we knew the impact of this change would we have done a major?
+
+Chris: if we would have done a major we wouldn’t have done it at all because the API is locked and only bugfixes are allowed.
+
+Jeremiah: that being said the only thing that breaks is a strange workflow from an undocumented feature.
+
+Ben: I am not very sympathetic to that argument; we broke someone’s workflow, and that’s bad.
+
+Domenic: I don’t think that’s fair. Every change is breaking to someone; even changing error messages will break people who parse error messages. The question is what side of the line this is on.
+
+Mikeal: it seemed weird…
+
+Domenic: I always thought NODE_PATH was deprecated. Should we warn about people using it?
+
+Ben: I understand that someone is already using the new require behavior, so reverting it would be backward-incompatible. So we have a few options: 1) add a hack that makes NODE_PATH interactions with require('.') work as they used to; 2) say “sorry” and keep as-is
+
+Bert: I’m sympathetic to adding the hack and a warning.
+
+Domenic: agree. And maybe try to kill NODE_PATH in 3.x.
+
+**Conclusion: hack plus a warning that shows up in this hacky case (“hey, you’re using the require-dot trick with NODE_PATH; we made it work because we’re nice people, but we want to take it away in 2.x, so gear up”). In 2.x, probably warn on any use of NODE_PATH at all.**
+
+### Bert shows off his CI prototype
+
+It’s pretty cool.
+
+It groups tests in interesting ways that are useful. (OS, flakiness, …)
+
+### Next meeting
+
+* 2015-04-15

--- a/meetings/io.js/2015-04-15.md
+++ b/meetings/io.js/2015-04-15.md
@@ -1,0 +1,87 @@
+# io.js TC Meeting 2015-04-15
+
+## Links
+
+* **Public YouTube feed**: http://www.youtube.com/watch?v=lsRu_of0Xp8
+* **Google Plus Event page**: https://plus.google.com/events/cdinisa9mlisv81um91h71g3css
+* **GitHub Issue**: https://github.com/nodejs/io.js/issues/1431
+* **Original Minutes Google Doc**: https://docs.google.com/document/d/1zlYeYS0LCyIjN4KsjXh9d46hNjp302M6L1K_-_OckzQ
+
+## Agenda
+
+Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+
+* [#1393](https://github.com/nodejs/io.js/issues/1393) Ready to upgrade to V8 4.2?
+* [#1413](https://github.com/nodejs/io.js/issues/1413) combining TC and Node core call
+* [#1416](https://github.com/nodejs/io.js/issues/1416) io.js diff node.js foundation
+
+### Present
+
+* Ben (TC)
+* Bert (TC)
+* Chris (TC)
+* Domenic
+* Isaac (TC)
+* Jeremiah
+* Mikeal
+* Rod (TC)
+
+### Review of last meeting
+
+* [#1101](https://github.com/nodejs/io.js/pull/1101) http: allow HTTP to return an HTTPS server
+* [#1301](https://github.com/nodejs/io.js/pull/1301) Util(.is*) Deprecations
+* [Dev Policy](https://github.com/jasnell/dev-policy)
+* Isaac
+* [#1365](https://github.com/nodejs/io.js/issues/1356) `require('.')`
+
+
+### Quick stand-up
+
+* Ben: will be working less on io.js in the coming weeks
+* Bert: come clang hacking but not much else
+* Chris: some review/work on dev-policy
+* Domenic: did some review of the URL work
+* Isaac: on vacation and busy re fundraising, probably have less time for io.js into the future, will likely be moved out of the role
+* Jeremiah: some issue management, working with dev-policy
+* Mikeal: dev-policy and readable summary of the foundation documents
+* Rod: lots of build WG work including auto Jenkins runs, write-up on “the state of the build”
+
+## Minutes
+
+### [#1393](https://github.com/nodejs/io.js/issues/1393) Ready to upgrade to V8 4.2?
+
+* Ben: `next` branch should be ready to go though needs to be upgraded to 4.2.77.14, C++ changes are fairly minimal.
+* Discussed potentially bumping major:
+  - Mikeal: there was a meeting where it was generally agreed that an ABI change would warrant a version bump
+  - Rod & Isaac suggested that ABI changes shouldn’t bump major
+  - Discussion came around to most members agreeing that ABI change _should_ bump major. Rod voted 0 on this, everyone else apparently +1.
+  - Discussed semver-major changes including process.send() sync regressions, agreed that https://github.com/nodejs/io.js/milestones/2.0.0 represents the best info on what’s mergable
+* Discussed git, agreed that we should move back to master, Chris to handle git changes
+* Discussed RC build, could use nightly or next-nightly but officially link it off the website and maybe label it differently. Rod to figure this out.
+
+Actions:
+ - Isaac to further review url changes, aside from his review and Domenic’s feedback in there it should be ready to merge
+ - Chris to handle git and a move back to master
+ - Ben to PR next branch back into master
+ - Rod to figure out how to do and publish an RC build that’s not just “nightly-xxxxxxxxxxxxxx”
+ - Chris will test packages against URL PR and write up results
+
+### [#1413](https://github.com/nodejs/io.js/issues/1413) combining TC and Node core call
+
+* Mikeal: last dev-policy call brought up the suggestion of combining TC calls for both projects, with an eye on merging it would be good to understand what both groups do. Single meeting for both would be good.
+* Discussed timing - we span more timezones than they do so our slot of 1pm PST makes more sense to get Rod and Fedor in at the same time. Could either be Tue or Wed UTC, they have a meeting the day before us.
+* No strong disagreement
+
+### [#1416](https://github.com/nodejs/io.js/issues/1416) io.js diff node.js foundation
+
+* Mikeal: Foundation doc is huge compared to ours and also contains some formalisation of our process that we just haven’t formalised yet. The diff contains a lot of those and some _actual_ changes too. Open for discussion amongst the community.
+* Rod: LTS discussion starting next week.
+
+## QA on Freenode/#io.js
+
+* Paused for input, nothing this week, will continue to offer a time for this.
+
+## Next meeting
+
+* FluentConf is on next week, Bert, Mikeal and Isaac will be at that. Agreed to go ahead and schedule one anyway.
+* 2015-04-22

--- a/meetings/io.js/2015-04-22.md
+++ b/meetings/io.js/2015-04-22.md
@@ -1,0 +1,127 @@
+# io.js TC Meeting 2015-04-22
+
+## Links
+
+* **Public YouTube feed**: http://www.youtube.com/watch?v=s7LIMsTFaps
+* **Google Plus Event page**: https://plus.google.com/events/co7i7pv2a51270jat7jvkfcue64
+* **GitHub Issue**: https://github.com/nodejs/io.js/issues/1502
+* **Original Minutes Google Doc**: https://docs.google.com/document/d/1G4aJ2OwiW2WphW7Vz2OW56VRot8xRBFitluKsuYPxk0
+
+## Agenda
+
+Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+
+* [#1130](https://github.com/nodejs/io.js/issues/1130) Nominating Jeremiah Senkpiel @Fishrock123 to the TC
+* [#1481](https://github.com/nodejs/io.js/issues/1481) Nominating @mikeal to the TC
+* [#1500](https://github.com/nodejs/io.js/issues/1500) Nominating Brian White @mscdex to the TC
+* [#1501](https://github.com/nodejs/io.js/issues/1501) Nominating Shigeki Ohtsu @shigeki to the TC
+* [#1393](https://github.com/nodejs/io.js/issues/1393) Ready to upgrade to V8 4.2?
+* [#1413](https://github.com/nodejs/io.js/issues/1413) Combined node.js/io.js TC/Core Call
+* [#1416](https://github.com/nodejs/io.js/issues/1416) Diffing io.js and the Node.js Foundation
+
+### Present
+
+* Ben (TC)
+* Bert (TC)
+* Brian
+* Chris (TC)
+* Domenic
+* Fedor (TC)
+* Jeremiah
+* Shigeki
+* Trevor (TC)
+* Rod (TC)
+
+### Review of last meeting
+
+* [#1393](https://github.com/nodejs/io.js/issues/1393) Ready to upgrade to V8 4.2?
+* [#1413](https://github.com/nodejs/io.js/issues/1413) combining TC and Node core call
+* [#1416](https://github.com/nodejs/io.js/issues/1416) io.js diff node.js foundation
+
+### Quick stand-up
+
+* Ben: Not much, company stuff
+* Bert: Playing with clang and FFI, FluentConf
+* Brian: JS HTTP parser, optimising and messing with regex
+* Chris: URL changes, looking for breakage, checked on newSession/resumeSession, 1.8.x release
+* Domenic: Not much, some work on V8 extensions with possible news next weeks
+* Fedor: Looking at the “debugger is slow” in WebStorm issue, possible fix to V8 soon, working on using the OpenSSL 1.0.2 hello parser, HTTP parser patch review
+* Jeremiah: Not so much work on io.js, helped get 1.8.1 out and looking into moving npm out of our git repo.
+* Rod: CI cluster dramas around 1.8.x release, new Raspberry Pis
+* Shigeki: OpenSSL upgrade, ALPM enabling PR coming this week
+* Trevor: Has been testing re-implementing Buffers using ES6 and TypedArrays. Some trickiness but seems doable and with patches that avoid zero-filling, performant.
+
+## Minutes
+
+### [#1130](https://github.com/nodejs/io.js/issues/1130) Nominating Jeremiah Senkpiel @Fishrock123 to the TC
+
+Voted:
+
+* Ben: +1
+* Bert: +1
+* Chris: +1
+* Fedor: +1
+* Rod: +1
+* Trevor: +1
+
+**Action: Jeremiah Senkpiel is now a member of the io.js Technical Committee!**
+
+### [#1481](https://github.com/nodejs/io.js/issues/1481) Nominating @mikeal to the TC
+
+* Bert, Rod: Discussion regarding the potential consequences of expanding the TC and how that might work if a merger with node happens.
+
+Discussed consequences of expansion for merger and for the practicalities of meeting.
+
+### [#1500](https://github.com/nodejs/io.js/issues/1500) Nominating Brian White @mscdex to the TC
+
+_See above_
+
+### [#1501](https://github.com/nodejs/io.js/issues/1501) Nominating Shigeki Ohtsu @shigeki to the TC
+
+_See above_
+
+### [#1393](https://github.com/nodejs/io.js/issues/1393) Ready to upgrade to V8 4.2?
+
+Rod: no formal “RC” builds yet but master is now going out on nightlies, they have a 2.0.0-pre version string now. Discussed whether we want formal RC builds or not. No strong opinions.
+
+Chris: `master` should be active for dev now, `next` should be used for ongoing V8 upgrade builds. Asked if the V8 changes were ready in `next` to merge - Ben confirmed - Chris to merge.
+
+Trevor: would like to get started on the upcoming V8 Buffer-related breakage and whether we should go to a 2.x branch and work on `master`.
+
+Chris: we should work on new stuff on `next` instead and leave `master` intact for now.
+
+Rod: status of URL parser changes?
+
+Chris: would like to test against candidate modules in npm that may cause breakage but otherwise seems good to merge.
+
+Domenic: would like there to be getters and setters for all data properties for completeness and future-proofing - still to be done
+
+Rod: any other breaking changes worth discussing?
+
+Ben: process.send() ready but not merged, any objections? - no objections.
+
+Chris: https://github.com/nodejs/io.js/milestones/2.0.0 new label “land-on-master” to indicate PRs that are still targeting the v1.x branch.
+
+Ben & Bert discussed Ben’s possible timers rewrite - Ben implemented a heap and red-black tree in JS, turned out to be a bit faster but not complete yet and Ben has been distracted on other projects. **
+
+### [#1413](https://github.com/nodejs/io.js/issues/1413) Combined node.js/io.js TC/Core Call
+
+Bert: probably not this week, intent is for next week.
+
+Jeremiah: there had been discussion around forming a convergence WG to handle some of this so as to not require everyone’s time except when necessary.
+
+### [#1416](https://github.com/nodejs/io.js/issues/1416) Diffing io.js and the Node.js Foundation
+
+_Nothing new to discuss_
+
+## Open QA on Freenode/#io.js
+
+Discussion on merger and how the possibility of merging may hold up progress in io.js. Generally agreed that we shouldn’t stop doing what we are doing, nor slow down progress. Bert would like us to be conscious of activities in the Foundation and how they may impact on what we are doing.
+
+Discussion about “production ready” - recommendation is to use latest, we follow semver so that should be enough information. Rod suggested not jumping straight on to 2.0 when it lands, just because of potential edge-cases around internal changes like the url parser.
+
+Discussed module integration testing to test certain modules that we would test with each release - Chris working on some tooling around being able to inspect what modules are impacted by changes - no specific work on actually running tests on modules but this could be a TODO for Build WG (Rod to make an issue for this).
+
+## Next meeting
+
+* 2015-04-29, UTC 20:00

--- a/meetings/io.js/2015-04-29.md
+++ b/meetings/io.js/2015-04-29.md
@@ -1,0 +1,101 @@
+# io.js TC Meeting 2015-04-29
+
+## Links
+
+* **Public YouTube feed**: http://www.youtube.com/watch?v=-e675TT4WEA
+* **Google Plus Event page**: https://plus.google.com/events/cei87pqnichrtt4qggbbo656bpk
+* **GitHub Issue**: https://github.com/nodejs/io.js/issues/1557
+* **Original Minutes Google Doc**: https://docs.google.com/document/d/1C9nfm_5EhNz1jifITbtQcnGBX4R9vktoZ9KsFiCU7sQ
+
+## Agenda
+
+Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+
+* Release Proposal: v2.0.0 [#1532](https://github.com/nodejs/io.js/pull/1532)
+* Forward-port from v1.x [#1559](https://github.com/nodejs/io.js/pull/1559)
+* Convergence plan (https://github.com/jasnell/dev-policy/pull/66)
+* Combined node.js/io.js TC/core call about convergence doc [#1413](https://github.com/nodejs/io.js/issues/1413)
+
+### Present
+
+* Ben (TC)
+* Bert (TC)
+* Brian
+* Chris (TC)
+* Domenic
+* Fedor (TC)
+* Jeremiah
+* Shigeki
+* Trevor (TC)
+
+
+### Review of last meeting
+
+* [#1130](https://github.com/nodejs/io.js/issues/1130) Nominating Jeremiah Senkpiel @Fishrock123 to the TC
+* [#1481](https://github.com/nodejs/io.js/issues/1481) Nominating @mikeal to the TC
+* [#1500](https://github.com/nodejs/io.js/issues/1500) Nominating Brian White @mscdex to the TC
+* [#1501](https://github.com/nodejs/io.js/issues/1501) Nominating Shigeki Ohtsu @shigeki to the TC
+* [#1393](https://github.com/nodejs/io.js/issues/1393) Ready to upgrade to V8 4.2?
+* [#1413](https://github.com/nodejs/io.js/issues/1413) Combined node.js/io.js TC/Core Call
+* [#1416](https://github.com/nodejs/io.js/issues/1416) Diffing io.js and the Node.js Foundation
+
+
+### Quick stand-up
+
+* Ben: nothing
+* Bert: nothing
+* Brian: finished optimizations for JS HTTP parser, posted a few questions; other miscellaneous improvements in core HTTP.
+* Chris: upgraded V8 and documented the process; also did some work on the REPL so that classes (and let/const) work
+* Domenic: PR reviews for v2.0.0, starting on V8 extension work to improve startup time
+* Fedor: worked on fixing some TLS memory issues, so far appears to be a large improvement in memory usage.
+* Jeremiah: issue management; discussions on moving npm out of the repo, which seems to have converged toward a helper tool instead of moving it out of the repo
+* Mikeal: connection too bad to stand up.
+* Shigeki: working on SSL issues; root cert updates. Chrome and Firefox do whitelist of CNNIC cert hashes.
+* Trevor: looking at bugs, streams compliance
+
+## Minutes
+
+### Release Proposal: v2.0.0 [#1532](https://github.com/nodejs/io.js/pull/1532)
+
+* Domenic:
+  - v8 changes merged
+  - worried that we’re getting into a bad cycle of “wait a few more days” for things to land
+  - process.send
+  - open an rc, add to website for a few days, ship by friday
+* Bert/Ben:
+  - talk of process.send
+    - Ben: should not hold up release, windows tests break right now
+    - less of a regression than a change
+* Domenic:
+  - these releases are a train
+  - don’t hold up the train for features
+    - make sure it’s ready for 3
+* url updates from petka: might be ready
+  - ci run passes on all platforms but arm7
+* Domenic recalls in the runup to 1.0 – “nobody tests rc's” was the consensus
+
+Chris, Trevor: discussion about how the `master` and `next` branches are used.
+
+* process.send changes will slip for v2.0
+* waiting for Petka’s comment and review on url changes (https://github.com/nodejs/io.js/pull/1561)
+* release 2.x asap (friday)
+
+After the release:
+
+* the master branch will contain version 2.x.
+* api-breaking changes will land on the ‘next’ branch alongside v8 upgrades. master will be merged into next regularly
+* fixes are backported to the maintenance (v1.x) branch
+
+### Forward-port from v1.x [#1559](https://github.com/nodejs/io.js/pull/1559)
+
+Discussed current plan for backporting patches to maintenance patches.
+
+* Consensus that we should give the “land in master and backport” plan a go and see how it works out.
+
+### Convergence plan (https://github.com/jasnell/dev-policy/pull/66)
+
+### Combined node.js/io.js TC/core call [#1413](https://github.com/nodejs/io.js/issues/1413)
+
+## Next meeting
+
+* April 6th

--- a/meetings/io.js/2015-05-13.md
+++ b/meetings/io.js/2015-05-13.md
@@ -1,0 +1,137 @@
+# io.js TC Meeting 2015-05-13
+
+## Links
+
+* **Public YouTube feed**: http://www.youtube.com/watch?v=UbYiFLf7MpU
+* **Google Plus Event page**: https://plus.google.com/events/cu606mlllfehl11u8kcj7q2407k
+* **GitHub Issue**: https://github.com/iojs/io.js/issues/1689
+* **Original Minutes Google Doc**: https://docs.google.com/document/d/15Y_kJlYm-8cIf-alniaqUWMM-TjGISCqLf40G3pv4sM
+
+## Agenda
+
+Extracted from https://github.com/iojs/io.js/labels/tc-agenda prior to meeting.
+
+* V8 4.4 to remove indexed properties via external data [#1451](https://github.com/iojs/io.js/issues/1451)
+* NODE_PATH deprecation [#1627](https://github.com/iojs/io.js/issues/1627)
+* Join the Node Foundation? [#1664](https://github.com/iojs/io.js/issues/1664)
+* Put `*Sync` methods behind a flag in some future major version [#1665](https://github.com/iojs/io.js/issues/1665)
+* TC Nominations
+ - Shigeki Ohtsu @shigeki [#1501](https://github.com/iojs/io.js/issues/1501)
+ - Brian White @mscdex [#1500](https://github.com/iojs/io.js/issues/1500)
+ - @mikeal [#1481](https://github.com/iojs/io.js/issues/1481)
+* Public QA via #io.js channel on Freenode
+
+### Present
+
+* Ben (TC)
+* Bert (TC)
+* Brian
+* Chris (TC)
+* Domenic
+* Jeremiah (TC)
+* Mikeal
+* Rod (TC)
+* Shigeki
+* Trevor (TC)
+
+### Quick stand-up
+
+* Ben: Upgraded V8, upgraded cares for the first time in 2 years, reviewed pull requests
+* Bert: Played Keen, not much io.js stuff; last Monday met with James, Mikeal about convergence
+* Brian: looking over potential optimizations in the JS codebase, started working on a DNS resolver as a potential replacement for cares
+* Chris: fixing race conditions in the REPL, poking at adding Ctrl-R history searching to readline
+* Domenic: working with V8 team in Munich, working on v8-extras feature, putting large portions of things into snapshot to speed up startup and other things: https://groups.google.com/forum/#!topic/v8-users/D6FmTwlvCgk
+* Jeremiah: issue management, working on tooling for automatic dependency upgrades, see [#1688](https://github.com/iojs/io.js/pull/1688)
+* Mikeal: Foundation stuff, getting ducks in a row
+* Shigeki: holiday in JP, fix TLS bug involving edge-case, needs review
+* Trevor: Helped with re-enabling snapshots, looking at changing the Buffer APIs to use TypedArrays
+* Rod: Been doing lots of little things, working on the CI and build cluster
+
+### Review of last meeting
+
+* Release Proposal: v2.0.0 [#1532](https://github.com/iojs/io.js/pull/1532)
+* Forward-port from v1.x [#1559](https://github.com/iojs/io.js/pull/1559)
+* Convergence plan (https://github.com/jasnell/dev-policy/pull/66)
+* Combined node.js/io.js TC/core call [#1413](https://github.com/iojs/io.js/issues/1413)
+
+## Minutes
+
+* Discussed creating a more formal deprecation policy, chris to open an issue.
+
+### V8 4.4 to remove indexed properties via external data [#1451](https://github.com/iojs/io.js/issues/1451)
+
+* ‘smalloc’ has to go away when we land this V8, thankfully it’s not been around for long but this is a forced deprecation & removal.
+* currently usage of ‘smalloc’ gives a deprecation warning, as of v2.0.0
+* @jeisinger has been backporting some APIs needed for Buffer, NAN will have to catch up but @kkoopa is involved
+* Domenic: V8 4.3 will be next week, 7 weeks from now will be 4.4 (~1 week behind Chrome release)
+* Trevor: no major problems with JS API, most problems will be in the C++ API, should be able to shim to ease it
+
+### NODE_PATH deprecation [#1627](https://github.com/iojs/io.js/issues/1627)
+
+* Jeremiah: there was a suggestion to deprecate NODE_PATH entirely, debate is over deprecation or not, lots of people appear to be finding novel uses of it.
+* Domenic: maybe we should document it
+* Chris: it is documented, Googling shows that it’s been ingrained into the Node background, there’s lots of info out there about how it’s used
+* Domenic: https://iojs.org/api/modules.html#modules_loading_from_the_global_folders
+* Mikeal: maybe write docs about how it exists but you shouldn’t use it
+
+**Action: Mikeal to open an issue to change the docs to talk about how you probably shouldn’t use them** (note: it might be as simple as styling!)
+
+### Join the Node Foundation? [#1664](https://github.com/iojs/io.js/issues/1664)
+
+* Mikeal: Mostly a consensus in the issue about joining
+* Mikeal: Next step is to move the “iojs” org to “nodejs”, then move the convergence repo in to be “node” to be the new tip: https://github.com/jasnell/node.js-convergence
+
+Lots of discussions about process and what needs to happen & when, Mikeal pushing for a vote to get the org moved.
+
+**Voting Question**: The io.js TC agrees to:
+ 1. have the io.js project join the Node Foundation
+ 2. rename the entire “iojs” GitHub org to be “nodejs”
+ 3. invite the the current Node.js TC on to our TC to form the basis of a Node Foundation TSC under the policies of the Node Foundation
+ 4. moving the io.js Working Groups to be under the Node Foundation
+
+**Voting Results**:
+
+* Fedor: 0
+* Ben: +1
+* Bert: +1
+* Chris: +1
+* Jeremiah: +1
+* Trevor: +1
+* Rod: +1
+
+Action: Mikeal to make the move happen in a coordinated way so we get redirects and whatnot
+
+### Put `*Sync` methods behind a flag in some future major version [#1665](https://github.com/iojs/io.js/issues/1665)
+
+* Ben: some people feel that `fs.*Sync()` methods are harmful and would like to see them go away and be behind a flag
+* Bert: don’t agree with deprecating but agree with a flag
+* Rod: agree with Bert, but would like to see doc changes
+* Trevor: working on a flag to print a stack trace
+
+### TC Nominations
+
+* Shigeki Ohtsu @shigeki [#1501](https://github.com/iojs/io.js/issues/1501)
+* Brian White @mscdex [#1500](https://github.com/iojs/io.js/issues/1500)
+* @mikeal [#1481](https://github.com/iojs/io.js/issues/1481)
+
+* Mikeal: joining
+* Rod: timing is awkward with convergence but I’d like to make sure that Shigeki and Brian have a path to join the TC and not have that delayed too much
+
+### Public QA via #io.js channel on Freenode
+
+* `<therebelrobot> After the converged release, will io.js/node still be semver? for example, the history would be node 0.10, 0.12, iojs 1.x 2.x then the converged one would be node 3.x?`
+ - Mikeal: the dev policy says so, there’s nobody advocating not to
+* `<evanlucas> Are there plans to symlink node to iojs in the installers after the first converged release?`
+ - Bert: undecided. We should figure out a way to allow users to “node lts” and “node bleeding edge” side by side.
+ - Mikeal: part of the above is covered by a thread in NG about localizing the node installation to global modules.
+* `<phpnode> will members of the core team be able to revive io.js if they disagree with the direction of the project in future`
+ - (Group) Yes
+* `<skinan5> any plans for nan resolution?`
+ - Rod: it’s just a header file and you need it for older versions of Node so it doesn’t make sense to _not_ use it from npm
+ - Ben: current NAN isn’t suitable for bringing in
+ - Trevor: would support bringing in something that would provide proper ABI support
+ - Action: Trevor to open an issue on the NAN repo to talk about a stable C++ layer
+
+## Next meeting
+
+* May 20th, invite joyent/node TC members, figure out who that is and if this timeslot works for them when we have a combined call tomorrow (14th)


### PR DESCRIPTION
Move old TSC meeting minutes out of nodejs/node and into nodejs/tsc repo