### PR TITLE
updates to TSC charter

### DIFF
--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -31,7 +31,7 @@ of the TSC.
 TSC memberships are not time-limited. There is no maximum size of the TSC.
 The size is expected to vary in order to ensure adequate coverage of important
 areas of expertise, balanced with the ability to make decisions efficiently.
-The TSC must have at least three members.
+The TSC must have at least four members.
 
 There is no specific set of requirements or qualifications for TSC
 membership beyond these rules. The TSC may add additional members to the
@@ -77,7 +77,7 @@ including:
 * Setting release dates.
 * Release quality standards.
 * Technical direction.
-* Project governance and process (including this policy).
+* Project governance and process.
 * GitHub repository hosting.
 * Conduct guidelines.
 * Maintaining the list of additional Collaborators.


### PR DESCRIPTION
These updates will require either CPC or Foundation Board approval.

Updates in this commit:

* Resolved an internal conflict in the charter where the minimum
  membership was stated to be three members, but a second provision
  provides that no more than one-fourth of the members can be affiliated
  with the same employer. That second requirement is impossible to meet if
  there are only three members. This change resolves that inconsistency by
  increasing the  minimum membership to four.

* Remove the indication that the TSC is responsible for the Charter. The
  Charter comes from the Foundation Board via the CPC. The TSC is not
  self-chartering.

Trivial updates from previous commits that were not run by the board,
but now is a good time to do it:

* The three links in the bottom references were changed from `http` to
  `https` in https://github.com/nodejs/TSC/pull/945.

* A superfluous space was removed from the end of a line in
  https://github.com/nodejs/TSC/pull/978.