### PR TITLE
Specify location of moderation guidelines

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -65,6 +65,10 @@ Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
 members of the project's leadership.
 
+To learn more about the process of how moderators enforce the Code of Conduct, 
+review the [Moderation Policy](https://github.com/nodejs/TSC/blob/master/Moderation-Policy.md#moderation-policy)
+and [Requesting Moderation](https://github.com/nodejs/TSC/blob/master/Moderation-Policy.md#requesting-moderation).
+
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -66,8 +66,10 @@ faith may face temporary or permanent repercussions as determined by other
 members of the project's leadership.
 
 To learn more about the process of how moderators enforce the Code of Conduct, 
-review the [Moderation Policy](https://github.com/nodejs/TSC/blob/master/Moderation-Policy.md#moderation-policy)
-and [Requesting Moderation](https://github.com/nodejs/TSC/blob/master/Moderation-Policy.md#requesting-moderation).
+review the [Moderation Policy] and [Requesting Moderation].
+
+[Moderation Policy]: https://github.com/nodejs/TSC/blob/master/Moderation-Policy.md#moderation-policy
+[Requesting Moderation]: https://github.com/nodejs/TSC/blob/master/Moderation-Policy.md#requesting-moderation
 
 ## Attribution
 


### PR DESCRIPTION
Many who are looking for a Code of Conduct are often doing so because they've experienced an incident they are considering reporting and they need to see what the process is to do so. Since CODE_OF_CONDUCT.MD is something folks know to look for across projects, but moderation-policy.md is not as much, I've added a little copy and link to this so the process can be found a little easier. 