### PR TITLE
Travel Fund request for bengl @ Code & Learn @ JSConf.cn 2017

### DIFF
--- a/Member-Travel-Fund.md
+++ b/Member-Travel-Fund.md
@@ -48,3 +48,4 @@ Anna Henningsen | Collaborator Summit | Attendance | Berlin, DE | 4 May – 5 Ma
 Santiago Gimeno | Collaborator Summit | Attendance | Berlin, DE | 4 May – 5 May 2017 | US$ 160
 Calvin Metcalf | Collaborator Summit | Attendance | Berlin, DE | 4 May – 5 May 2017 | US$ 600
 Никита Сковорода | Collaborator Summit | Attendance | Berlin, DE | 4 May – 5 May 2017 | €573
+Bryan English | JSConf.cn 2017 | Code & Learn Mentor | Shanghai, CN | 15 July - 16 July 2017 | $1100


### PR DESCRIPTION
Event: Code & Learn event at JSConf.cn 2017
Location: Shanghai, China
From: San Francisco, USA
Amount: US$ 1200

I'd like to reprise my role as a mentor at [Code & Learn at JSConf.cn 2017](https://github.com/nodejs/code-and-learn/issues/68), but my employer is not in a position to cover the travel costs. The amount is an estimate of flights, hotel and visa fees.