### PR TITLE
remove "Core Projects" and "Maintainer" from charter

### DIFF
--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -10,9 +10,8 @@ must not merely be open, but also easily visible to outsiders.
 
 Most large, complex open source communities have both a business and a
 technical governance model. Node.js Foundation’s technical leadership
-contains both a Technical Steering Committee (“TSC”) and Maintainers for
-major components or subsystems. Node.js Foundation’s business leadership
-is instantiated in a Board of Directors (the “Board”).  
+is the Technical Steering Committee (“TSC”). Node.js Foundation’s business
+leadership is the Board of Directors (the “Board”).
 
 This Technical Steering Committee Charter reflects a carefully
 constructed balanced role for the TSC and the Board in the governance of
@@ -134,8 +133,8 @@ review of contributions, including the Node.js Foundation IP Policy.
 Leadership roles in Node.js Foundation will be peer elected
 representatives of the community.
 
-For election of persons (TSC Chairperson, Maintainers, etc.) a
-multiple-candidate method should be used, e.g.:
+For election of persons (such as the TSC Chairperson), a multiple-candidate
+method should be used, such as:
 
 * [Condorcet][] or
 * [Single Transferable Vote][]
@@ -202,9 +201,8 @@ looking to participate in the development effort.
 * **Contributors**: contribute code or other artifacts, but do not have
 the right to commit to the code base. Contributors work with the
 Project’s Collaborators to have code committed to the code base. A
-Contributor may be promoted to a Collaborator by the projects’ Maintainer
-or the TSC. Contributors should rarely be encumbered by the TSC and never
-by the Board.
+Contributor may be promoted to a Collaborator by the TSC. Contributors should
+rarely be encumbered by the TSC and never by the Board.
 
 * **Project**: a technical collaboration effort, e.g. a subsystem, that
 is organized through the project creation process and approved by the

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -146,11 +146,6 @@ election is required if there is only one candidate and no objections to
 the candidates election. Elections shall be done within the Projects by
 the Collaborators active in the Project.
 
-Each Core Project’s Collaborators shall elect one Maintainer from the
-Collaborators on the project to serve on the TSC. There may be only one
-Maintainer per Core Project that shall be nominated and elected by the
-Collaborators within the Core Project.
-
 The TSC will elect from amongst voting TSC members a TSC Chairperson to
 work on building an agenda for TSC meetings and a TSC Director to represent
 the TSC to the Board for a term of one year according to the Node.js Foundation’s
@@ -214,9 +209,6 @@ by the Board.
 * **Project**: a technical collaboration effort, e.g. a subsystem, that
 is organized through the project creation process and approved by the
 TSC.
-
-* **Maintainer**: a Collaborator within a Core Project elected to
-represent the Core Project on the TSC.
 
 [Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making
 [Condorcet]: http://en.wikipedia.org/wiki/Condorcet_method


### PR DESCRIPTION
Core Projects are not defined anywhere in the Charter. As far as I know,
we do not have Core Project representation as defined in the Charter. We
do not intend to expand the number of Core Projects, and I'm not even
sure we have any at the current time. Remove this material from the
Charter for clarity and concision. (This will require board approval.
Technically doesn't require TSC approval, but that would be nice.)

Removing *Core Projects* from the Charter makes the *Maintainer* terminology superfluous, so that is being removed too. The *Maintainer* terminology is not often used in reference to Node.js in my experience, and when it *is* used. it is synonymous with *Collaborator* and in contradiction with the definition in the Charter. So, again, this removes the *Maintainer* terminology too.