### PR TITLE
fix: add missing md link

### DIFF
--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -445,4 +445,5 @@ Responsibilities include:
 
 
 [Technical Steering Committee (TSC)]: ./TSC-Charter.md
+[Node.js TSC]: https://github.com/nodejs/tsc 
 [Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making


### PR DESCRIPTION
I was reading through this doc today and noticed that there was a Markdown link on line [422](https://github.com/nodejs/TSC/blame/main/WORKING_GROUPS.md#L422) that was borked, so I fixed it <3