### PR TITLE
remove potential conflict in Charter about meeting frequency

### DIFF
--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -184,9 +184,9 @@ additional Collaborators who are added by the TSC on an ongoing basis.
 Individuals making significant and valuable contributions,
 “Contributor(s)”, are made Collaborators and given commit-access to the
 project. These individuals are identified by the TSC and their addition
-as Collaborators is discussed during the weekly TSC meeting.
-Modifications of the contents of the git repository are made on a
-collaborative basis as defined in the development process.
+as Collaborators is discussed during the TSC meeting. Modifications of the
+contents of the git repository are made on a collaborative basis as defined in
+the development process.
 
 Collaborators may opt to elevate significant or controversial
 modifications, or modifications that have not found consensus to the TSC

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -184,7 +184,7 @@ additional Collaborators who are added by the TSC on an ongoing basis.
 Individuals making significant and valuable contributions,
 “Contributor(s)”, are made Collaborators and given commit-access to the
 project. These individuals are identified by the TSC and their addition
-as Collaborators is discussed during the TSC meeting. Modifications of the
+as Collaborators is discussed during a TSC meeting. Modifications of the
 contents of the git repository are made on a collaborative basis as defined in
 the development process.
 


### PR DESCRIPTION
Section 4 says the TSC must meet regularly, but does not determine a frequency. ("weekly" is suggested as an example but not mandated.)

Section 9 then describes the TSC meeting as "weekly". This removes the word "weekly" from section 9.

Charter changes need Board approval so this should not land until the Board approves it.