### PR TITLE
doc: update reference to member travel fund

### DIFF
--- a/Member-Travel-Fund.md
+++ b/Member-Travel-Fund.md
@@ -1,2 +1,2 @@
 Travel fund policy and usage records have been moved to
-[nodejs/admin/MEMBER_TRAVEL_FUND.md](https://github.com/nodejs/admin/blob/master/MEMBER_TRAVEL_FUND.md).
+[nodejs/admin](https://github.com/nodejs/admin).


### PR DESCRIPTION
The member travel fund documents were split into multiple documents and the link doesn't work anymore, so it's probably better to link to the repository instead of a non-existing file.