### PR TITLE
doc: Charter the package-maintenance working group

### DIFF
--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -458,7 +458,6 @@ Responsibilities include:
   * nodejs/ci-config-travis
   * nodejs/ci-config-github-actions
   * nodejs/package-maintenance repository.
-* Ongoing work to improve the state of 
 
 
 [Technical Steering Committee (TSC)]: ./TSC-Charter.md

--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -437,5 +437,29 @@ This Working Group is _not_ responsible for managing or responding to
 security reports against Node.js itself. That responsibility remains with
 the [Node.js TSC][].
 
+### [Package Maintenance](https://github.com/nodejs/package-maintenance)
+
+Responsibilities include:
+* Building, documenting and evangelizing guidance, tools and processes that make it easier for maintainers to
+  maintain packages and accept help from those who depend on their packages.
+* Management of repositories within the [pkgjs](https://github.com/pkgjs)
+  GitHub organization including but not limited to:
+  * Managing the list of organization owners which supplement the standard
+    Node.js organization owners as outlined in:
+[https://github.com/nodejs/admin/blob/master/GITHUB_ORG_MANAGEMENT_POLICY.md#owners](https://github.com/nodejs/admin/blob/master/GITHUB_ORG_MANAGEMENT_POLICY.md#owners)
+  * Overseeing new repositories (creating, moving, removing)
+  * Managing the maintainer teams for all of the repositories.
+  * Contribution policy for repositories
+* Technical direction for the projects within
+  the [pkgjs](https://github.com/pkgjs)  organization
+* Project governance and process (including this policy)
+* Managing the maintainer teams and contribution policies for the
+  following repositories
+  * nodejs/ci-config-travis
+  * nodejs/ci-config-github-actions
+  * nodejs/package-maintenance repository.
+* Ongoing work to improve the state of 
+
+
 [Technical Steering Committee (TSC)]: ./TSC-Charter.md
 [Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making


### PR DESCRIPTION
Refs: https://github.com/nodejs/admin/issues/470
Refs: https://github.com/nodejs/package-maintenance/pull/338

Signed-off-by: Michael Dawson <michael_dawson@ca.ibm.com>


[470](https://github.com/nodejs/admin/issues/470) includes the initial request for a separate org under the auspices of the Node.js project and the agreement for that.

[338](https://github.com/nodejs/package-maintenance/pull/338) includes the governance updates which document who the new org will be managed by the package-maintenance WG.