### PR TITLE
meta: modify Ecosystem Security WG charter

### DIFF
--- a/Security-Team.md
+++ b/Security-Team.md
@@ -1,0 +1,94 @@
+# Node.js Security Team
+
+Node.js security team members are expected to keep all information that they have
+privileged access to by being on the team completely private to the team. This
+includes agreeing to not notify anyone outside the team of issues that have not
+yet been disclosed publicly, including the existence of issues, expectations of
+upcoming releases, and patching of any issues other than in the process of their
+work as a member of the security team.
+
+## Node.js Security Team Membership Policy
+
+The Node.js Security Team has access to security-sensitive issues and patches
+that aren't appropriate for public availability.
+
+The policy for inclusion is as follows:
+
+1. All members of @nodejs/TSC have access to private security reports and
+   private patches.
+2. Members of the [release team](https://github.com/nodejs/node#release-team)
+   have access to private security patches in order to produce releases.
+3. On a case-by-case basis, individuals outside the Technical Steering
+   Committee are invited by the TSC to have access to private security reports
+   or private patches so that their expertise can be applied to an issue or
+   patch. This access may be temporary or permanent, as decided by the TSC.
+
+Membership on the security teams can be requested via an issue in the TSC repo.
+
+## Team responsible for Triaging security reports
+
+Initial triage is done by HackerOne staff. Once enough information is gathered
+to confirm there is a reproducible issue, triage is assigned to this group.
+
+- @bnoordhuis - **Ben Noordhuis**
+- @cjihrig - **Colin Ihrig**
+- @indutny - **Fedor Indutny**
+- @jasnell - **James M Snell**
+- @mcollina - **Matteo Collina**
+- @MylesBorins - **Myles Borins**
+- @rvagg - **Rod Vagg**
+- @vdeturckheim - **Vladimir de Turckheim**
+
+## Team with access to private security reports against Node.js
+
+The [TSC](https://github.com/nodejs/node#tsc-technical-steering-committee)
+have access.
+
+These non-TSC and TSC Emeriti also have access:
+* [bnoordhuis](https://github.com/bnoordhuis) - **Ben Noordhuis**
+* [indutny](https://github.com/indutny) - **Fedor Indutny**
+* [rvagg](https://github.com/rvagg) - **Rod Vagg**
+* [vdeturckheim](https://github.com/vdeturckheim) - **Vladimir de Turckheim**
+
+List is from the [member page](https://hackerone.com/nodejs/team_members) for
+the Node.js program on HackerOne.
+
+## Team with access to private security patches to Node.js
+
+<!-- ncu-team-sync.team(nodejs-private/security) -->
+
+- [@addaleax](https://github.com/addaleax) - Anna Henningsen
+- [@apapirovski](https://github.com/apapirovski) - Anatoli Papirovski
+- [@BethGriggs](https://github.com/BethGriggs) - Bethany Nicolle Griggs
+- [@bnoordhuis](https://github.com/bnoordhuis) - Ben Noordhuis
+- [@BridgeAR](https://github.com/BridgeAR) - Ruben Bridgewater
+- [@ChALkeR](https://github.com/ChALkeR) - Сковорода Никита Андреевич
+- [@cjihrig](https://github.com/cjihrig) - Colin Ihrig
+- [@codebytere](https://github.com/codebytere) - Shelley Vohr
+- [@danbev](https://github.com/danbev) - Daniel Bevenius
+- [@dougwilson](https://github.com/dougwilson) - Douglas Wilson
+- [@evanlucas](https://github.com/evanlucas) - Evan Lucas
+- [@evilpacket](https://github.com/evilpacket) - Adam Baldwin
+- [@fhinkel](https://github.com/fhinkel) - F. Hinkelmann
+- [@Fishrock123](https://github.com/Fishrock123) - Jeremiah Senkpiel
+- [@gabrielschulhof](https://github.com/gabrielschulhof) - Gabriel Schulhof
+- [@gibfahn](https://github.com/gibfahn) - Gibson Fahnestock
+- [@gireeshpunathil](https://github.com/gireeshpunathil) - Gireesh Punathil
+- [@indutny](https://github.com/indutny) - Fedor Indutny
+- [@jasnell](https://github.com/jasnell) - James M Snell
+- [@jbergstroem](https://github.com/jbergstroem) - Johan Bergström
+- [@joaocgreis](https://github.com/joaocgreis) - João Reis
+- [@joyeecheung](https://github.com/joyeecheung) - Joyee Cheung
+- [@mcollina](https://github.com/mcollina) - Matteo Collina
+- [@mhdawson](https://github.com/mhdawson) - Michael Dawson
+- [@MylesBorins](https://github.com/MylesBorins) - Myles Borins
+- [@rvagg](https://github.com/rvagg) - Rod Vagg
+- [@saghul](https://github.com/saghul) - Saúl Ibarra Corretgé
+- [@sam-github](https://github.com/sam-github) - Sam Roberts
+- [@shigeki](https://github.com/shigeki) - Shigeki Ohtsu
+- [@targos](https://github.com/targos) - Michaël Zasso
+- [@thefourtheye](https://github.com/thefourtheye) - Sakthipriyan Vairamani
+- [@Trott](https://github.com/Trott) - Rich Trott
+- [@vdeturckheim](https://github.com/vdeturckheim) - Vladimir de Turckheim
+
+<!-- ncu-team-sync end -->

--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -424,22 +424,16 @@ Responsibilities include:
   backporting changes to these branches.
 * Define the policy for what gets backported to release streams.
 
-### [Security](https://github.com/nodejs/security-wg)
+### [Ecosystem Security](https://github.com/nodejs/security-wg)
 
-The Security Working Group manages all aspects and processes linked to Node.js security.
+The Ecosystem Security Working Group works to improve the security of the Node.js Ecosystem.
 
 Responsibilities include:
-* Define and maintain security policies and procedures for:
-  * the core Node.js project
-  * other projects maintained by the Node.js Technical Steering Committee (TSC).
 * Work with the Node Security Platform to bring community vulnerability data into
   the foundation as a shared asset.
 * Ensure the vulnerability data is updated in an efficient and timely manner. For example, ensuring there
   are well-documented processes for reporting vulnerabilities in community
   modules.
-* Review and recommend processes for handling of security reports (but not the
-  actual administration of security reports, which are reviewed by a group of people
-  directly delegated to by the TSC).
 * Define and maintain policies and procedures for the coordination of security
   concerns within the external Node.js open source ecosystem.
 * Offer help to npm package maintainers to fix high-impact security bugs.
@@ -448,9 +442,12 @@ Responsibilities include:
   * other projects maintained by the Node.js Foundation technical group
   * the external Node.js open source ecosystem
 * Promote the improvement of security practices within the Node.js ecosystem.
-* Recommend security improvements for the core Node.js project.
 * Facilitate and promote the expansion of a healthy security service and product
   provider ecosystem.
+
+This Working Group is _not_ responsible for managing or responding to
+security reports against Node.js itself. That responsibility remains with
+the [Node.js TSC][].
 
 [Technical Steering Committee (TSC)]: ./TSC-Charter.md
 [Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making


### PR DESCRIPTION
Draft until discussed in https://github.com/nodejs/security-wg/pull/579

2 changes:


    doc: describe security team membership
    
    The TSC is directly responsible for security of the Node.js project,
    document the responsibilities and the people.

and

    meta: modify Ecosystem Security WG charter