### PR TITLE
add strategic initiative for Build resources

### DIFF
--- a/Strategic-Initiatives.md
+++ b/Strategic-Initiatives.md
@@ -11,20 +11,21 @@ and have the support needed.
 
 # Current Initiatives
 
-| Initiative        | Champion                                                  | Links                                                            |
-|-------------------|-----------------------------------------------------------|------------------------------------------------------------------|
-| Modules           | [Myles Borins][MylesBorins]                               | https://github.com/nodejs/node-eps/blob/master/002-es-modules.md |
-| N-API             | [Michael Dawson][mhdawson]                                | https://github.com/nodejs/abi-stable-node                        |
-| OpenSSL Evolution | [Rod Vagg][rvagg]                                         | https://github.com/nodejs/TSC/issues/364                         |
-| Workers           | [Anna Henningson][addaleax]                               | https://github.com/nodejs/worker                                 |
-| Core Promise APIs | [Matteo Collina][mcollina]                                |                                                                  |
-| Governance        | [Myles Borins][MylesBorins]                               |                                                                  |
-| New Streams APIs  | [Jeremiah Senkpiel][fishrock123] | https://github.com/Fishrock123/bob, https://github.com/Fishrock123/socket                        |
-| V8 Currency       | [Michaël Zasso][targos]                                   |                                                                  |
-| Async Hooks       | [Ali Ijaz Sheikh][ofrobots]                               | https://github.com/nodejs/diagnostics/issues/124                 |
-| Open Web Standards| [Myles Borins][MylesBorins] + [Joyee Cheung][joyeecheung] | https://github.com/nodejs/open-standards                         |
-| Python 3 & GYP    | [Sakthipriyan Vairamani][thefourtheye]                    | https://github.com/nodejs/TSC/issues/642                         |
-| Startup performance  | [Joyee Cheung][joyeecheung]                            | https://github.com/nodejs/node/issues/17058 https://github.com/nodejs/node/issues/21563                        |
+| Initiative          | Champion                                                  | Links                                                                                   |
+|---------------------|-----------------------------------------------------------|-----------------------------------------------------------------------------------------|
+| Modules             | [Myles Borins][MylesBorins]                               | https://github.com/nodejs/node-eps/blob/master/002-es-modules.md                        |
+| N-API               | [Michael Dawson][mhdawson]                                | https://github.com/nodejs/abi-stable-node                                               |
+| OpenSSL Evolution   | [Rod Vagg][rvagg]                                         | https://github.com/nodejs/TSC/issues/364                                                |
+| Workers             | [Anna Henningson][addaleax]                               | https://github.com/nodejs/worker                                                        |
+| Core Promise APIs   | [Matteo Collina][mcollina]                                |                                                                                         |
+| Governance          | [Myles Borins][MylesBorins]                               |                                                                                         |
+| New Streams APIs    | [Jeremiah Senkpiel][fishrock123]                          | https://github.com/Fishrock123/bob, https://github.com/Fishrock123/socket               |
+| V8 Currency         | [Michaël Zasso][targos]                                   |                                                                                         |
+| Async Hooks         | [Ali Ijaz Sheikh][ofrobots]                               | https://github.com/nodejs/diagnostics/issues/124                                        |
+| Open Web Standards  | [Myles Borins][MylesBorins] + [Joyee Cheung][joyeecheung] | https://github.com/nodejs/open-standards                                                |
+| Python 3 & GYP      | [Sakthipriyan Vairamani][thefourtheye]                    | https://github.com/nodejs/TSC/issues/642                                                |
+| Startup performance | [Joyee Cheung][joyeecheung]                               | https://github.com/nodejs/node/issues/17058 https://github.com/nodejs/node/issues/21563 |
+| Build resrouces     | [Rich Trott][Trott] + [Rod Vagg][rvagg]                   | https://github.com/nodejs/build/issues/1154#issuecomment-448418977                      |
 
 # Need volunteers for
 


### PR DESCRIPTION
From https://github.com/nodejs/build/issues/1154#issuecomment-448418977:

---

Rich and I (Rod) will begin a strategic initiative sometime in January
to do some accounting of resources and costs (people and other) and try
and come up with proposals and plans for reducing pain and improving the
experience for collaborators while managing quality. Or something like
that. Basically we need to think more strategically about this and
understand what our problems and risks are and what we can do about
them.

---

This is that initiative (in April rather than January, but such is
life).