### PR TITLE
move to emeritus 

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,6 @@ whom they elect at their own discretion.
 **Fedor Indutny** &lt;fedor.indutny@gmail.com&gt;
 * [jasnell](https://github.com/jasnell) -
 **James M Snell** &lt;jasnell@gmail.com&gt; (he/him)
-* [joshgav](https://github.com/joshgav) -
-**Josh Gavant** &lt;josh.gavant@outlook.com&gt;
 * [joyeecheung](https://github.com/joyeecheung) -
 **Joyee Cheung** &lt;joyeec9h3@gmail.com&gt; (she/her)
 * [mcollina](https://github.com/mcollina) -
@@ -189,6 +187,8 @@ whom they elect at their own discretion.
 
 ### TSC Emeriti
 
+* [joshgav](https://github.com/joshgav) -
+**Josh Gavant** &lt;josh.gavant@gmail.com&gt;
 * [bnoordhuis](https://github.com/bnoordhuis) -
 **Ben Noordhuis** &lt;info@bnoordhuis.nl&gt;
 * [chrisdickinson](https://github.com/chrisdickinson) -


### PR DESCRIPTION
It's been a pleasure serving the Node.js project and community and I look forward to future opportunities to do so! In the meantime, due to recent changes I'm not able to contribute at the level a [TSC][] member should so I think it would best serve the project for me to revert to a standard [Collaborator][].

Thanks to all of you for your time and commitment. Node.js continues to rock cause of all of you :tada:. See you on GitHub!

[TSC]: https://github.com/nodejs/node/blob/master/GOVERNANCE.md#technical-steering-committee
[Collaborator]: https://github.com/nodejs/node/blob/master/GOVERNANCE.md#collaborators