### PR TITLE
Clarify security triage team membership and responsibilities

### DIFF
--- a/Security-Team.md
+++ b/Security-Team.md
@@ -30,6 +30,12 @@ Membership on the security teams can be requested via an issue in the TSC repo.
 Initial triage is done by HackerOne staff. Once enough information is gathered
 to confirm there is a reproducible issue, triage is assigned to this group.
 
+The responsibility of Triage is to determine whether Node.js must take any
+action to mitigate the issue, and if so, to ensure that the action is taken.
+
+Mitigation may take many forms, for example, a Node.js security release that
+includes a fix, documentation, an informational CVE or blog post.
+
 <!-- ncu-team-sync.team(nodejs/security-triage) -->
 
 - [@bnoordhuis](https://github.com/bnoordhuis) - Ben Noordhuis

--- a/Security-Team.md
+++ b/Security-Team.md
@@ -30,14 +30,18 @@ Membership on the security teams can be requested via an issue in the TSC repo.
 Initial triage is done by HackerOne staff. Once enough information is gathered
 to confirm there is a reproducible issue, triage is assigned to this group.
 
-- @bnoordhuis - **Ben Noordhuis**
-- @cjihrig - **Colin Ihrig**
-- @indutny - **Fedor Indutny**
-- @jasnell - **James M Snell**
-- @mcollina - **Matteo Collina**
-- @MylesBorins - **Myles Borins**
-- @rvagg - **Rod Vagg**
-- @vdeturckheim - **Vladimir de Turckheim**
+<!-- ncu-team-sync.team(nodejs/security-triage) -->
+
+- [@bnoordhuis](https://github.com/bnoordhuis) - Ben Noordhuis
+- [@cjihrig](https://github.com/cjihrig) - Colin Ihrig
+- [@indutny](https://github.com/indutny) - Fedor Indutny
+- [@jasnell](https://github.com/jasnell) - James M Snell
+- [@mcollina](https://github.com/mcollina) - Matteo Collina
+- [@MylesBorins](https://github.com/MylesBorins) - Myles Borins
+- [@shigeki](https://github.com/shigeki) - Shigeki Ohtsu
+- [@vdeturckheim](https://github.com/vdeturckheim) - Vladimir de Turckheim
+
+<!-- ncu-team-sync end -->
 
 ## Team with access to private security reports against Node.js
 
@@ -88,6 +92,7 @@ the Node.js program on HackerOne.
 - [@shigeki](https://github.com/shigeki) - Shigeki Ohtsu
 - [@targos](https://github.com/targos) - Michaël Zasso
 - [@thefourtheye](https://github.com/thefourtheye) - Sakthipriyan Vairamani
+- [@tniessen](https://github.com/tniessen) - Tobias Nießen
 - [@Trott](https://github.com/Trott) - Rich Trott
 - [@vdeturckheim](https://github.com/vdeturckheim) - Vladimir de Turckheim
 


### PR DESCRIPTION
Syncing the Triage team membership with the [github team](https://github.com/orgs/nodejs/teams/security-triage/members) results in:
- removals: @cjihrig @mcollina and @rvagg are no longer members
- addition: @shigeki is added as a member

To very clear, this doesn't express an opinion on my part, I'm happy for you all to work on Triage, but we have tooling to sync from github, but not the other way around.

1. Do all the current members of @nodejs/security-triage want to remain on the team?
2. Do any of the documented members, @cjihrig @mcollina @rvagg, want to join the github team?

I added some text to state triage team responsibility:

1. @nodejs/tsc, does that look like a reasonable description of the responsibility?
2. @nodejs/security-triage, do you agree to that responsibility?!

Note the number of [security meta-teams](https://github.com/orgs/nodejs/teams?utf8=%E2%9C%93&query=security) and their [private counterparts](https://github.com/orgs/nodejs-private/teams?utf8=%E2%9C%93&query=security)
... I'm not sure if they all have a purpose, do we need them all? Keeping them in-sync seems an entirely manual (thus error prone) process.

Commits:

    2. Clarify Triage team responsibilities

    1. Sync security team members from github
    
    Sync with:
            $ ncu-team sync Security-Team.md