### PR TITLE
Move Async Hooks to section that needs champions

### DIFF
--- a/Strategic-Initiatives.md
+++ b/Strategic-Initiatives.md
@@ -22,7 +22,6 @@ and have the support needed.
 | Core Promise APIs | [James Snell][jasnell]                                    |                                                                  |
 | TSC Governance    | [Myles Borins][MylesBorins]                               | https://github.com/nodejs/TSC/issues/383                         |
 | New Streams APIs  | [James Snell][jasnell] + [Jeremiah Senkpiel][fishrock123] | https://github.com/nodejs/node/pull/16414                        |
-| Async Hooks       | [Trevor Norris][trevnorris]                               |                                                                  |
 | V8 Currency       | [Michaël Zasso][targos]                                   |                                                                  |
 
 
@@ -32,7 +31,7 @@ and have the support needed.
 |-------------------|---------------------------------|------------------------------------------------------------------|
 | Mentoring         | ?                               |                                                                  |
 | nsp and modules   | ?                               |                                                                  |
-
+| Async Hooks       | ?                               |                                                                  |
 
 # Completed
 

--- a/Strategic-Initiatives.md
+++ b/Strategic-Initiatives.md
@@ -49,5 +49,4 @@ and have the support needed.
 [mhdawson]: https://github.com/mhdawson
 [rvagg]: https://github.com/rvagg
 [trott]: https://github.com/trott
-[trevnorris]: https://github.com/trevnorris
 [targos]: https://github.com/targos


### PR DESCRIPTION
As discussed in TSC Meeting, https://github.com/nodejs/TSC/issues/520, move this to the section that needs champions. 