### PR TITLE
meta: fold the Post-mortem WG into Diagnostics WG

### DIFF
--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -242,7 +242,6 @@ The [Node.js Code of Conduct][] applies to this WG.
 * [Docker](#docker)
 * [Addon API](#addon-api)
 * [Benchmarking](#benchmarking)
-* [Post-mortem](#post-mortem)
 * [Release](#release)
 * [Security](#security)
 
@@ -303,6 +302,10 @@ Responsibilities include:
 * Exploring opportunities and gaps, discussing feature requests, and addressing
   conflicts in Node.js diagnostics.
 * Fostering an ecosystem of diagnostics tools for Node.js.
+* Defining and adding interfaces/APIs in order to allow dumps to be generated
+  when needed.
+* Defining and adding common structures to the dumps generated in order to
+  support tools that want to introspect those dumps.
 
 ### i18n
 
@@ -407,20 +410,6 @@ Responsibilities include:
 * Working to get community consensus on the list chosen
 * Adding regular execution of chosen benchmarks to Node.js builds
 * Tracking/publicizing performance between builds/releases
-
-### [Post-mortem](https://github.com/nodejs/post-mortem)
-
-The Post-mortem Diagnostics Working Group is dedicated to the support
-and improvement of postmortem debugging for Node.js. It seeks to
-elevate the role of postmortem debugging for Node, to assist in the
-development of techniques and tools, and to make techniques and tools
-known and available to Node.js users.
-
-Responsibilities include:
-* Defining and adding interfaces/APIs in order to allow dumps
-  to be generated when needed.
-* Defining and adding common structures to the dumps generated
-  in order to support tools that want to introspect those dumps.
 
 ### [Release](https://github.com/nodejs/release)
 


### PR DESCRIPTION
Refs: https://github.com/nodejs/post-mortem/issues/48

https://github.com/nodejs/post-mortem has been largely inactive over the last year. I don't believe that's because its activities ceased, rather that the work it was responsible for is happening elsewhere in the organization and, in practice, under the Diagnostics WG. This PR folds the Post-mortem WG into the Diagnostics WG. There were no objections raised in the Post-mortem WG during the nine months since this was proposed in https://github.com/nodejs/post-mortem/issues/48.