### PR TITLE
doc: update link to PR for OpenSSL Policy

### DIFF
--- a/Strategic-Initiatives.md
+++ b/Strategic-Initiatives.md
@@ -15,7 +15,7 @@ and have the support needed.
 |---------------------|-----------------------------------------------------------|-----------------------------------------------------------------------------------------|
 | Modules             | [Myles Borins][MylesBorins]                               | https://github.com/nodejs/node-eps/blob/master/002-es-modules.md                        |
 | N-API               | [Michael Dawson][mhdawson]                                | https://github.com/nodejs/abi-stable-node                                               |
-| OpenSSL Evolution   | [Rod Vagg][rvagg]                                         | https://github.com/nodejs/TSC/issues/364                                                |
+| OpenSSL Evolution   | [Rod Vagg][rvagg]                                         | https://github.com/nodejs/TSC/issues/677                                                |
 | Workers             | [Anna Henningson][addaleax]                               | https://github.com/nodejs/worker                                                        |
 | Core Promise APIs   | [Matteo Collina][mcollina]                                |                                                                                         |
 | Governance          | [Myles Borins][MylesBorins]                               |                                                                                         |


### PR DESCRIPTION
The OpenSSL policy changed over time:
- https://github.com/nodejs/TSC/issues/364
- https://github.com/nodejs/TSC/pull/479
- https://github.com/nodejs/TSC/pull/677

------

If its not intended that the strategic initiatives point to the most recent PR, please close, but I followed the existing link through a chain of closed issues before it ended at #677 (which landed), so perhaps that's the link that should be in the document?