### PR TITLE
Fix broken link to release team

### DIFF
--- a/Security-Team.md
+++ b/Security-Team.md
@@ -16,7 +16,7 @@ The policy for inclusion is as follows:
 
 1. All members of @nodejs/TSC have access to private security reports and
    private patches.
-2. Members of the [release team](https://github.com/nodejs/node#release-keys)
+2. Members of the @nodejs/releasers team
    have access to private security patches in order to produce releases.
 3. On a case-by-case basis, individuals outside the Technical Steering
    Committee are invited by the TSC to have access to private security reports

--- a/Security-Team.md
+++ b/Security-Team.md
@@ -16,7 +16,7 @@ The policy for inclusion is as follows:
 
 1. All members of @nodejs/TSC have access to private security reports and
    private patches.
-2. Members of the [release team](https://github.com/nodejs/node#release-team)
+2. Members of the [release team](https://github.com/nodejs/node#release-keys)
    have access to private security patches in order to produce releases.
 3. On a case-by-case basis, individuals outside the Technical Steering
    Committee are invited by the TSC to have access to private security reports


### PR DESCRIPTION
The existing link is dead (since https://github.com/nodejs/node/pull/23927 renamed the section).

It looks like it is more accurate to say @nodejs/releasers (i.e. the team that can do releases) rather than link to the signing keys.