### PR TITLE
doc: expections on leadership committees

### DIFF
--- a/MemberExpectations.md
+++ b/MemberExpectations.md
@@ -3,11 +3,12 @@ in a way that not only complies with the
 [Code of Conduct](https://github.com/nodejs/TSC/blob/master/CODE_OF_CONDUCT.md)
 but that supports the vision, mission and operating principles of the Node.js project.
 
-Members are encouraged to have individual opinions and are encouraged
+It is understood that members will have individual opinions and are encouraged
 to express those opinions during discussions within the organization. While
 discourse is encouraged internally, members also have the obligation outside
 of the organization (for example in social media) to be respectful of the
-decisions made within the projects's documented processes.  A member who does
+decisions made within the projects's documented processes even (and especially)
+if the results run counter to their person point of view.  A member who does
 not support a team decision or current team value may express the member's
 opposition within the team in an appropriate manner, but must be extremely
 careful when expressing the opinion externally.  External communication must
@@ -16,13 +17,11 @@ actions of the team. If another team member expresses that they believe external
 communications appear to have the intent to undermine the committee
 it is the responsibility of the individual expressing their opinions to rectify
 the situation immediately. If a member feels that there is no recourse aside
-from going public regarding an extremely contentious issue then they should
-resign from the team before doing so.
+from going public to campain against the teams decision on an extremely
+contentious issue then they should resign from the team before doing so.
 
-In addition to being willing to act as a team player, members of our
-leadership groups must conduct themselves in a professional and
-respectful manner. Some general
-guidelines include:
+Members of our leadership groups must also conduct themselves in a
+professional and respectful manner. Some general guidelines include:
 
 - Serve as ambassadors of the vision, mission and operating
   principles of the Node.js project.
@@ -41,7 +40,7 @@ guidelines include:
   set of standards.  Everyone gets to speak up. 
 - Deal with issues directly with the person in question. Resist complaining
   about others in the project in a public sphere.
-- Built trust by keeping your promises.
+- Build trust by keeping your promises.
 - Be the model of accountability and leadership. Provide the example of
   ownership and stewardship that everyone can follow to success.
 - Commit to ongoing development and learning best practices for governing.
@@ -49,8 +48,6 @@ guidelines include:
   whenever possible, and taking responsibility for our statements by
   speaking as much as possible
   in the first person (.I. statements) rather than in the third person.
-- Collectively and as an individual serve as a role model to demonstrate
-  the highest standards of ethical conduct.
   
 Finally, the public behavior of members reflects on the Node.js project.  It is
 often difficult for those external to the project to separate actions which 

--- a/MemberExpectations.md
+++ b/MemberExpectations.md
@@ -1,0 +1,58 @@
+It is important that members of our leadership groups (TSC, CommComm) act
+in a way that not only complies with the code of conduct but that supports
+the vision, mission and operating principles of the Node.js project.
+
+While members have the right and responsibility to exercise independent
+judgment and to express dissenting opinions during discussions within
+the organization, members also have the obligation outside the
+organization (twitter, reddit, etc.) to respect and support decisions
+and values of the majority, even when a member dissented from
+the majority view. A member who does not support a team decision
+or current team value may express the member's opposition within
+the team in an appropriate manner, but must not take actions publicly
+that have the purpose or result of undermining the decisions, values
+or actions of the team. Accordingly, a member who itends to publicly
+oppose a team decision action should resign from the team before doing so.
+
+In addition to being willing to act as a team player, members of our
+leadership groups must conduct themselves in a professional and
+respectful manner. Some general
+guidelines include:
+
+- Serve as ambassadors of the vision, mission and operating
+  principles of the Node.js project.
+- Treat all community members as professionals. with respect, consideration,
+  and valuing a diversity of views and opinions. Strive to avoid preferential
+  treatment, and hold everyone (including ourselves) accountable to the same
+  set of standards.  Everyone gets to speak up. 
+- Deal with issues directly with the person in question. Resist complaining
+  about others in the project in a public sphere.
+- Keep your promises. Your word is your bond. Commit to anything you can
+  deliver upon. 
+- Be the model of accountability and leadership. Provide the example of
+  ownership and stewardship that everyone can follow to success.
+- Commit to ongoing development and learning best practices for governing.
+- Critique ideas rather than individuals, discussing any concerns in person
+  whenever possible, and  taking responsibility for our statements by
+  speaking as much as possible
+  in the first person (.I. statements) rather than in the third person.
+- Collectively and as an individual serve as a role model to demonstrate
+  the highest standards of ethical conduct.
+- Remediate quickly when you realize you made a mistake. Leaders are human,
+  and they will make mistakes - however they should act swiftly to
+  acknowlege mistakes and correct them. Most often this can mitigate
+  any damage done.
+- Aim to remediate first and then discuss.  If other members of the
+  team express concerns about actions, acknowledge their concerns by
+  stopping the actions in question and then discuss within the team
+  to come to a common agreement.
+  
+Finally, the public behaviour of members reflects on the Node.js project.  It is
+often difficult for those external to the project to separate actions which 
+reflect the members private views from how they will act within
+the project.  Members are expected to avoid acting in a way that might bring
+disrepute to the Node.js organization and avoid any actions that might be
+interpreted as undermining the core values of the project.
+
+
+

--- a/MemberExpectations.md
+++ b/MemberExpectations.md
@@ -1,18 +1,23 @@
 It is important that members of our leadership groups (TSC, CommComm) act
-in a way that not only complies with the code of conduct but that supports
-the vision, mission and operating principles of the Node.js project.
+in a way that not only complies with the
+[Code of Conduct](https://github.com/nodejs/TSC/blob/master/CODE_OF_CONDUCT.md)
+but that supports the vision, mission and operating principles of the Node.js project.
 
-While members have the right and responsibility to exercise independent
-judgment and to express dissenting opinions during discussions within
-the organization, members also have the obligation outside the
-organization (twitter, reddit, etc.) to respect and support decisions
-and values of the majority, even when a member dissented from
-the majority view. A member who does not support a team decision
-or current team value may express the member's opposition within
-the team in an appropriate manner, but must not take actions publicly
-that have the purpose or result of undermining the decisions, values
-or actions of the team. Accordingly, a member who itends to publicly
-oppose a team decision action should resign from the team before doing so.
+Members are encouraged to have individual opinions and are encouraged
+to express those opinions during discussions within the organization. While
+discourse is encouraged internally, members also have the obligation outside
+of the organization (for example in social media) to be respectful of the
+decisions made within the projects's documented processes.  A member who does
+not support a team decision or current team value may express the member's
+opposition within the team in an appropriate manner, but must be extremely
+careful when expressing the opinion externally.  External communication must
+not be done with the intent of undermining a decision, project values, or
+actions of the team. If another team member expresses that they believe external
+communications appear to have the intent to undermine the committee
+it is the responsibility of the individual expressing their opinions to rectify
+the situation immediately. If a member feels that there is no recourse aside
+from going public regarding an extremely contentious issue then they should
+resign from the team before doing so.
 
 In addition to being willing to act as a team player, members of our
 leadership groups must conduct themselves in a professional and
@@ -21,33 +26,33 @@ guidelines include:
 
 - Serve as ambassadors of the vision, mission and operating
   principles of the Node.js project.
-- Treat all community members as professionals. with respect, consideration,
-  and valuing a diversity of views and opinions. Strive to avoid preferential
-  treatment, and hold everyone (including ourselves) accountable to the same
-  set of standards.  Everyone gets to speak up. 
-- Deal with issues directly with the person in question. Resist complaining
-  about others in the project in a public sphere.
-- Keep your promises. Your word is your bond. Commit to anything you can
-  deliver upon. 
-- Be the model of accountability and leadership. Provide the example of
-  ownership and stewardship that everyone can follow to success.
-- Commit to ongoing development and learning best practices for governing.
-- Critique ideas rather than individuals, discussing any concerns in person
-  whenever possible, and  taking responsibility for our statements by
-  speaking as much as possible
-  in the first person (.I. statements) rather than in the third person.
-- Collectively and as an individual serve as a role model to demonstrate
-  the highest standards of ethical conduct.
 - Remediate quickly when you realize you made a mistake. Leaders are human,
   and they will make mistakes - however they should act swiftly to
-  acknowlege mistakes and correct them. Most often this can mitigate
+  acknowledge mistakes and correct them. Most often this can mitigate
   any damage done.
 - Aim to remediate first and then discuss.  If other members of the
   team express concerns about actions, acknowledge their concerns by
   stopping the actions in question and then discuss within the team
   to come to a common agreement.
+- Treat all community members with respect, consideration, and highest
+  standards of ethical conduct.  
+- Valuing a diversity of views and opinions. Strive to avoid preferential
+  treatment, and hold everyone (including ourselves) accountable to the same
+  set of standards.  Everyone gets to speak up. 
+- Deal with issues directly with the person in question. Resist complaining
+  about others in the project in a public sphere.
+- Built trust by keeping your promises.
+- Be the model of accountability and leadership. Provide the example of
+  ownership and stewardship that everyone can follow to success.
+- Commit to ongoing development and learning best practices for governing.
+- Critique ideas rather than individuals, discussing any concerns in person
+  whenever possible, and taking responsibility for our statements by
+  speaking as much as possible
+  in the first person (.I. statements) rather than in the third person.
+- Collectively and as an individual serve as a role model to demonstrate
+  the highest standards of ethical conduct.
   
-Finally, the public behaviour of members reflects on the Node.js project.  It is
+Finally, the public behavior of members reflects on the Node.js project.  It is
 often difficult for those external to the project to separate actions which 
 reflect the members private views from how they will act within
 the project.  Members are expected to avoid acting in a way that might bring


### PR DESCRIPTION
Document expectations on members of the TSC and CommComm beyond
following the Code of Conduct.

Likely to be lots of discussion and differing views, but some initial text that can be refined.

A follow on step would be to define/document the process for reporting/remediation
when members don't meet this standard.