### PR TITLE
decharter website working group

### DIFF
--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -234,7 +234,6 @@ The [Node.js Code of Conduct][] applies to this WG.
 
 ## Current Working Groups
 
-* [Website](#website)
 * [Streams](#streams)
 * [Build](#build)
 * [Diagnostics](#diagnostics)
@@ -244,17 +243,6 @@ The [Node.js Code of Conduct][] applies to this WG.
 * [Benchmarking](#benchmarking)
 * [Release](#release)
 * [Security](#security)
-
-### [Website](https://github.com/nodejs/nodejs.org)
-
-The website Working Group's purpose is to build and maintain a public
-website for the Node.js project.
-
-Responsibilities include:
-* Developing and maintaining a build and automation system for nodejs.org.
-* Ensuring the site is regularly updated with changes made to Node.js, like
-  releases and features.
-* Fostering and enabling a community of translators.
 
 ### [Streams](https://github.com/nodejs/readable-stream)
 


### PR DESCRIPTION
The Website working group has not been a functioning working group for
some time. (No meetings, charter is frequently iignored, etc.) It is
effectively a GitHub team and I would like to be able to add and remove
people as appropriate, but I can't do that with a working group. Let's
switch it to a GitHub team. We can always recharter at a later date if
necessary.