### PR TITLE
Create startup performance strategic initiative

### DIFF
--- a/Strategic-Initiatives.md
+++ b/Strategic-Initiatives.md
@@ -25,6 +25,7 @@ and have the support needed.
 | Async Hooks       | [Ali Ijaz Sheikh][ofrobots]                               | https://github.com/nodejs/diagnostics/issues/124                 |
 | Open Web Standards| [Myles Borins][MylesBorins] + [Joyee Cheung][joyeecheung] | https://github.com/nodejs/open-standards                         |
 | Python 3 & GYP    | [Sakthipriyan Vairamani][thefourtheye]                    | https://github.com/nodejs/TSC/issues/642                         |
+| Startup performance  | [Joyee Cheung][joyeecheung]                            | https://github.com/nodejs/node/issues/17058 https://github.com/nodejs/node/issues/21563                        |
 
 # Need volunteers for
 


### PR DESCRIPTION
I've been spending the past few months on refactoring the bootstrap to pave the way for shipping snapshot (probably created a lot of conflicts for whoever rebases against our master branch but I believe once the refactor reaches a stable state it would be easier to rebase from now on since it'll be less spaghetti-like). Prior to that, I had been working on code cache integration though I am still stuck with build issues, which I plan to solve together with the snapshot integration given how similar the requirements are.

Considering that there is a pretty clear plan for this effort, I think it is worthy of being a strategic initiative of its own. This makes Node.js more viable for tooling, mobile and serverless use cases. (It also does not hurt that this helps us spend less time on waiting for the tests to complete ;) ) . 

Other than builtin snapshot integration I am also looking into implementing snapshot builders for users (either in core or as a separate module, but I suspect we'll end up reusing most of the code in core so we may consider just exposing the functionality to users) - this has been a common request when I chat about what I've been working on lately with other people.