### PR TITLE
Remove Workers from strategic initiatives

### DIFF
--- a/Strategic-Initiatives.md
+++ b/Strategic-Initiatives.md
@@ -43,6 +43,7 @@ and have the support needed.
 | npm Integration     | Myles Borins         | https://github.com/nodejs/node/pull/21594       |
 | OpenSSL Evolution   | Rod Vagg             | https://github.com/nodejs/TSC/issues/677        |
 | Governance          | Myles Borins         |                                                 |
+| Workers             | Anna Henningsen      | https://github.com/nodejs/worker                |
 
 
 [joyeecheung]: https://github.com/joyeecheung

--- a/Strategic-Initiatives.md
+++ b/Strategic-Initiatives.md
@@ -15,7 +15,6 @@ and have the support needed.
 |---------------------|-----------------------------------------------------------|-----------------------------------------------------------------------------------------|
 | Modules             | [Myles Borins][MylesBorins]                               | https://github.com/nodejs/node-eps/blob/master/002-es-modules.md                        |
 | N-API               | [Michael Dawson][mhdawson]                                | https://github.com/nodejs/abi-stable-node                                               |
-| Workers             | [Anna Henningson][addaleax]                               | https://github.com/nodejs/worker                                                        |
 | Core Promise APIs   | [Matteo Collina][mcollina]                                |                                                                                         |
 | New Streams APIs    | [Jeremiah Senkpiel][fishrock123]                          | https://github.com/Fishrock123/bob, https://github.com/Fishrock123/socket               |
 | V8 Currency         | [Michaël Zasso][targos]                                   |                                                                                         |


### PR DESCRIPTION
Workers have been stable for a while now, and while there are still PRs being made against the Worker code, the activity does not stand out from other Node.js core areas and I don’t think the feature requires any special handling at this point.

Also, my name was misspelled.