### PR TITLE
meta: add back Release WG

### DIFF
--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -244,7 +244,7 @@ The [Node.js Code of Conduct][] applies to this WG.
 * [Benchmarking](#benchmarking)
 * [Post-mortem](#post-mortem)
 * [Intl](#intl)
-
+* [Release](#release)
 
 ### [Website](https://github.com/nodejs/nodejs.org)
 
@@ -438,6 +438,19 @@ Responsibilities include:
   to be generated when needed.
 * Defining and adding common structures to the dumps generated
   in order to support tools that want to introspect those dumps.
+
+### [Release](https://github.com/nodejs/release)
+
+The Release Working Group manages the release process for Node.js.
+
+Responsibilities include:
+* Define the release process.
+* Define the content of releases.
+* Generate and create releases.
+* Test Releases.
+* Manage the Long Term Support and Current branches including
+  backporting changes to these branches.
+* Define the policy for what gets backported to release streams.
 
 
 [Technical Steering Committee (TSC)]: ./TSC-Charter.md


### PR DESCRIPTION
In the CTC -> TSC merge of documents the release WG was dropped
somehow. Add it back in.