### PR TITLE
feat(charter): introduce emergency and async votes

### DIFF
--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -139,9 +139,9 @@ object?" as a final call for dissent from the consensus.
 
 If an agenda item cannot reach a consensus a TSC member can call for
 either a closing vote or a vote to table the issue to the next meeting or to
-be conducted asynchronously through a system to be chosen and seconded by the
-majority of TSC members. The call for a vote must be seconded by a majority
-of the TSC or else the discussion will continue.
+be conducted asynchronously through a system to be chosen by the TSC. The
+call for a vote is approved if none of the TSC members in the meeting object
+to it.
 
 For all votes, a simple majority of all TSC members for, or against, the issue
 wins. A TSC member may choose to participate in any vote through abstention.
@@ -149,16 +149,16 @@ wins. A TSC member may choose to participate in any vote through abstention.
 Note that, in addition to requiring a simple majority vote of the TSC, all
 changes to this charter are also subject to approval from the CPC.
 
-### Section 7.1. Emergency Votes
+### Section 7.1. Immediate Votes
 
 For time-sensitive issues where reaching consensus asynchronously fails, TSC
-members may call for a vote through the TSC mailing list. A compelling reason
+members may call for a vote through the TSC issue tracker. A compelling reason
 must be provided on why calling for a vote can't wait until the next meeting.
-Emergency Votes must be seconded by a majority of the TSC, otherwise the
-issue will be discussed in the next meeting (where a regolar vote can be
-called).
+The issue must remain open for 24 hours before starting the vote process. If
+there are any objections to having a vote, the issue will be discussed in the
+next meeting (where a regular vote can be called).
 
-Except for how they are called, emergency votes follow the same rules as
+Except for how they are called, immediate votes follow the same rules as
 regular votes.
 
 ## Section 8. Project Roles

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -138,10 +138,10 @@ item has appeared to reach a consensus the moderator will ask "Does anyone
 object?" as a final call for dissent from the consensus.
 
 If an agenda item cannot reach a consensus a TSC member can call for
-either a closing vote or a vote to table the issue to the next meeting or to
-be conducted asynchronously through a system to be chosen by the TSC. The
-call for a vote is approved if none of the TSC members in the meeting object
-to it.
+a closing vote (assumes enough TSC members in the meeting), a vote to table the
+issue to the next meeting, or a vote to be conducted asynchronously through a
+system to be chosen by the TSC. The call for a vote is approved if none of the
+TSC members in the meeting object to it.
 
 For all votes, a simple majority of all TSC members for, or against, the issue
 wins. A TSC member may choose to participate in any vote through abstention.

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -68,7 +68,7 @@ participate in TSC discussions, *and* does not participate in TSC votes, the
 member shall be automatically removed from the TSC. The member may be invited
 to continue attending TSC meetings as an observer.
 
-## Section 4. Responsibilities of the TSC.  
+## Section 4. Responsibilities of the TSC.
 
 Subject to such policies as may be set by the CPC, the TSC is
 responsible for all technical development within the Node.js project,
@@ -138,15 +138,28 @@ item has appeared to reach a consensus the moderator will ask "Does anyone
 object?" as a final call for dissent from the consensus.
 
 If an agenda item cannot reach a consensus a TSC member can call for
-either a closing vote or a vote to table the issue to the next meeting.
-The call for a vote must be seconded by a majority of the TSC or else the
-discussion will continue.
+either a closing vote or a vote to table the issue to the next meeting or to
+be conducted asynchronously through a system to be chosen and seconded by the
+majority of TSC members. The call for a vote must be seconded by a majority
+of the TSC or else the discussion will continue.
 
 For all votes, a simple majority of all TSC members for, or against, the issue
 wins. A TSC member may choose to participate in any vote through abstention.
 
 Note that, in addition to requiring a simple majority vote of the TSC, all
 changes to this charter are also subject to approval from the CPC.
+
+### Section 7.1. Emergency Votes
+
+For time-sensitive issues where reaching consensus asynchronously fails, TSC
+members may call for a vote through the TSC mailing list. A compelling reason
+must be provided on why calling for a vote can't wait until the next meeting.
+Emergency Votes must be seconded by a majority of the TSC, otherwise the
+issue will be discussed in the next meeting (where a regolar vote can be
+called).
+
+Except for how they are called, emergency votes follow the same rules as
+regular votes.
 
 ## Section 8. Project Roles
 


### PR DESCRIPTION
Asynchronous voting is appropriate for issues that should be votes by
as many TSC members as possible.

Emergency votes are intended as a tool to resolve issues that are
time-sensitive and TSC can't reach consensus on it in a timely manner
asynchronously.