### PR TITLE
General update to the Member Travel Fund doc

### DIFF
--- a/Member-Travel-Fund.md
+++ b/Member-Travel-Fund.md
@@ -19,6 +19,7 @@ for the TSC to approve or decline.
  * Include the presentation you intend to give, if applicable.
  * Include the size of the stipend you wish to receive.
   * Reimbursement stipends are expected to vary with travel distance.
+* Once the final amount spent is known, update the table again with that information.
 
 The TSC will consider each proposal in its next regular meeting. While it is
 ultimately at the TSC's discretion who to approve the following considerations

--- a/Member-Travel-Fund.md
+++ b/Member-Travel-Fund.md
@@ -1,45 +1,44 @@
 ## Purpose
 
 To establish and administer a fund for members of the Node.js
-Foundation to travel and spread knowledge about the foundation
+Foundation to travel and spread knowledge about and support the foundation
 and the Node.js Foundation projects.
 
 ## Restrictions
 
 * Candidates must be Individual Members of the Node.js Foundation.
-* Candidates must be presenting one of the following presentations:
- * [The Node.js Foundation](https://github.com/nodejs/foundation-slides).
 
 ## Process
 
-New slide decks are added to the list of approved decks on an ongoing basis.
-
-* Slide deck must be managed by the Node.js Evangelism WG.
-* Send a pull request to this file adding the slides to
- the list above.
-* Slide deck must be approved by the TSC.
-
-Any member can apply to give an approved talk. Each request may take up to a month
+Any member can apply for travel funds. Each request may take up to a month
 for the TSC to approve or decline.
 
-* Log an issue in this repository.
+* Open a pull request against this repository which adds an entry to the table at the bottom of this file.
  * Include the name of the event you plan to attend.
  * Include the location of the event and where you will be traveling from.
- * Include the presentation you intend to give.
+ * Include the presentation you intend to give, if applicable.
  * Include the size of the stipend you wish to receive.
-  * Reimbursement stipends are anywhere from $100 to $1,500 USD and vary with travel distance.
+  * Reimbursement stipends are expected to vary with travel distance.
 
 The TSC will consider each proposal in its next regular meeting. While it is
 ultimately at the TSC's discretion who to approve the following considerations
 are made.
 
 * Impact: Preference given to underserved communities. More specifically,
-within a subject the foundation trying to promote awareness about (e.g. general
-knowledge about the foundation) there are people, communities and geographies
-where that knowledge is not very wide spread. This is where preference will
-be given. For instance, an event in San Francisco would be less attractive
-than an event of the same size in Kansas City.
+within a subject the foundation is trying to promote awareness about (e.g.
+general knowledge about the foundation) there are people, communities and
+geographies where that knowledge is not very widespread. This is where
+preference will be given. For instance, an event in San Francisco would be
+less attractive than an event of the same size in Kansas City.
 * Cost: The larger the stipend the more critically the TSC will consider the application.
 Budget for this program is a finite resource.
 * Equity: Preference given to individuals who do not have a corporate travel fund and have
 not previously received a stipend.
+
+Name | Event | Kind of participation | Location | Date | Stipend size
+---- | ----- | --------------------- | -------- | ---- | ------------
+Rich Trott | NINA 2016 | Collaborator Summit and Code & Learn | Austin, TX, US | 29 Nov – 2 Dec 2016 | US$ 2000
+Anna Henningsen | NINA 2016 | Collaborator Summit and Code & Learn | Austin, TX, US | 29 Nov – 2 Dec 2016 | US$ 3000
+Stephen Belanger | NINA 2016 | Collaborator Summit | Austin, TX, US | 1 Dec – 2 Dec 2016 | US$ 800
+Italo A. Casas | NINA 2016 | Collaborator Summit | Austin, TX, US | 1 Dec – 2 Dec 2016 | US$ 800
+Anna Henningsen | TC39 Meeting | Attendance | San Jose, CA, US | 24 Jan – 26 Jan 2017 | US$ 3000


### PR DESCRIPTION
We talked about travel funding at the last TSC meeting with the result that the document on it should be updated and we would want to keep track of all approved requests (and, in particular, their amounts) in a table.

@nodejs/tsc Please take a look and let me know what you think!