### PR TITLE
Add Travel Fund request for calvinmetcalf/collab summit Berlin 2017

### DIFF
--- a/Member-Travel-Fund.md
+++ b/Member-Travel-Fund.md
@@ -43,3 +43,4 @@ Anna Henningsen | NINA 2016 | Collaborator Summit and Code & Learn | Austin, TX,
 Stephen Belanger | NINA 2016 | Collaborator Summit | Austin, TX, US | 1 Dec – 2 Dec 2016 | US$ 800
 Italo A. Casas | NINA 2016 | Collaborator Summit | Austin, TX, US | 1 Dec – 2 Dec 2016 | US$ 644
 Anna Henningsen | TC39 Meeting | Attendance | San Jose, CA, US | 24 Jan – 26 Jan 2017 | US$ 1048
+Calvin Metcalf | Collaborator Summit | Attendance | Berlin, DE | 4 May – 5 May 2017 | US$ 600


### PR DESCRIPTION
Event: Collaborator Summit adjacent to JSConf EU
Location: Berlin, Germany
Amount: USD$ 600

Moved from #234 
> The @nodejs/streams wg face to face to hammer out some of the longer term issues with streams is the primary reason I'd like to be able to go. I work for a small company and while they couldn't cover all of this, they may be able to cover the difference if I only get partial funding.