### PR TITLE
Remove joyee from champions for error migration

### DIFF
--- a/Strategic-Initiatives.md
+++ b/Strategic-Initiatives.md
@@ -17,7 +17,6 @@ and have the support needed.
 | N-API             | [Michael Dawson][mhdawson]                                | https://github.com/nodejs/abi-stable-node                        |
 | OpenSSL Evolution | [Rod Vagg][rvagg]                                         | https://github.com/nodejs/TSC/issues/364                         |
 | Workers           | [Anna Henningson][addaleax]                               | https://github.com/nodejs/worker                                 |
-| Error Messages    | [Joyee Cheung][joyeecheung]                               | [node#11273][], [node#18106][]                                   |
 | Core Promise APIs | [Matteo Collina][mcollina]                                |                                                                  |
 | Governance        | [Myles Borins][MylesBorins]                               |                                                                  |
 | New Streams APIs  | [Jeremiah Senkpiel][fishrock123] | https://github.com/Fishrock123/bob, https://github.com/Fishrock123/socket                        |
@@ -32,6 +31,7 @@ and have the support needed.
 |-------------------|---------------------------------|------------------------------------------------------------------|
 | Mentoring         | ?                               |                                                                  |
 | nsp and modules   | ?                               |                                                                  |
+| Error Messages    | ?                               | [node#11273][], [node#18106][]                                   |
 
 # Completed
 


### PR DESCRIPTION
I have not been very active on this initiative for a while and will be focusing on other stuff in the foreseeable future so I think I should just remove myself as a champion. If anyone would like to become a new champion for this feel free to push a new commit here or open a follow on PR.

Although IMO the initiative is no longer strategic for us anymore as it's mostly done and the remaining unmigrated errors are all fairly rare. Maybe a more reasonable move is to create a separate section for these inactive (or no longer strategic?) initiatives, or move it to completed (which feels a bit odd since technically it is not completed).