### PR TITLE
remove unused TLP representation on TSC sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,6 @@ to be people who have a competancy for community management and a high tolerance
 and patience for process minutiae as the TSC delegates most of its responsibilities
 to other projects and working groups.
 
-Every Top Level Project not currently incubating can appoint someone to the TSC
-whom they elect at their own discretion.
-
 A [current list of TSC members](https://github.com/nodejs/node#tsc-technical-steering-committee)
 is maintained in the main Node.js repository.
 


### PR DESCRIPTION
Top-level projects do not elect TSC members (and in my opinion should
not but it's a bit of an academic question because tecnically there are
no top-level projects other than core).