### PR TITLE
Travel Fund request for @joyeecheung at Feb 2018 Diagnostics WG Summit

### DIFF
--- a/Member-Travel-Fund.md
+++ b/Member-Travel-Fund.md
@@ -76,3 +76,4 @@ Bryan English | JSConf.cn 2017 | Code & Learn Mentor | Shanghai, CN | 15 July - 
 Tobias Nießen | NINA 2017 | Collaborator Summit and Code & Learn | Vancouver, BC, CA | 5 Oct - 8 Oct 2017 | €1300
 Tiancheng Gu | NINA 2017 | Collaborator Summit | Vancouver, BC, CA | 3 Oct – 8 Oct 2017 | US$ 1200
 Ruben Bridgewater | NINA 2017 | Collaborator Summit and Code & Learn | Vancouver, BC, CA | 4 Oct - 8 Oct 2017 | €1500
+Joyee Cheung | Diagnostics WG Summit | Attendance | Ottawa, ON, CA | 12 Feb - 13 Feb 2018 | US$ 1400


### PR DESCRIPTION
Event: Diagnostics WG Summit
Location: Ottawa, ON Canada
Date: 12 Feb - 13 Feb 2018
From: Hangzhou, China
Amount: USD$ 1400

I would like to attend the Diagnostics WG Summit in Feb 2018 and discuss about post-mortem diagnosis (mainly llnode stuff). My employer won't be able to cover my travel expenses.

Refs: https://github.com/nodejs/diagnostics/issues/121

I live in Hangzhou, China but I usually fly from Shanghai when I need to travel to another country (there are much more flights in Shanghai). The roundtrip flight between Shanghai and Ottawa costs around 950 USD, I've booked my hotel and it costs 432 USD.
