### PR TITLE
meta: move the code of conduct into the TSC repository

### DIFF
--- a/BasePolicies/CODE_OF_CONDUCT.md
+++ b/BasePolicies/CODE_OF_CONDUCT.md
@@ -24,4 +24,4 @@ adopt the recommended changes, the TSC may choose to revoke the WGs charter.
 
 The [Node.js Code of Conduct][] applies to this WG.
 
-[Node.js Code of Conduct]: https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md
+[Node.js Code of Conduct]: https://github.com/nodejs/TSC/blob/master/CODE_OF_CONDUCT.md

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,56 @@
+# Code of Conduct
+
+## Conduct
+
+* We are committed to providing a friendly, safe and welcoming
+  environment for all, regardless of level of experience, gender
+  identity and expression, sexual orientation, disability,
+  personal appearance, body size, race, ethnicity, age, religion,
+  nationality, or other similar characteristic.
+* Please avoid using overtly sexual nicknames or other nicknames that
+  might detract from a friendly, safe and welcoming environment for
+  all.
+* Please be kind and courteous. There's no need to be mean or rude.
+* Respect that some individuals and cultures consider the casual use of
+  profanity and sexualized language offensive and off-putting.
+* Respect that people have differences of opinion and that every
+  design or implementation choice carries a trade-off and numerous
+  costs. There is seldom a right answer.
+* Please keep unstructured critique to a minimum. If you have solid
+  ideas you want to experiment with, make a fork and see how it works.
+* We will exclude you from interaction if you insult, demean or harass
+  anyone. That is not welcome behavior. We interpret the term
+  "harassment" as including the definition in the [Citizen Code of
+  Conduct](http://citizencodeofconduct.org/); if you have any lack of
+  clarity about what might be included in that concept, please read
+  their definition. In particular, we don't tolerate behavior that
+  excludes people in socially marginalized groups.
+* Private harassment is also unacceptable. No matter who you are, if
+  you feel you have been or are being harassed or made uncomfortable
+  by a community member, please contact one of the channel ops or any
+  of the TSC members immediately with a capture (log, photo, email) of
+  the harassment if possible. Whether you're a regular contributor or
+  a newcomer, we care about making this community a safe place for you
+  and we've got your back.
+* Likewise any spamming, trolling, flaming, baiting or other
+  attention-stealing behavior is not welcome.
+* Avoid the use of personal pronouns in code comments or
+  documentation. There is no need to address persons when explaining
+  code (e.g. "When the developer").
+
+## Contact
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by:
+
+* Emailing [report@nodejs.org](mailto:report@nodejs.org) (this will email all TSC members)
+* Contacting [individual TSC members](https://nodejs.org/en/foundation/tsc/#current-members-of-the-technical-steering-committee).
+
+## Moderation
+See the TSC's [moderation policy](https://github.com/nodejs/TSC/blob/master/Moderation-Policy.md) for details about moderation.
+
+## Attribution
+
+This Code of Conduct is adapted from [Rust's wonderful
+CoC](http://www.rust-lang.org/conduct.html) as well as the
+[Contributor Covenant v1.3.0](http://contributor-covenant.org/version/1/3/0/).
+

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -41,7 +41,7 @@ Any alternative Moderation Policy used for a given repository must be included i
 
 ### Grounds for Moderation
 
-Any Post considered to be in violation of the [Node.js Code of Conduct](https://GitHub.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md) is subject to Moderation.
+Any Post considered to be in violation of the Node.js [Code of Conduct][] is subject to Moderation.
 
 The TSC is solely responsible for deciding what constitutes inappropriate behavior that may be subject to Moderation (see: [Escalation to the TSC](#escalation-to-the-tsc)).
 
@@ -66,19 +66,19 @@ External public venues or social media services such as Twitter should never be 
 
 Collaborators should never discuss the specific details of a Moderation request in any public forum or any social media service outside of the Node.js GitHub Organization.
 
-Note that quoting the original content of a Post within a Moderation request or nodejs/moderation repository issue is not considered a violation of the Code of Conduct. However, discretion is advised when including such quotes in requests posted to public repositories.
+Note that quoting the original content of a Post within a Moderation request or nodejs/moderation repository issue is not considered a violation of the [Code of Conduct][]. However, discretion is advised when including such quotes in requests posted to public repositories.
 
-Requests for Moderation that do not appear to have been submitted in good faith with intent to address a legitimate Code of Conduct violation, as determined by the TSC, may be ignored.
+Requests for Moderation that do not appear to have been submitted in good faith with intent to address a legitimate [Code of Conduct][] violation, as determined by the TSC, may be ignored.
 
 ### Consideration of Intent
 
-Before Moderating a Post, Collaborators should carefully consider the possible intent of the author. It may be that the author has simply made an error or is not yet familiar with the [Code of Conduct](https://GitHub.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md); or it may be that cultural differences exist, or that the author is unaware that certain content is considered inappropriate. In such cases, the author should be given an opportunity to correct any error that may have been made.
+Before Moderating a Post, Collaborators should carefully consider the possible intent of the author. It may be that the author has simply made an error or is not yet familiar with the [Code of Conduct][]; or it may be that cultural differences exist, or that the author is unaware that certain content is considered inappropriate. In such cases, the author should be given an opportunity to correct any error that may have been made.
 
-Note, however, that unfamiliarity with the [Code of Conduct](https://GitHub.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md) does not excuse a Post from Moderation.
+Note, however, that unfamiliarity with the [Code of Conduct][] does not excuse a Post from Moderation.
 
 ### Guidelines and Requirements
 
-* All Posts are expected to respect the [Node.js Code of Conduct](https://GitHub.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md).
+* All Posts are expected to respect the Node.js [Code of Conduct][].
 * Only Collaborators with commit rights to a given repository may Moderate Posts within that repository's issue tracker.
 * The TSC serves as the final arbiter for all Moderation issues (see: [Escalation to the TSC](#escalation-to-the-tsc)).
 * Only a TSC member may Remove or Ban an individual from the Node.js GitHub Organization.
@@ -90,7 +90,7 @@ Note, however, that unfamiliarity with the [Code of Conduct](https://GitHub.com/
 
 * Collaborators must not Moderate any Post authored by another Collaborator without first giving the author at least 24 hours (from the time of the initial request) to modify or remove the Post on their own.
 * If the author of the Post disagrees that Moderation is required, the matter can be [escalated to the TSC](#escalation-to-the-tsc) for resolution. In such cases, no Moderation action should be taken until a decision by the TSC is made.
-* In extreme circumstances involving either obvious gross violations of the [Node.js Code of Conduct](https://GitHub.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md) or possible compromise of a Collaborator's GitHub account, the TSC can be consulted to waive the 24 hour grace period and dispute process.
+* In extreme circumstances involving either obvious gross violations of the Node.js [Code of Conduct][] or possible compromise of a Collaborator's GitHub account, the TSC can be consulted to waive the 24 hour grace period and dispute process.
 * When Moderating any Post authored by another Collaborator, the moderating Collaborator must:
  * Explain the justification for Moderating the post,
  * Identify all changes made to the Post, and
@@ -102,7 +102,7 @@ Note, however, that unfamiliarity with the [Code of Conduct](https://GitHub.com/
 
 #### Non-Collaborator Posts
 
-* Posts authored by non-Collaborators are always subject to immediate Moderation by any Collaborator if the content is intentionally disruptive or in violation of the [Node.js Code of Conduct](https://GitHub.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md).
+* Posts authored by non-Collaborators are always subject to immediate Moderation by any Collaborator if the content is intentionally disruptive or in violation of the [Code of Conduct][].
 * When Moderating non-Collaborator Posts, the moderating Collaborator should:
  * Explain the justification for Moderating the post, and
  * Identify all changes made to the Post.
@@ -138,3 +138,5 @@ For any Moderation issue that does not directly involve a TSC member, the TSC ma
 ### Modifications to This Policy
 
 Modifications to this policy are made through normal [TSC motion and vote](https://GitHub.com/nodejs/TSC/blob/master/TSC-Charter.md#section-8-voting). Any Collaborator may submit a PR proposing changes to this policy. Those PRs must be labeled using the `tsc-agenda` label. Including a mention to `@nodejs/tsc` can be used to call the issue to TSC's attention.
+
+[Code of Conduct]: https://GitHub.com/nodejs/TSC/blob/master/CODE_OF_CONDUCT.md

--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -263,6 +263,6 @@ The [Node.js Moderation Policy] applies to this WG.
 
 The [Node.js Code of Conduct][] applies to this WG.
 
-[Node.js Code of Conduct]: https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md
+[Node.js Code of Conduct]: https://github.com/nodejs/TSC/blob/master/CODE_OF_CONDUCT.md
 [Node.js Moderation Policy]: https://github.com/nodejs/TSC/blob/master/Moderation-Policy.md
 ```


### PR DESCRIPTION
@nodejs/tsc ... per the discussion and decision at the last TSC call...

Refs: https://github.com/nodejs/TSC/issues/224