### PR TITLE
charter: add TSC membership terms, mandatory mediation, and removal requirements

### DIFF
--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -220,12 +220,6 @@ overturn or vacate the decision of the TSC, the Board may issue a statement
 requesting that the TSC revisit the decision and recommend that the matter be
 referred to a Foundation appointed third party mediator for arbitration.
 
-All decisions regarding removal of TSC members is subject to review by the body
-of Node.js collaborators. Should no fewer than one-quarter of the current
-Node.js project Collaborators (as defined by the TSC's governance and
-contribution policies) disagree with the TSC vote, the matter shall be referred
-to a Foundation appointed third party mediator for arbitration. 
-
 Once referred to arbitration, the decision of the mediator will be considered
 final and binding on all parties.
 

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -36,10 +36,12 @@ approved by the Board.
 
 ## Section 4. Establishment of the TSC.
 
-TSC memberships are for one year terms that must be recertified by a simple
-majority of TSC members every year. Recertified members will continue through
-the next years term. Members failing recertification may return to the TSC
-after no less than six months following normal TSC motion.
+TSC memberships are for one year terms that must be recertified. Motions for
+recertification are automatic and require a vote. Members are recertified if a
+simple majority of TSC members vote in favor of recertifying the individual as
+a TSC member. Such members will continue through the next years term.
+Individuals failing recertification may return to the TSC after no less than
+six months following normal TSC motion.
 
 There is no maximum size of the TSC. The size is expected to vary in order to
 ensure adequate coverage of important areas of expertise, balanced with the
@@ -184,6 +186,11 @@ discussion will continue.
 
 For all votes, a simple majority of all TSC members for, or against, the issue
 wins. A TSC member may choose to participate in any vote through abstention.
+
+While the results of all votes must be made public, the actual individual
+ballots cast for most votes may be made public or confidential at the discretion
+of the TSC Chair. However, individual ballots for recertification or removal of
+TSC members must remain confidential.
 
 Note that, in addition to requiring a simple majority vote of the TSC, all
 changes to this charter are also subject to approval from the Node.js

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -36,10 +36,10 @@ approved by the Board.
 
 ## Section 4. Establishment of the TSC.
 
-TSC memberships are limited to 2 consecutive year periods. An individual
-members term starts at 12am GMT the day after their nomination to the TSC
-is approved and ends precisely two years later. Individuals may be nominated
-to the TSC multiple times but at least one year must pass between terms.
+TSC memberships are for one year terms that must be recertified by a simple
+majority of TSC members every year. Recertified members will continue through
+the next years term. Members failing recertification may return to the TSC
+after no less than six months following normal TSC motion.
 
 There is no maximum size of the TSC. The size is expected to vary in order to
 ensure adequate coverage of important areas of expertise, balanced with the

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -191,7 +191,8 @@ While the results of all votes must be made public, the actual individual
 ballots cast for most votes may be made public or confidential at the discretion
 of the TSC Chair. However, individual ballots for recertification or removal of
 TSC members must remain confidential. The names of members voting or abstaining
-in all votes must be made public.
+in all votes must be made public with a clear indication given of whether the
+individual voted or abstained.
 
 Following the completion of all votes, a public statement must be made via
 GitHub specifying the results of the vote. Contextual detail about why the
@@ -227,30 +228,28 @@ shall participate in the vote and the remaining members of the TSC may meet or
 discuss the issue privately without the member in question present.
 
 Should a vote to remove a member result in a tie (50%/50% split of non
-abstaining participants) the matter shall be referred to a Node.js Foundation
+abstaining participants) the matter shall be referred to a Foundation
 appointed independent third party mediator for arbitration.
 
 At any point during this process, the individual member in question, the
 individuals opening the request, or the TSC Chair may request that the issue
-be referred to a Node.js Foundation appointed third party mediator for
+be referred to a Foundation appointed third party mediator for
 arbitration.
 
 All decisions regarding removal of TSC members is subject to review by the
-Node.js Foundation Board. Should the Board decide to vacate the TSC vote, the
-matter shall be referred to a Node.js Foundation appointed third party mediator
-for arbitration.
+Node.js Foundation Board. While the Board will not have the ability to
+overturn or vacate the decision of the TSC, the Board may issue a statement
+requesting that the TSC revisit the decision and recommend that the matter be
+referred to a Foundation appointed third party mediator for arbitration.
 
 All decisions regarding removal of TSC members is subject to review by the body
 of Node.js collaborators. Should no fewer than one-quarter of the current
 Node.js project Collaborators (as defined by the TSC's governance and
 contribution policies) disagree with the TSC vote, the matter shall be referred
-to a Node.js Foundation appointed third party mediator for arbitration. 
+to a Foundation appointed third party mediator for arbitration. 
 
 Once referred to arbitration, the decision of the mediator will be considered
 final and binding on all parties.
-
-The third party mediator selected must not be a member of either the TSC,
-Node.js Community Committee, or Node.js Foundation Board of Directors.
 
 ## Section 9. Project Roles
 
@@ -295,12 +294,18 @@ that is established by the TSC. The TSC is required to establish a policy
 for the enforcement of Code of Conduct issues. Any reports of Code of Conduct
 or policy violations on the part of TSC members that are not resolvable through
 that established policy will be referred to binding, independent third party
-mediation under the oversight of the Node.js Foundation Board. All TSC members,
-upon acceptance of their nomination to the TSC body, voluntarily agree to abide
-by the decisions of the independent third party mediator.
+arbitration with a Foundation appointed mediator All TSC members, upon
+acceptance of their nomination to the TSC body, voluntarily agree to abide by
+the decisions of the independent third party mediator.
 
-The third party mediator selected must not be a member of either the TSC,
-Node.js Community Committee, or Node.js Foundation Board of Directors.
+## Section 12: Selection of Mediators
+
+When it becomes necessary within the context of this charter to select a
+third party mediator for arbitration, the mediator shall be selected by the
+Node.js Foundation Board of Directors (or an individual designated by the Board
+to so act on their behalf). The only requirement for this mediator is that the
+individual selected must not be a member of the TSC, Node.js Community
+Committee, or Node.js Foundation Board of Directors.
 
 [Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making
 [Condorcet]: http://en.wikipedia.org/wiki/Condorcet_method

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -39,7 +39,7 @@ approved by the Board.
 TSC memberships are for one year terms that must be recertified. Motions for
 recertification are automatic and require a vote. Members are recertified if a
 simple majority of TSC members vote in favor of recertifying the individual as
-a TSC member. Such members will continue through the next years term.
+a TSC member. Such members will continue through the next year's term.
 Individuals failing recertification may return to the TSC after no less than
 six months following normal TSC motion.
 

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -205,20 +205,21 @@ Foundation board.
 
 ### Votes to Remove Members
 
-Should a vote to remove a member result in a tie (50%/50% split of non
-abstaining participants) the matter shall be referred to a Foundation
-appointed independent third party mediator for arbitration.
+Should a situation arise that considers the removal of a TSC member, an
+attempt should first be made to resolve the issue without requiring a vote.
+The TSC Chair may, at their discretion, request that the issue be referred
+to a Foundation appointed third-party mediator for arbitration.
 
-At any point prior to calling for a vote, the individual member in question, the
-individuals opening the request, or the TSC Chair may request that the issue
-be referred to a Foundation appointed third party mediator for
-arbitration.
+Failing all other possible resolutions, a simple majority vote of TSC members
+is required to remove a member. Should such a vote to result in a tie (50%/50%
+split of non-abstaining participants) the matter shall be referred to a
+Foundation appointed independent third-party mediator for arbitration.
 
-All decisions regarding removal of TSC members is subject to review by the
-Node.js Foundation Board. While the Board will not have the ability to
-overturn or vacate the decision of the TSC, the Board may issue a statement
+All decisions regarding removal of TSC members will be subject to review by
+the Node.js Foundation Board. While the Board will not have the ability to
+overturn or vacate the decisions of the TSC, the Board may issue a statement
 requesting that the TSC revisit the decision and recommend that the matter be
-referred to a Foundation appointed third party mediator for arbitration.
+referred to a Foundation appointed third-party mediator for arbitration.
 
 Once referred to arbitration, the decision of the mediator will be considered
 final and binding on all parties.
@@ -265,12 +266,25 @@ Participation in the Node.js project is governed by a Code of Conduct policy
 that is established by the TSC. The TSC is required to establish a policy
 for the enforcement of Code of Conduct issues. Any reports of Code of Conduct
 or policy violations on the part of TSC members that are not resolvable through
-that established policy will be referred to binding, independent third party
+that established policy will be referred to binding, independent third-party
 arbitration with a Foundation appointed mediator. All TSC members, upon
 acceptance of their nomination to the TSC body, voluntarily agree to abide by
-the decisions of the independent third party mediator.
+the decisions of the independent third-party mediator.
 
-## Section 12: Selection of Mediators
+## Section 12: Leaves of Absence and Temporary Suspension of TSC Membership
+
+TSC Members may voluntarily temporarily suspend their memberships in the TSC
+for any period of time not in excess of twelve months. In such cases, the member
+may return to full TSC membership status at any time.
+
+TSC Members may have their memberships involuntarily suspended by a simple
+majority vote of the other TSC members for any period of time not in excess of
+twelve months. The suspension period must be specified in advance of the
+decision. The members privileges as a TSC member will be restored automatically
+after the given period has passed. The TSC may decide, through simple majority
+vote, to lift the suspension early.
+
+## Section 13: Selection of Mediators
 
 When it becomes necessary within the context of this charter to select a
 third party mediator for arbitration, a qualified mediator shall be selected by

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -228,11 +228,13 @@ represent the Core Project on the TSC.
 ## Section 11. Escalation of Disputes and Code of Conduct Violations
 
 Participation in the Node.js project is governed by a Code of Conduct policy
-that is established by the TSC. Any accusations of Code of Conduct or policy
-violations on the part of TSC members will be referred to binding, independent
-third party mediation under the oversight of the Node.js Foundation Board. All
-TSC members, upon acceptance of their nomination to the TSC body, voluntarily
-agree to abide by the decisions of the independent third party mediator.
+that is established by the TSC. The TSC is required to established a policy
+for the enforcement of Code of Conduct issues. Any reports of Code of Conduct
+or policy violations on the part of TSC members that are not resolvable through
+that established policy will be referred to binding, independent third party
+mediation under the oversight of the Node.js Foundation Board. All TSC members,
+upon acceptance of their nomination to the TSC body, voluntarily agree to abide
+by the decisions of the independent third party mediator.
 
 [Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making
 [Condorcet]: http://en.wikipedia.org/wiki/Condorcet_method

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -205,28 +205,6 @@ Foundation board.
 
 ### Votes to Remove Members
 
-Requests to remove a member from the TSC may be raised only by other members of
-the TSC or by members of the Node.js Foundation Board. When an issue to remove
-someone from the TSC is raised, the issue must include a list of the specific
-issues the TSC is being asked to consider as grounds for removal. The discussion
-and vote will be limited strictly to considering of the specific issues listed
-in the issue. The issue must also include a description of what outcome those
-reporting the issue expect.
-
-The vote must be structured in terms of whether or not the specific issues
-listed constitute grounds for removal.
-
-When votes to remove individuals from the TSC are scheduled, the member in
-question is to be notified about the vote in advance along with adequate
-contextual details of why the vote is taking place, what, if any, specific
-complaints are being leveled, and the specific questions that the members are
-being asked to consider. The member in question shall be given no less than one
-week before the vote to provide an answer or rebuttal to those issues.
-
-Neither the member in question, nor the member or members raising the issue
-shall participate in the vote and the remaining members of the TSC may meet or
-discuss the issue privately without the member in question present.
-
 Should a vote to remove a member result in a tie (50%/50% split of non
 abstaining participants) the matter shall be referred to a Foundation
 appointed independent third party mediator for arbitration.
@@ -301,11 +279,11 @@ the decisions of the independent third party mediator.
 ## Section 12: Selection of Mediators
 
 When it becomes necessary within the context of this charter to select a
-third party mediator for arbitration, the mediator shall be selected by the
-Node.js Foundation Board of Directors (or an individual designated by the Board
-to so act on their behalf). The only requirement for this mediator is that the
-individual selected must not be a member of the TSC, Node.js Community
-Committee, or Node.js Foundation Board of Directors.
+third party mediator for arbitration, a qualified mediator shall be selected by
+the Node.js Foundation Board of Directors (or an individual designated by the
+Board to so act on their behalf). The mediator should be trained and qualified
+in mediation/conflict resolution and must not be a member of the TSC, Node.js
+Community Committee, or Node.js Foundation Board of Directors.
 
 [Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making
 [Condorcet]: http://en.wikipedia.org/wiki/Condorcet_method

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -190,11 +190,67 @@ wins. A TSC member may choose to participate in any vote through abstention.
 While the results of all votes must be made public, the actual individual
 ballots cast for most votes may be made public or confidential at the discretion
 of the TSC Chair. However, individual ballots for recertification or removal of
-TSC members must remain confidential.
+TSC members must remain confidential. The names of members voting or abstaining
+in all votes must be made public.
+
+Following the completion of all votes, a public statement must be made via
+GitHub specifying the results of the vote. Contextual detail about why the
+vote was held, including a listing of the specific questions voted on must be
+included in the statement.
 
 Note that, in addition to requiring a simple majority vote of the TSC, all
 changes to this charter are also subject to approval from the Node.js
 Foundation board.
+
+### Votes to Remove Members
+
+Requests to remove a member from the TSC may be raised only by other members of
+the TSC or by members of the Node.js Foundation Board. When an issue to remove
+someone from the TSC is raised, the issue must include a list of the specific
+issues the TSC is being asked to consider as grounds for removal. The discussion
+and vote will be limited strictly to considering of the specific issues listed
+in the issue. The issue must also include a description of what outcome those
+reporting the issue expect.
+
+The vote must be structured in terms of whether or not the specific issues
+listed constitute grounds for removal.
+
+When votes to remove individuals from the TSC are scheduled, the member in
+question is to be notified about the vote in advance along with adequate
+contextual details of why the vote is taking place, what, if any, specific
+complaints are being leveled, and the specific questions that the members are
+being asked to consider. The member in question shall be given no less than one
+week before the vote to provide an answer or rebuttal to those issues.
+
+Neither the member in question, nor the member or members raising the issue
+shall participate in the vote and the remaining members of the TSC may meet or
+discuss the issue privately without the member in question present.
+
+Should a vote to remove a member result in a tie (50%/50% split of non
+abstaining participants) the matter shall be referred to a Node.js Foundation
+appointed independent third party mediator for arbitration.
+
+At any point during this process, the individual member in question, the
+individuals opening the request, or the TSC Chair may request that the issue
+be referred to a Node.js Foundation appointed third party mediator for
+arbitration.
+
+All decisions regarding removal of TSC members is subject to review by the
+Node.js Foundation Board. Should the Board decide to vacate the TSC vote, the
+matter shall be referred to a Node.js Foundation appointed third party mediator
+for arbitration.
+
+All decisions regarding removal of TSC members is subject to review by the body
+of Node.js collaborators. Should no fewer than one-quarter of the current
+Node.js project Collaborators (as defined by the TSC's governance and
+contribution policies) disagree with the TSC vote, the matter shall be referred
+to a Node.js Foundation appointed third party mediator for arbitration. 
+
+Once referred to arbitration, the decision of the mediator will be considered
+final and binding on all parties.
+
+The third party mediator selected must not be a member of either the TSC,
+Node.js Community Committee, or Node.js Foundation Board of Directors.
 
 ## Section 9. Project Roles
 
@@ -242,6 +298,9 @@ that established policy will be referred to binding, independent third party
 mediation under the oversight of the Node.js Foundation Board. All TSC members,
 upon acceptance of their nomination to the TSC body, voluntarily agree to abide
 by the decisions of the independent third party mediator.
+
+The third party mediator selected must not be a member of either the TSC,
+Node.js Community Committee, or Node.js Foundation Board of Directors.
 
 [Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making
 [Condorcet]: http://en.wikipedia.org/wiki/Condorcet_method

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -228,7 +228,7 @@ represent the Core Project on the TSC.
 ## Section 11. Escalation of Disputes and Code of Conduct Violations
 
 Participation in the Node.js project is governed by a Code of Conduct policy
-that is established by the TSC. The TSC is required to established a policy
+that is established by the TSC. The TSC is required to establish a policy
 for the enforcement of Code of Conduct issues. Any reports of Code of Conduct
 or policy violations on the part of TSC members that are not resolvable through
 that established policy will be referred to binding, independent third party

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -266,7 +266,7 @@ that is established by the TSC. The TSC is required to establish a policy
 for the enforcement of Code of Conduct issues. Any reports of Code of Conduct
 or policy violations on the part of TSC members that are not resolvable through
 that established policy will be referred to binding, independent third party
-arbitration with a Foundation appointed mediator All TSC members, upon
+arbitration with a Foundation appointed mediator. All TSC members, upon
 acceptance of their nomination to the TSC body, voluntarily agree to abide by
 the decisions of the independent third party mediator.
 

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -36,16 +36,25 @@ approved by the Board.
 
 ## Section 4. Establishment of the TSC.
 
-TSC memberships are not time-limited. There is no maximum size of the TSC.
-The size is expected to vary in order to ensure adequate coverage of important
-areas of expertise, balanced with the ability to make decisions efficiently.
-The TSC must have at least three members.
+TSC memberships are limited to 2 consecutive year periods. An individual
+members term starts at 12am GMT the day after their nomination to the TSC
+is approved and ends precisely two years later. Individuals may be nominated
+to the TSC multiple times but at least one year must pass between terms.
+
+There is no maximum size of the TSC. The size is expected to vary in order to
+ensure adequate coverage of important areas of expertise, balanced with the
+ability to make decisions efficiently. The TSC must have at least three members.
+
+Individuals nominated to the TSC must be members of at least one Node.js
+Working Group at the time of their nomination and must maintain active
+participation in at least one Working Group throughout their term.
 
 There is no specific set of requirements or qualifications for TSC
-membership beyond these rules. The TSC may add additional members to the
-TSC by a standard TSC motion and vote. A TSC member may be removed from the
-TSC by voluntary resignation, by a standard TSC motion, or in accordance to the
-participation rules described below.
+membership beyond these rules.
+
+The TSC may add additional members to the TSC by a standard TSC motion and vote.
+A TSC member may be removed from the TSC by voluntary resignation, by a standard
+TSC motion, or in accordance to the participation rules described below.
 
 Changes to TSC membership should be posted in the agenda, and may be suggested
 as any other agenda item.
@@ -215,6 +224,15 @@ TSC.
 
 * **Maintainer**: a Collaborator within a Core Project elected to
 represent the Core Project on the TSC.
+
+## Section 11. Escalation of Disputes and Code of Conduct Violations
+
+Participation in the Node.js project is governed by a Code of Conduct policy
+that is established by the TSC. Any accusations of Code of Conduct or policy
+violations on the part of TSC members will be referred to binding, independent
+third party mediation under the oversight of the Node.js Foundation Board. All
+TSC members, upon acceptance of their nomination to the TSC body, voluntarily
+agree to abide by the decisions of the independent third party mediator.
 
 [Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making
 [Condorcet]: http://en.wikipedia.org/wiki/Condorcet_method

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -209,7 +209,7 @@ Should a vote to remove a member result in a tie (50%/50% split of non
 abstaining participants) the matter shall be referred to a Foundation
 appointed independent third party mediator for arbitration.
 
-At any point during this process, the individual member in question, the
+At any point prior to calling for a vote, the individual member in question, the
 individuals opening the request, or the TSC Chair may request that the issue
 be referred to a Foundation appointed third party mediator for
 arbitration.

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -48,8 +48,8 @@ ensure adequate coverage of important areas of expertise, balanced with the
 ability to make decisions efficiently. The TSC must have at least three members.
 
 Individuals nominated to the TSC must be members of at least one Node.js
-Working Group at the time of their nomination and must maintain active
-participation in at least one Working Group throughout their term.
+Working Group or Team at the time of their nomination and must maintain active
+participation in at least one Working Group or Team throughout their term.
 
 There is no specific set of requirements or qualifications for TSC
 membership beyond these rules.


### PR DESCRIPTION
This PR proposes a change to the TSC Charter. It would need to be approved by the TSC and the Node.js Foundation Board.

Specifically, this introduces a couple of changes:

* 1 year terms for TSC members that must be recertified each year by a simple majority of the TSC peers.

* Adds a requirement that TSC members must maintain participation in at least one chartered working group or team through their term

* Adds mandatory independent, binding third-party mediation under the oversight of the Node.js Foundation Board should any TSC member be reported for a Code of Conduct or Policy violation.

@nodejs/tsc @nodejs/ctc @hackygolucky 