### PR TITLE
doc: avoid directing to HTTP if possible

### DIFF
--- a/BasePolicies/Governance.md
+++ b/BasePolicies/Governance.md
@@ -153,5 +153,5 @@ By making a contribution to this project, I certify that:
   maintained indefinitely and may be redistributed consistent with
   this project or the open source license(s) involved.
 
-[Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making
+[Consensus Seeking]: https://en.wikipedia.org/wiki/Consensus-seeking_decision-making
 [README.md]: ./README.md#current-project-team-members

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -180,6 +180,6 @@ rarely be encumbered by the TSC and never by the CPC or OpenJS Foundation Board.
 is organized through the project creation process and approved by the
 TSC.
 
-[Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making
-[Condorcet]: http://en.wikipedia.org/wiki/Condorcet_method
-[Single Transferable Vote]: http://en.wikipedia.org/wiki/Single_transferable_vote
+[Consensus Seeking]: https://en.wikipedia.org/wiki/Consensus-seeking_decision-making
+[Condorcet]: https://en.wikipedia.org/wiki/Condorcet_method
+[Single Transferable Vote]: https://en.wikipedia.org/wiki/Single_transferable_vote


### PR DESCRIPTION
There is no reason to use plain HTTP, it only makes things easier to track/hijack for ISPs and other untrustworthy entities.