### PR TITLE
strategic initiatives: mark modules as complete

### DIFF
--- a/Strategic-Initiatives.md
+++ b/Strategic-Initiatives.md
@@ -41,7 +41,7 @@ and have the support needed.
 | Workers             | Anna Henningsen      | https://github.com/nodejs/worker                |
 | N-API               | Michael Dawson       | https://github.com/nodejs/abi-stable-node       |
 | Open Web Standards  | Myles Borins Joyee Cheung | https://github.com/nodejs/open-standards   |
-| Modules             | Myles Borins.        | https://github.com/nodejs/modules               |
+| Modules             | Myles Borins         | https://github.com/nodejs/modules               |
 
 
 [joyeecheung]: https://github.com/joyeecheung
@@ -61,4 +61,3 @@ and have the support needed.
 [mcollina]: https://github.com/mcollina
 [jasnell]: https://github.com/jasnell
 [mmarchini]: https://github.com/mmarchini
-

--- a/Strategic-Initiatives.md
+++ b/Strategic-Initiatives.md
@@ -13,7 +13,6 @@ and have the support needed.
 
 | Initiative                | Champion                                                  | Links                                                                                   |
 |---------------------------|-----------------------------------------------------------|-----------------------------------------------------------------------------------------|
-| Modules                   | [Myles Borins][MylesBorins]                               | https://github.com/nodejs/modules                        |
 | Core Promise APIs         | [Matteo Collina][mcollina]                                |                                                                                         |
 | V8 Currency               | [Michaël Zasso][targos]                                   |                                                                                         |
 | QUIC / HTTP3              | [James M Snell][jasnell]                                  | https://github.com/nodejs/quic                                                          |
@@ -42,6 +41,7 @@ and have the support needed.
 | Workers             | Anna Henningsen      | https://github.com/nodejs/worker                |
 | N-API               | Michael Dawson       | https://github.com/nodejs/abi-stable-node       |
 | Open Web Standards  | Myles Borins Joyee Cheung | https://github.com/nodejs/open-standards   |
+| Modules             | Myles Borins.        | https://github.com/nodejs/modules               |
 
 
 [joyeecheung]: https://github.com/joyeecheung


### PR DESCRIPTION
After many years of work we are marking ESM in Node.js as stable
and sunsetting the Modules Team. Some high level next steps

* Mark modules as stable in core
* Review remaining open issues in nodejs/modules and close / transfer
* Simplify team structure and prune inactive team members

Refs: https://github.com/nodejs/node/pull/35781
Refs: https://github.com/nodejs/modules/issues/567
Refs: https://github.com/orgs/nodejs/teams/modules/discussions/8