### PR TITLE
Charter Security WG

### DIFF
--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -244,6 +244,7 @@ The [Node.js Code of Conduct][] applies to this WG.
 * [Benchmarking](#benchmarking)
 * [Post-mortem](#post-mortem)
 * [Release](#release)
+* [Security](#security)
 
 ### [Website](https://github.com/nodejs/nodejs.org)
 
@@ -442,27 +443,27 @@ Responsibilities include:
 * Define and maintain security policies and procedures for:
   * the core Node.js project
   * other projects maintained by the Node.js Foundation technical group
-* Work with the node security project to bring community vulnerability data into
+* Work with the Node Security Platform to bring community vulnerability data into
   the foundation as a shared asset.
 * Set up processes and procedures and follow these to ensure the vulnerability
   data is updated in an efficient and timely manner. For example, ensuring there
-  are well documented processes for reporting vulnerabilities in community
+  are well-documented processes for reporting vulnerabilities in community
   modules.
 * Work to set a high standard for the Node.js project. Possibly efforts could
-  include penetration testing, security reviews etc, review guidelines, coding
-  standards etc.
+  include penetration testing, security reviews, review guidelines, coding
+  standards, etc.
 * Review and recommend processes for handling of security reports (but not the
-  actual handling of security reports, which are reviewed by a group of people
+  actual administration of security reports, which are reviewed by a group of people
   directly delegated to by the TSC).
 * Define and maintain policies and procedures for the coordination of security
   concerns within the external Node.js open source ecosystem.
-* Offer help to npm package maintainers to fix high-impact security bugs
+* Offer help to npm package maintainers to fix high-impact security bugs.
 * Maintain and make available data on disclosed security vulnerabilities in:
   * the core Node.js project
   * other projects maintained by the Node.js Foundation technical group
   * the external Node.js open source ecosystem
-* Promote improvement of security practices within the Node.js ecosystem
-* Recommend security improvements for the core Node.js project
+* Promote the improvement of security practices within the Node.js ecosystem.
+* Recommend security improvements for the core Node.js project.
 * Facilitate and promote the expansion of a healthy security service and product
   provider ecosystem vulnerabilities.
 

--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -437,7 +437,7 @@ Responsibilities include:
 
 ### [Security](https://github.com/nodejs/security-wg)
 
-The Security Working Group manages all aspects and process linked to security for Node.js.
+The Security Working Group manages all aspects and processes linked to Node.js security.
 
 Responsibilities include:
 * Define and maintain security policies and procedures for:
@@ -445,13 +445,9 @@ Responsibilities include:
   * other projects maintained by the Node.js Foundation technical group
 * Work with the Node Security Platform to bring community vulnerability data into
   the foundation as a shared asset.
-* Set up processes and procedures and follow these to ensure the vulnerability
-  data is updated in an efficient and timely manner. For example, ensuring there
+* Ensure the vulnerability data is updated in an efficient and timely manner. For example, ensuring there
   are well-documented processes for reporting vulnerabilities in community
   modules.
-* Work to set a high standard for the Node.js project. Possibly efforts could
-  include penetration testing, security reviews, review guidelines, coding
-  standards, etc.
 * Review and recommend processes for handling of security reports (but not the
   actual administration of security reports, which are reviewed by a group of people
   directly delegated to by the TSC).

--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -434,6 +434,37 @@ Responsibilities include:
   backporting changes to these branches.
 * Define the policy for what gets backported to release streams.
 
+### [Security](https://github.com/nodejs/security-wg)
+
+The Security Working Group manages all aspects and process linked to security for Node.js.
+
+Responsibilities include:
+* Define and maintain security policies and procedures for:
+  * the core Node.js project
+  * other projects maintained by the Node.js Foundation technical group
+* Work with the node security project to bring community vulnerability data into
+  the foundation as a shared asset.
+* Set up processes and procedures and follow these to ensure the vulnerability
+  data is updated in an efficient and timely manner. For example, ensuring there
+  are well documented processes for reporting vulnerabilities in community
+  modules.
+* Work to set a high standard for the Node.js project. Possibly efforts could
+  include penetration testing, security reviews etc, review guidelines, coding
+  standards etc.
+* Review and recommend processes for handling of security reports (but not the
+  actual handling of security reports, which are reviewed by a group of people
+  directly delegated to by the TSC).
+* Define and maintain policies and procedures for the coordination of security
+  concerns within the external Node.js open source ecosystem.
+* Offer help to npm package maintainers to fix high-impact security bugs
+* Maintain and make available data on disclosed security vulnerabilities in:
+  * the core Node.js project
+  * other projects maintained by the Node.js Foundation technical group
+  * the external Node.js open source ecosystem
+* Promote improvement of security practices within the Node.js ecosystem
+* Recommend security improvements for the core Node.js project
+* Facilitate and promote the expansion of a healthy security service and product
+  provider ecosystem vulnerabilities.
 
 [Technical Steering Committee (TSC)]: ./TSC-Charter.md
 [Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making

--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -442,7 +442,7 @@ The Security Working Group manages all aspects and processes linked to Node.js s
 Responsibilities include:
 * Define and maintain security policies and procedures for:
   * the core Node.js project
-  * other projects maintained by the Node.js Foundation technical group
+  * other projects maintained by the Node.js Technical Steering Committee (TSC).
 * Work with the Node Security Platform to bring community vulnerability data into
   the foundation as a shared asset.
 * Ensure the vulnerability data is updated in an efficient and timely manner. For example, ensuring there
@@ -461,7 +461,7 @@ Responsibilities include:
 * Promote the improvement of security practices within the Node.js ecosystem.
 * Recommend security improvements for the core Node.js project.
 * Facilitate and promote the expansion of a healthy security service and product
-  provider ecosystem vulnerabilities.
+  provider ecosystem.
 
 [Technical Steering Committee (TSC)]: ./TSC-Charter.md
 [Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making


### PR DESCRIPTION
This PR adds the Security WG as a chartered WG.
This probably can't be merged until https://github.com/nodejs/security-wg/pull/295 is merged.

After this, is there anything else I should to to have this validated?

cc @mhdawson 