### PR TITLE
Coordinate travel fund across project committees

### DIFF
--- a/Member-Travel-Fund.md
+++ b/Member-Travel-Fund.md
@@ -1,29 +1,46 @@
 ## Purpose
 
 To establish and administer a fund for members of the Node.js
-Foundation to travel and spread knowledge about and support the foundation
-and the Node.js Foundation projects.
+Foundation to travel, spread knowledge about, and support the Node.js 
+Foundation projects.
 
 ## Restrictions
 
 * Candidates must be Individual Members of the Node.js Foundation.
 
+### Travel Fund Administrators
+
+Members of both the TSC and CommComm are responsible for approving fund requests
+and communicating approval/denial through the PR filed by the member requesting. 
+
+Travel fund admins will consider each proposal tagged for their respective group 
+in its next regular meeting. Requests tagged for both committees must be coordinated 
+and communicated together by the Chair of each. See considerations below to set 
+yourself up for success to be approved.
+
+Linux Foundation Accounts Payable and the Node.js community manager are responsible for 
+verifying the requester is an Individual Member of the Node.js Foundation and dispersing funds,
+as required to receive funds(see Reimbursement below).
+
 ## Process
 
 Any member can apply for travel funds. Each request may take up to a month
-for the TSC to approve or decline.
+for the travel fund administrators to approve or decline.
 
+### Request
 * Open a pull request against this repository which adds an entry to the table at the bottom of this file.
  * Include the name of the event you plan to attend.
  * Include the location of the event and where you will be traveling from.
  * Include the presentation you intend to give, if applicable.
  * Include the size of the stipend you wish to receive.
   * Reimbursement stipends are expected to vary with travel distance.
+  * In the PR description, tag the group relevant to the request: @nodejs/tsc or @nodejs/commcomm-members. If unsure, include both.
 * Once the final amount spent is known, update the table again with that information.
 
-The TSC will consider each proposal in its next regular meeting. While it is
-ultimately at the TSC's discretion who to approve the following considerations
-are made.
+### Reimbursement
+Once the request has been approved, provide receipts as attachments in an email stating your name, the participation covered, and the total approved for reimbursement. Send to ap@linuxfoundation.org and cc tracyhinds@linuxfoundation.org with subject ```Node.js Member Travel Fund```. Due to privacy, the Individual Members list is not public. This team will verify the requester is on the Individual Members list before funds are dispersed. This dispersement is generally processed within 30 days. 
+
+**The following considerations are made for approval of the request:**
 
 * Impact: Preference given to underserved communities. More specifically,
 within a subject the foundation is trying to promote awareness about (e.g.
@@ -31,11 +48,14 @@ general knowledge about the foundation) there are people, communities and
 geographies where that knowledge is not very widespread. This is where
 preference will be given. For instance, an event in San Francisco would be
 less attractive than an event of the same size in Kansas City.
-* Cost: The larger the stipend the more critically the TSC will consider the application.
-Budget for this program is a finite resource.
+* Cost: The larger the stipend the more critically the travel fund admins will 
+consider the application. Budget for this program is a finite resource.
 * Equity: Preference given to individuals who do not have a corporate travel fund and have
 not previously received a stipend.
 
+Examples of prior travel requests include attending a TC39 meeting, Collab Summit, and Code + Learn mentoring.
+
+## 2017 Approved Travel Requests  
 Name | Event | Kind of participation | Location | Date | Stipend size
 ---- | ----- | --------------------- | -------- | ---- | ------------
 Rich Trott | NINA 2016 | Collaborator Summit and Code & Learn | Austin, TX, US | 29 Nov – 2 Dec 2016 | US$ 2000

--- a/Member-Travel-Fund.md
+++ b/Member-Travel-Fund.md
@@ -14,13 +14,14 @@ Members of both the TSC and CommComm are responsible for approving fund requests
 and communicating approval/denial through the PR filed by the member requesting. 
 
 Travel fund admins will consider each proposal tagged for their respective group 
-in its next regular meeting. Requests tagged for both committees must be coordinated 
-and communicated together by the Chair of each. See considerations below to set 
-yourself up for success to be approved.
+in its next regular meeting. Requests tagged for both committees must be reviewed 
+and given opportunity to objection through lazy consensus by both groups and 
+communicated together by the two chairs. See considerations below to set yourself 
+up for success to be approved. 
 
 Linux Foundation Accounts Payable and the Node.js community manager are responsible for 
 verifying the requester is an Individual Member of the Node.js Foundation and dispersing funds,
-as required to receive funds(see Reimbursement below).
+as required to receive funds (see Reimbursement below).
 
 ## Process
 
@@ -34,11 +35,13 @@ for the travel fund administrators to approve or decline.
  * Include the presentation you intend to give, if applicable.
  * Include the size of the stipend you wish to receive.
   * Reimbursement stipends are expected to vary with travel distance.
-  * In the PR description, tag the group relevant to the request: @nodejs/tsc or @nodejs/commcomm-members. If unsure, include both.
+  * In the PR description, tag the group relevant to the request: @nodejs/tsc or @nodejs/commcomm-members. 
+  If unsure, just pick one, and that group will tag with the other group if they believe it is more appropriate.
 * Once the final amount spent is known, update the table again with that information.
 
 ### Reimbursement
-Once the request has been approved, provide receipts as attachments in an email stating your name, the participation covered, and the total approved for reimbursement. Send to ap@linuxfoundation.org and cc tracyhinds@linuxfoundation.org with subject ```Node.js Member Travel Fund```. Due to privacy, the Individual Members list is not public. This team will verify the requester is on the Individual Members list before funds are dispersed. This dispersement is generally processed within 30 days. 
+  
+Once the request has been approved, provide receipts as attachments in an email stating your name, the participation covered, and the total approved for reimbursement. Send to ap@linuxfoundation.org and cc tracyhinds@linuxfoundation.org with subject `Node.js Member Travel Fund`. Due to privacy, the Individual Members list is not public. This team will verify the requester is on the Individual Members list before funds are dispersed. This dispersement is generally processed within 30 days. The community manager or a member of the Node.js Foundation team within the Linux Foundation will report back amounts consumed from the travel allocation on a monthly basis to the Chairs.
 
 **The following considerations are made for approval of the request:**
 
@@ -55,7 +58,8 @@ not previously received a stipend.
 
 Examples of prior travel requests include attending a TC39 meeting, Collab Summit, and Code + Learn mentoring.
 
-## 2017 Approved Travel Requests  
+## 2017 Approved Travel Requests 
+  
 Name | Event | Kind of participation | Location | Date | Stipend size
 ---- | ----- | --------------------- | -------- | ---- | ------------
 Rich Trott | NINA 2016 | Collaborator Summit and Code & Learn | Austin, TX, US | 29 Nov – 2 Dec 2016 | US$ 2000


### PR DESCRIPTION
Per conversations with the Board upon requests for an additional allocation to the TSC Travel Fund and a new fund being created for CommComm because the scope may be different, the Board asked that the top-level committees move forward with coordinating a joint fund. This PR lays out the minimal changes I believe is necessary to establish the joint fund. Once merged, we will approach the Board with the new joint allocation request for the remainder of 2017. 

### Specific asks to prepare for the travel fund request:
- New allocation $$ amount(TSC amount that needs to be with updated for money spent in the last 2 months and CommComm amount combined)
- Scope of fund–it needs to cover all needs of the project. It currently covers Individual Members. 
- Document coordination and process of admins

**Future to-do for this work:**
- Will also open a new issue for a joint repo(collaboration repurposed? or an admin repo) for this type of work but should not be a blocker in the short term to coordinating efforts.

cc @nodejs/tsc @nodejs/commcomm-members 
