### PR TITLE
retire mod team from strategic initiatives

### DIFF
--- a/Strategic-Initiatives.md
+++ b/Strategic-Initiatives.md
@@ -22,7 +22,6 @@ and have the support needed.
 | Core Promise APIs | James Snell                     |                                                                  |
 | TSC Governance    | Myles Borins                    | https://github.com/nodejs/TSC/issues/383                         |
 | New Streams APIs  | James Snell + Jeremiah Senkpiel | https://github.com/nodejs/node/pull/16414                        |
-| Moderation        | Rich Trott                      |                                                                  |
 | Async Hooks       | Trevor Norris                   |                                                                  |
 | V8 Currency       | Michaël Zasso                   |                                                                  |
 


### PR DESCRIPTION
The Moderation Team is spun up and operational. It is now an ongoing
day-to-day activity rather than a strategic initiative. It will still
need to report weekly activity to TSC and CommComm, but it is no longer
necessary to include it in the list of Strategic Initiatives.

By the way, this might be a good opportunity for others to look for items that may no longer need to be treated as strategic.