### PR TITLE
fix: remark-lint-no-literal-urls

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -5,7 +5,6 @@
     ["remark-lint-fenced-code-flag", false],
     ["remark-lint-first-heading-level", false],
     ["remark-lint-maximum-line-length", false],
-    ["remark-lint-no-literal-urls", false],
     ["remark-lint-prohibited-strings", false],
     ["remark-lint-unordered-list-marker-style", false]
   ]

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,5 +3,5 @@
 The Technical Steering Committee is committed to upholding the Node.js Code of Conduct.
 
 The Node.js Code of Conduct document has moved to
-https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md Please update
+<https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md> Please update
 links to this document accordingly.

--- a/Moderation-Policy.md
+++ b/Moderation-Policy.md
@@ -1,5 +1,5 @@
 # Moderation Policy
 
 The Node.js Moderation policy has moved to
-https://github.com/nodejs/admin/blob/master/Moderation-Policy.md Please update
+<https://github.com/nodejs/admin/blob/master/Moderation-Policy.md> Please update
 links to this document accordingly.

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -19,7 +19,7 @@ invalid and are superseded by the TSC Charter.
 * Invite them to the HackerOne [Node.js team](https://hackerone.com/nodejs/team_members).
 * Add them to the `tsc` and `crypto-export` mailing lists.
 * Update the `@nodejs/node` repository README to reflect membership in the TSC.
-* Update https://github.com/nodejs/create-node-meeting-artifacts/blob/master/templates/invited_tsc and https://github.com/nodejs/create-node-meeting-artifacts/blob/master/templates/observers_tsc to reflect membership in the TSC.
+* Update <https://github.com/nodejs/create-node-meeting-artifacts/blob/master/templates/invited_tsc> and <https://github.com/nodejs/create-node-meeting-artifacts/blob/master/templates/observers_tsc> to reflect membership in the TSC.
 
 ## Offboarding
 
@@ -36,4 +36,4 @@ invalid and are superseded by the TSC Charter.
 * Remove them from the `tsc` and `crypto-export` mailing lists.
 * Update the `@nodejs/node` repository README to reflect membership in the TSC.
   In all likelihood, they should be listed as TSC Emeritus.
-* Update https://github.com/nodejs/create-node-meeting-artifacts/blob/master/templates/invited_tsc to reflect membership in the TSC.
+* Update <https://github.com/nodejs/create-node-meeting-artifacts/blob/master/templates/invited_tsc> to reflect membership in the TSC.

--- a/OpenSSL-Strategy.md
+++ b/OpenSSL-Strategy.md
@@ -68,7 +68,7 @@ The plan described above is to:
   retain ABI and API compatibility. OpenSSL 1.1.1 is claimed by the OpenSSL
   project to be API and ABI compatible with 1.1.0, and Node.js experiments
   indicates that it is, see
-  https://github.com/nodejs/node/issues/18770#issuecomment-446785733.
+  <https://github.com/nodejs/node/issues/18770#issuecomment-446785733>.
 * **No support for FIPS** The latest [OpenSSL 3.0 and FIPS Update][] does not
   predict that an OpenSSL 1.1.1 ABI compatible library with FIPS support will
   ever exist. Without such a library, Node.js 10.x cannot support FIPS.
@@ -163,7 +163,7 @@ Challenges are:
   Node.js master test suite (effort to fix this is unknown, impact of fixing
   in terms of compatibility is unknown).
 
-Tracking issue: https://github.com/nodejs/node/issues/29817
+Tracking issue: <https://github.com/nodejs/node/issues/29817>
 
 ## Background
 
@@ -281,7 +281,7 @@ source:
   `deps: fix asm build error of openssl in x86_win32`. A fix for
   deps/openssl/openssl/crypto/perlasm/x86masm.pl for ASM produced for Windows on
   IA32 as described in
-  https://mta.openssl.org/pipermail/openssl-dev/2015-February/000651.html
+  <https://mta.openssl.org/pipermail/openssl-dev/2015-February/000651.html>
 * [2eb170874](https://github.com/nodejs/node/commit/2eb170874aa5e84e71b62caab7ac9792fd59c10f):
   `openssl: fix keypress requirement in apps on win32`. A fix for the `openssl`
   client application, used by the Node.js test suite, to properly accept stdin

--- a/README.md
+++ b/README.md
@@ -29,18 +29,18 @@ document and ship Node.js releases.
 
 These projects are located in the following repositories:
 
-* https://github.com/nodejs/TSC
-* https://github.com/nodejs/build — administration delegated to the Build Working Group
-* https://github.com/nodejs/citgm — administration delegated to the Release Working Group
-* https://github.com/nodejs/docker-node — administration delegated to the Docker Working Group
-* https://github.com/nodejs/http-parser — administration delegated to the Core Technical Committee
-* https://github.com/nodejs/node-eps — administration delegated to the Core Technical Committee
-* https://github.com/nodejs/nodejs-dist-indexer — administration delegated to the Build Working Group
-* https://github.com/nodejs/nodejs-latest-linker — administration delegated to the Build Working Group
-* https://github.com/nodejs/nodejs-nightly-builder — administration delegated to the Build Working Group
-* https://github.com/nodejs/nodejs.org — administration delegated to the Website Working Group
-* https://github.com/nodejs/secrets — _private_, administration delegated to the Build Working Group
-* https://github.com/nodejs/Release — administration delegated to the Release Working Group
+* <https://github.com/nodejs/TSC>
+* <https://github.com/nodejs/build> — administration delegated to the Build Working Group
+* <https://github.com/nodejs/citgm> — administration delegated to the Release Working Group
+* <https://github.com/nodejs/docker-node> — administration delegated to the Docker Working Group
+* <https://github.com/nodejs/http-parser> — administration delegated to the Core Technical Committee
+* <https://github.com/nodejs/node-eps> — administration delegated to the Core Technical Committee
+* <https://github.com/nodejs/nodejs-dist-indexer> — administration delegated to the Build Working Group
+* <https://github.com/nodejs/nodejs-latest-linker> — administration delegated to the Build Working Group
+* <https://github.com/nodejs/nodejs-nightly-builder> — administration delegated to the Build Working Group
+* <https://github.com/nodejs/nodejs.org> — administration delegated to the Website Working Group
+* <https://github.com/nodejs/secrets> — _private_, administration delegated to the Build Working Group
+* <https://github.com/nodejs/Release> — administration delegated to the Release Working Group
 
 ### Adjacent Projects
 
@@ -61,33 +61,33 @@ changes to scope that it entails are acceptable.
 Current adjacent projects that are within the TSC's scope of responsibility
 include:
 
-* https://github.com/nodejs/abi-stable-node — administration delegated to the API Working Group
-* https://github.com/nodejs/abi-stable-node-addon-examples — administration delegated to the API Working Group
-* https://github.com/nodejs/api — administration delegated to the API Working Group
-* https://github.com/nodejs/code-and-learn
-* https://github.com/nodejs/diagnostics — administration delegated to the Diagnostics Working Group
-* https://github.com/nodejs/docs
-* https://github.com/nodejs/education
-* https://github.com/nodejs/email — administration delegated to the Build Working Group
-* https://github.com/nodejs/github-bot
-* https://github.com/nodejs/help
-* https://github.com/nodejs/http
-* https://github.com/nodejs/http2
-* https://github.com/nodejs/installer
-* https://github.com/nodejs/llnode — administration delegated to the Post Mortem Working Group
-* https://github.com/nodejs/nan — administration delegated to the Addon API Working Group
-* https://github.com/nodejs/node-addon-examples — administration delegated to the Addon API Working Group
-* https://github.com/nodejs/node-chakracore
-* https://github.com/nodejs/node-gyp
-* https://github.com/nodejs/node-inspect — administration delegated to the Diagnostics Working Group
-* https://github.com/nodejs/node-report — administration delegated to the Post Mortem Working Group
-* https://github.com/nodejs/nodejs.org — administration delegated to the Website Working Group
-* https://github.com/nodejs/post-mortem — administration delegated to the Post Mortem Working Group
-* https://github.com/nodejs/promises
-* https://github.com/nodejs/readable-stream — administration delegated to the Streams Working Group
-* https://github.com/nodejs/summit
-* https://github.com/nodejs/testing
-* _And_ various language and resource translation groups under https://github.com/nodejs/
+* <https://github.com/nodejs/abi-stable-node> — administration delegated to the API Working Group
+* <https://github.com/nodejs/abi-stable-node-addon-examples> — administration delegated to the API Working Group
+* <https://github.com/nodejs/api> — administration delegated to the API Working Group
+* <https://github.com/nodejs/code-and-learn>
+* <https://github.com/nodejs/diagnostics> — administration delegated to the Diagnostics Working Group
+* <https://github.com/nodejs/docs>
+* <https://github.com/nodejs/education>
+* <https://github.com/nodejs/email> — administration delegated to the Build Working Group
+* <https://github.com/nodejs/github-bot>
+* <https://github.com/nodejs/help>
+* <https://github.com/nodejs/http>
+* <https://github.com/nodejs/http2>
+* <https://github.com/nodejs/installer>
+* <https://github.com/nodejs/llnode> — administration delegated to the Post Mortem Working Group
+* <https://github.com/nodejs/nan> — administration delegated to the Addon API Working Group
+* <https://github.com/nodejs/node-addon-examples> — administration delegated to the Addon API Working Group
+* <https://github.com/nodejs/node-chakracore>
+* <https://github.com/nodejs/node-gyp>
+* <https://github.com/nodejs/node-inspect> — administration delegated to the Diagnostics Working Group
+* <https://github.com/nodejs/node-report> — administration delegated to the Post Mortem Working Group
+* <https://github.com/nodejs/nodejs.org> — administration delegated to the Website Working Group
+* <https://github.com/nodejs/post-mortem> — administration delegated to the Post Mortem Working Group
+* <https://github.com/nodejs/promises>
+* <https://github.com/nodejs/readable-stream> — administration delegated to the Streams Working Group
+* <https://github.com/nodejs/summit>
+* <https://github.com/nodejs/testing>
+* _And_ various language and resource translation groups under <https://github.com/nodejs/>
 
 ### List of TSC Responsibilities
 
@@ -134,6 +134,7 @@ A [current list of TSC members](https://github.com/nodejs/node#tsc-technical-ste
 is maintained in the main Node.js repository.
 
 ## YouTube
+
 Many teams/groups post meeting videos to the
 [Node.js YouTube channel][].
 

--- a/Security-Team.md
+++ b/Security-Team.md
@@ -132,7 +132,7 @@ The expected workflow for issues reported to Node.js is:
   Issues in this state are waiting for the Node.js team to take some action to
   resolve them. Typically, this would be publishing a Node.js release that
   resolves the issue, but it could also be publishing documentation, or making
-  a configuration change to our infrastructure for a https://nodejs.org
+  a configuration change to our infrastructure for a <https://nodejs.org>
   problem. The expected resolution should be described in a comment on the
   issue when it is moved to `TRIAGED`.
     - ...: There are no explicit states for an issue as it is in process of

--- a/Strategic-Initiatives.md
+++ b/Strategic-Initiatives.md
@@ -15,32 +15,32 @@ and have the support needed.
 |---------------------------|-----------------------------|------------------------------------------------------------------------------------------|
 | Core Promise APIs         | [Matteo Collina][mcollina]  |                                                                                          |
 | V8 Currency               | [Michaël Zasso][targos]     |                                                                                          |
-| QUIC / HTTP3              | [James M Snell][jasnell]    | https://github.com/nodejs/quic                                                           |
-| Startup performance       | [Joyee Cheung][joyeecheung] | https://github.com/nodejs/node/issues/17058 https://github.com/nodejs/node/issues/21563  |
-| Build resources           | [Michael Dawson][mhdawson]  | https://github.com/nodejs/build/issues/1154#issuecomment-448418977                       |
-| Future of Build Toolchain | [Mary Marchini][mmarchini]  | https://github.com/nodejs/TSC/issues/901, https://github.com/nodejs/build-toolchain-next |
+| QUIC / HTTP3              | [James M Snell][jasnell]    | <https://github.com/nodejs/quic>                                                           |
+| Startup performance       | [Joyee Cheung][joyeecheung] | <https://github.com/nodejs/node/issues/17058> <https://github.com/nodejs/node/issues/21563>  |
+| Build resources           | [Michael Dawson][mhdawson]  | <https://github.com/nodejs/build/issues/1154#issuecomment-448418977>                       |
+| Future of Build Toolchain | [Mary Marchini][mmarchini]  | <https://github.com/nodejs/TSC/issues/901>, <https://github.com/nodejs/build-toolchain-next> |
 
 ## Need volunteers for
 
 | Initiative       | Champion | Links                                                                     |
 |------------------|----------|---------------------------------------------------------------------------|
-| Async Hooks      | ?        | https://github.com/nodejs/diagnostics/issues/124                          |
-| New Streams APIs | ?        | https://github.com/Fishrock123/bob, https://github.com/Fishrock123/socket |
+| Async Hooks      | ?        | <https://github.com/nodejs/diagnostics/issues/124>                          |
+| New Streams APIs | ?        | <https://github.com/Fishrock123/bob>, <https://github.com/Fishrock123/socket> |
 
 ## Completed
 
 | Initiative         | Champion                  | Links                                           |
 |--------------------|---------------------------|-------------------------------------------------|
-| CVE Management     | Michael Dawson            | https://github.com/nodejs/security-wg/issues/33 |
-| Moderation Team    | Rich Trott                | https://github.com/nodejs/TSC/issues/329        |
-| VM module fix      | Franziska Hinkelmann      | https://github.com/nodejs/node/issues/6283      |
-| npm Integration    | Myles Borins              | https://github.com/nodejs/node/pull/21594       |
-| OpenSSL Evolution  | Rod Vagg                  | https://github.com/nodejs/TSC/issues/677        |
+| CVE Management     | Michael Dawson            | <https://github.com/nodejs/security-wg/issues/33> |
+| Moderation Team    | Rich Trott                | <https://github.com/nodejs/TSC/issues/329>        |
+| VM module fix      | Franziska Hinkelmann      | <https://github.com/nodejs/node/issues/6283>      |
+| npm Integration    | Myles Borins              | <https://github.com/nodejs/node/pull/21594>       |
+| OpenSSL Evolution  | Rod Vagg                  | <https://github.com/nodejs/TSC/issues/677>        |
 | Governance         | Myles Borins              |                                                 |
-| Workers            | Anna Henningsen           | https://github.com/nodejs/worker                |
-| N-API              | Michael Dawson            | https://github.com/nodejs/abi-stable-node       |
-| Open Web Standards | Myles Borins Joyee Cheung | https://github.com/nodejs/open-standards        |
-| Modules            | Myles Borins              | https://github.com/nodejs/modules               |
+| Workers            | Anna Henningsen           | <https://github.com/nodejs/worker>                |
+| N-API              | Michael Dawson            | <https://github.com/nodejs/abi-stable-node>       |
+| Open Web Standards | Myles Borins Joyee Cheung | <https://github.com/nodejs/open-standards>        |
+| Modules            | Myles Borins              | <https://github.com/nodejs/modules>               |
 
 [joyeecheung]: https://github.com/joyeecheung
 [mhdawson]: https://github.com/mhdawson

--- a/Streaming/Streaming-To-Youtube.md
+++ b/Streaming/Streaming-To-Youtube.md
@@ -13,7 +13,7 @@ Your YouTube Account must be a manager of the
 Ask the TSC Chair or foundation managers (Amanda Ennis, Brian Warner, Rachel
 Romoff) to make your account a manager. To add managers or verify an account
 is a manager:
-1. Go to https://youtube.com
+1. Go to <https://youtube.com>
 2. Click on the node.js icon on the right top.
 3. Select settings, select "Add or remove managers", select "Manage permissions"
 4. On that page you can use the +people at the top right of the popup to add
@@ -23,13 +23,13 @@ is a manager:
 
 ### Start and Stop the stream
 
-1. Login to https://zoom.us using the Foundation credentials.
-2. Go to https://zoom.us/webinar/list, find the meeting.
+1. Login to <https://zoom.us> using the Foundation credentials.
+2. Go to <https://zoom.us/webinar/list>, find the meeting.
 3. Press "Start", it should open the meeting in the Zoom application.
 4. Go to "Participants" panel, check Attendees, promote them to panelists.
 5. Go to "... More" in toolbar, choose "Live on YouTube", it will open in
   browser.
-6. Choose to login to https://youtube.com with Node.js account, accept
+6. Choose to login to <https://youtube.com> with Node.js account, accept
   Zoom usage agreement (on first use)
 7. On the Streaming page, edit the webinar title to include the meeting date,
   then press the red "Go Live!" button. Troubleshooting note: at least one

--- a/meetings/2015-05-27.md
+++ b/meetings/2015-05-27.md
@@ -2,10 +2,10 @@
 
 ## Links
 
-* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-05-27
-* **Public YouTube feed**: http://www.youtube.com/watch?v=0DPfLxulsbQ
-* **GitHub Issue**: https://github.com/nodejs/node-convergence-archive/issues/41
-* **Original Minutes Google Doc**: https://docs.google.com/document/d/1-KlxiQGMsJFNJu3meok9e9XFsM39k_PMnQmY_9d_cy0
+* **Audio Recording**: <https://soundcloud.com/node-foundation/tsc-meeting-2015-05-27>
+* **Public YouTube feed**: <http://www.youtube.com/watch?v=0DPfLxulsbQ>
+* **GitHub Issue**: <https://github.com/nodejs/node-convergence-archive/issues/41>
+* **Original Minutes Google Doc**: <https://docs.google.com/document/d/1-KlxiQGMsJFNJu3meok9e9XFsM39k_PMnQmY_9d_cy0>
 
 ## Agenda
 

--- a/meetings/2015-06-03.md
+++ b/meetings/2015-06-03.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-06-03
-* **GitHub Issue**: https://github.com/nodejs/node-convergence-archive/issues/47
-* **Original Minutes Google Doc**: https://docs.google.com/document/d/1sTD0uryasBR15UBzEbJj3oHYtnuN9ZIqVxA2A_-N56E
+* **Audio Recording**: <https://soundcloud.com/node-foundation/tsc-meeting-2015-06-03>
+* **GitHub Issue**: <https://github.com/nodejs/node-convergence-archive/issues/47>
+* **Original Minutes Google Doc**: <https://docs.google.com/document/d/1sTD0uryasBR15UBzEbJj3oHYtnuN9ZIqVxA2A_-N56E>
 
 ## Agenda
 

--- a/meetings/2015-06-10.md
+++ b/meetings/2015-06-10.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-06-10
-* **GitHub Issue**: https://github.com/nodejs/node-convergence-archive/issues/53
-* **Original Minutes Google Doc**: https://docs.google.com/document/d/1cn7SKaKYUMYLBiQhE6HAAknnwPabKsYjpOuyQkVikW8
+* **Audio Recording**: <https://soundcloud.com/node-foundation/tsc-meeting-2015-06-10>
+* **GitHub Issue**: <https://github.com/nodejs/node-convergence-archive/issues/53>
+* **Original Minutes Google Doc**: <https://docs.google.com/document/d/1cn7SKaKYUMYLBiQhE6HAAknnwPabKsYjpOuyQkVikW8>
 
 ## Agenda
 
@@ -93,7 +93,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting
 
 #### Nominating new collaborators to this repository
 
-See https://github.com/joyent/node/issues/25481.
+See <https://github.com/joyent/node/issues/25481>.
 
 Main question was: should we add nominated collaborators who are not io.js collaborators too the “collaborators” team in the nodejs organization too?
 
@@ -145,7 +145,7 @@ Decision was that it might be confusing at first, so onboarding of these collabo
 * **Julien**: timing might not work for anyone.
 * **Bert**: Rod pinged a bunch of people, haven’t seen a lot of response. Wyatt Preul is involved, you will probably want to reach out to him, Same for ofrobots.
 * **Michael**: want to make sure that everyone is ok with merging LTS meeting with joyent/node TSC meeting.
-* **Julien**: discussion ongoing here: https://github.com/nodejs/LTS/issues/6#issuecomment-109352447.
+* **Julien**: discussion ongoing here: <https://github.com/nodejs/LTS/issues/6#issuecomment-109352447>.
 
 ### Discussion items not on the agenda
 

--- a/meetings/2015-06-17.md
+++ b/meetings/2015-06-17.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-06-17
-* **GitHub Issue**: https://github.com/nodejs/node-convergence-archive/issues/56
-* **Original Minutes Google Doc**: https://docs.google.com/document/d/1d4mAJgm06rpPWLDqhZcxsRnKMrS92Ip4CW2akOyeIL4
+* **Audio Recording**: <https://soundcloud.com/node-foundation/tsc-meeting-2015-06-17>
+* **GitHub Issue**: <https://github.com/nodejs/node-convergence-archive/issues/56>
+* **Original Minutes Google Doc**: <https://docs.google.com/document/d/1d4mAJgm06rpPWLDqhZcxsRnKMrS92Ip4CW2akOyeIL4>
 
 ## Agenda
 
@@ -64,14 +64,14 @@ Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting
 * Rod: build, productive work on improving the ci and build convergence, ci now does linting before running the tests, also improving the io.js make file so that less logic for releases is contained in jenkins
 * Colin: reviewing issues and pr’s, landed a cluster patch to not use --debug_port on cluster workers by default
 * Chris: NodeConf, got great feedback there. PR for code coverage incoming soon, spun up the docs WG.
-  * http://neversaw.us/scratch/node-coverage/ – code coverage
-  * https://github.com/nodejs/docs
+  * <http://neversaw.us/scratch/node-coverage/> – code coverage
+  * <https://github.com/nodejs/docs>
 * Michael: Reviewing OpenSSL changes for LogJam; PPC LE & BE work nearly complete, some OpenSSL blockers (EC related)--working towards including PPC in CI
 * Mikeal: running NodeConf and writing up feedback & foundation work
 * Steven: getting back on board
-* Bert: libuv work for multi-worker on Windows (https://github.com/libuv/libuv/pull/396), found a potential libuv/Windows contributor at NodeConf, NF board meeting
+* Bert: libuv work for multi-worker on Windows (<https://github.com/libuv/libuv/pull/396>), found a potential libuv/Windows contributor at NodeConf, NF board meeting
 * Alexis: Working on build & CI convergence with Rod, CI can now automatically decide what options to use for different node versions, and porting node-accept-pull-request CI job.
-* Julien: time off, launching nodejs.org updates for NF launch, working on changes for 0.10/0.12 releases, onboarded two new collaborators for joyent/node - https://github.com/nodejs/LTS/wiki/Breaking-changes-between-v0.12-and-next-LTS-release
+* Julien: time off, launching nodejs.org updates for NF launch, working on changes for 0.10/0.12 releases, onboarded two new collaborators for joyent/node - <https://github.com/nodejs/LTS/wiki/Breaking-changes-between-v0.12-and-next-LTS-release>
 * Shigeki: Working on upgrading OpenSSL, the upgrade process is becoming much simpler, landed the CINNIC whitelist
 * Jeremiah: NodeConf - brought back good feedback, helping spin up the Diversity WG, integrating timers heap impl, struggling with bugs
 * Brian: not much, triage & PR review
@@ -86,19 +86,19 @@ Called for a vote, got +1's for both candidates from each of: Chris, Rod, Bert, 
 
 ### on working with proposals from the API WG [#1993](https://github.com/nodejs/io.js/issues/1993)
 
-* Trevor: started discussions back in advisory board before io.js existed, large companies wanted “official Node.js compatibility” at both module and JS layer. Some dissenting voices in Joyent that prevented things proceeding. After io.js happened the formal discussion ended but informal discussion continued, e.g. in https://github.com/nodejs/nan/issues/349, aim at the C++ level is to reduce API turn-over. Companies involved have their own VMs and want to maintain them for their own purposes (e.g. Chakra, JVM).
+* Trevor: started discussions back in advisory board before io.js existed, large companies wanted “official Node.js compatibility” at both module and JS layer. Some dissenting voices in Joyent that prevented things proceeding. After io.js happened the formal discussion ended but informal discussion continued, e.g. in <https://github.com/nodejs/nan/issues/349>, aim at the C++ level is to reduce API turn-over. Companies involved have their own VMs and want to maintain them for their own purposes (e.g. Chakra, JVM).
 * Trevor: interested in starting a WG or piggy-backing Addon API WG.
 * Domenic: would like more clarity on what this thing could be, is it libuv.js? is it a VM abstraction layer?
 * Bert: would be good to scope this work
 * Trevor: there’s one interest group--concerned with binary addons and not having to ship new versions with each new Node release. Another interest group is concerned with something akin to a process.bindings abstraction layer so you could put the Node JS layer on top of whatever runtime chosen.
 * Bert: standardising the process.bindings API might be easiest but standardising the C++ API has more beneifits because it solves the v8-upgrade-breaks-addons problem.
-* Rod: https://github.com/nodejs/nan/issues/373 is an issue in NAN for organising a meeting for the various groups interested in exploring C++ API compatibility, specifically for addons.
+* Rod: <https://github.com/nodejs/nan/issues/373> is an issue in NAN for organising a meeting for the various groups interested in exploring C++ API compatibility, specifically for addons.
 
 ### zlib: prevent uncaught exception in zlibBuffer [#1811](https://github.com/nodejs/io.js/issues/1811)
 
 * Trevor: Issue #1811 is potentially CVE-worthy, it’s been fixed but what is the process for going forward with a CVE if necessary?
-* Rod: security@nodejs.org has an expanded team and security@iojs.org redirects there as well. That team should be delegated to for discussion--if you have concerns then email them and let them be responsible for deciding how to proceed.
-* ACTION: Trevor to email summary of potential security concern to security@nodejs.org for further discussion amongst that group. Potentially also backporting to 0.10 and 0.12.
+* Rod: <mailto:security@nodejs.org> has an expanded team and <mailto:security@iojs.org> redirects there as well. That team should be delegated to for discussion--if you have concerns then email them and let them be responsible for deciding how to proceed.
+* ACTION: Trevor to email summary of potential security concern to <mailto:security@nodejs.org> for further discussion amongst that group. Potentially also backporting to 0.10 and 0.12.
 
 ### Proposal: Release Process [#1997](https://github.com/nodejs/io.js/issues/1997)
 

--- a/meetings/2015-07-01.md
+++ b/meetings/2015-07-01.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-07-01
-* **GitHub Issue**: https://github.com/nodejs/node-convergence-archive/issues/60
-* **Original Minutes Google Doc**: https://docs.google.com/document/d/1TN3Ks0fC4ciY3jeS0VxXxXRkT_dq8-tfs-bWQqZGRoE
+* **Audio Recording**: <https://soundcloud.com/node-foundation/tsc-meeting-2015-07-01>
+* **GitHub Issue**: <https://github.com/nodejs/node-convergence-archive/issues/60>
+* **Original Minutes Google Doc**: <https://docs.google.com/document/d/1TN3Ks0fC4ciY3jeS0VxXxXRkT_dq8-tfs-bWQqZGRoE>
 
 ## Agenda
 
@@ -63,9 +63,9 @@ Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting
 
 ### Internationalization WG (Steven)
 
-* https://github.com/nodejs/internationalization (repo)
-* https://github.com/nodejs/internationalization/issues/4 (README)
-* https://github.com/nodejs/internationalization/issues/5 (CFP)
+* <https://github.com/nodejs/internationalization> (repo)
+* <https://github.com/nodejs/internationalization/issues/4> (README)
+* <https://github.com/nodejs/internationalization/issues/5> (CFP)
 
 * Steven introduced the work towards getting this set up
 * Steven clarified the scope of the work (this is done in the README), it’s different to outreach and user assistance (i.e. the i18n translation stuff that io.js already has).

--- a/meetings/2015-07-08.md
+++ b/meetings/2015-07-08.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-07-08
-* **GitHub Issue**: https://github.com/nodejs/node-convergence-archive/issues/64
-* **Original Minutes Google Doc**: https://docs.google.com/document/d/1HuRtu5ZP7ZlrIp756EbZYo4I26v2RY-7CY1pr_3y1nY
+* **Audio Recording**: <https://soundcloud.com/node-foundation/tsc-meeting-2015-07-08>
+* **GitHub Issue**: <https://github.com/nodejs/node-convergence-archive/issues/64>
+* **Original Minutes Google Doc**: <https://docs.google.com/document/d/1HuRtu5ZP7ZlrIp756EbZYo4I26v2RY-7CY1pr_3y1nY>
 
 ## Agenda
 
@@ -82,7 +82,7 @@ Chris: “count-docula”, a MDAST-based tool to verify correctness of the docs.
 * Rod: not sure we should do anything since detecting this is somewhat arbitrary.
 * Domenic: there is a proposal for this that chrome implements behind a flag that comes close to how the unhandledRejection hook in node works
 * Discussion about the technicalities of having a better hook for printing a warning after garbage collection of an unhandled rejection.
-* See this thread for background detail of options in v8: https://code.google.com/p/v8/issues/detail?id=3093#c1
+* See this thread for background detail of options in v8: <https://code.google.com/p/v8/issues/detail?id=3093#c1>
 * Action: nothing now, maybe if v8 adds a hook for when rejections get garbage collected.
 * Domenic: looking at v8, it seems to have most of the hooks, so this may be possible soon.
 
@@ -105,7 +105,7 @@ Chris: “count-docula”, a MDAST-based tool to verify correctness of the docs.
 * Chris: iojs has had the release manager propose other release managers. Open an issue for this.
 * Resolved as such.
 
-### lts: LTS Proposal https://github.com/nodejs/LTS#proposed-lts)/ Proposal: Release Process [#1997](https://github.com/nodejs/io.js/issues/1997)
+### lts: LTS Proposal <https://github.com/nodejs/LTS#proposed-lts)/> Proposal: Release Process [#1997](https://github.com/nodejs/io.js/issues/1997)
 
 * James: when are we cutting over to the converged stream? Thinking of late august, first LTS release in October. Is this a good time? Most users won’t start migrating until next year because of the holidays.
 * Julien: what are other projects doing, when do they release?

--- a/meetings/2015-07-15.md
+++ b/meetings/2015-07-15.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-07-15
-* **GitHub Issue**: https://github.com/nodejs/node-convergence-archive/issues/67
-* **Original Minutes Google Doc**: https://docs.google.com/document/d/1r8boI4E67Cq7PEsYeIpXkFZM0be4Ww5UDlNr_uXOop0
+* **Audio Recording**: <https://soundcloud.com/node-foundation/tsc-meeting-2015-07-15>
+* **GitHub Issue**: <https://github.com/nodejs/node-convergence-archive/issues/67>
+* **Original Minutes Google Doc**: <https://docs.google.com/document/d/1r8boI4E67Cq7PEsYeIpXkFZM0be4Ww5UDlNr_uXOop0>
 
 ## Agenda
 
@@ -50,7 +50,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting
 
 ### Standup:
 
-* Steven Loomis: Intl WG - https://github.com/nodejs/io.js/issues/2165
+* Steven Loomis: Intl WG - <https://github.com/nodejs/io.js/issues/2165>
 * Mikeal Rogers: Meeting with the Linux Foundation
 * Colin Ihrig: Issues & PRs, met with Julien & Sam for joyent/node release onboarding
 * James Snell: Deep diving on a couple issues, looking into TC39 involvement, LTS feedback

--- a/meetings/2015-07-22.md
+++ b/meetings/2015-07-22.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-07-22
-* **GitHub Issue**: https://github.com/nodejs/node-convergence-archive/issues/69
-* **Original Minutes Google Doc**: https://docs.google.com/document/d/1r8boI4E67Cq7PEsYeIpXkFZM0be4Ww5UDlNr_uXOop0
+* **Audio Recording**: <https://soundcloud.com/node-foundation/tsc-meeting-2015-07-22>
+* **GitHub Issue**: <https://github.com/nodejs/node-convergence-archive/issues/69>
+* **Original Minutes Google Doc**: <https://docs.google.com/document/d/1r8boI4E67Cq7PEsYeIpXkFZM0be4Ww5UDlNr_uXOop0>
 
 ## Agenda
 
@@ -47,7 +47,7 @@ Discussed ISO 29147 “Vulnerability Disclosure Overview” and ISO 30111 “Vul
 * Foundation Discussion (@mikeal leading)
 * Intl [#238](https://github.com/nodejs/io.js/issues/238)
 * TC39 representation [#2153](https://github.com/nodejs/io.js/issues/2153)
-* lts: LTS Proposal (https://github.com/nodejs/LTS#proposed-lts)[ Proposal: Release Process] [#1997](https://github.com/nodejs/io.js/issues/1997)
+* lts: LTS Proposal [Proposal: Release Process](https://github.com/nodejs/LTS#proposed-lts) [#1997](https://github.com/nodejs/io.js/issues/1997)
 
 ### Standup:
 
@@ -150,7 +150,7 @@ Approval for expenditure on @yosuke-furukawa (from Japan) max spend of $2400
 
 * Rod outlined the state of play:
   - LTS WG moved from “proposal” to “plan” but are still depending on the stable release branch having a clear process
-  - LTS WG discussed a proposal by Trevor for how to handle next/canary/alpha & master & release branches & LTS branches: https://gist.github.com/trevnorris/7620a64b086e95271197
+  - LTS WG discussed a proposal by Trevor for how to handle next/canary/alpha & master & release branches & LTS branches: <https://gist.github.com/trevnorris/7620a64b086e95271197>
 * Mikeal: it’s more helpful if we think about V8 upgrades as a pull-request to master rather than a separate “next” that has to be separately managed.
 
 Much bikeshedding was had in an attempt to move forward.

--- a/meetings/2015-07-29.md
+++ b/meetings/2015-07-29.md
@@ -2,10 +2,10 @@
 
 ## Links
 
-* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-07-29
-* **GitHub Issue**: https://github.com/nodejs/node-convergence-archive/issues/71
-* **Original Minutes Google Doc**: https://docs.google.com/document/d/1FBmDczHD4D8jfffc6A8CW-K9mmT0KI8shG6dm_d3jXI
-* Previous minutes: https://docs.google.com/document/d/1eCETYn44gAOUp0udl22QxqyxrJ0oEeAFRdWHDCIq9V4
+* **Audio Recording**: <https://soundcloud.com/node-foundation/tsc-meeting-2015-07-29>
+* **GitHub Issue**: <https://github.com/nodejs/node-convergence-archive/issues/71>
+* **Original Minutes Google Doc**: <https://docs.google.com/document/d/1FBmDczHD4D8jfffc6A8CW-K9mmT0KI8shG6dm_d3jXI>
+* Previous minutes: <https://docs.google.com/document/d/1eCETYn44gAOUp0udl22QxqyxrJ0oEeAFRdWHDCIq9V4>
 
 ## Agenda
 

--- a/meetings/2015-08-12.md
+++ b/meetings/2015-08-12.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-08-12
-* **GitHub Issue**: https://github.com/nodejs/node-convergence-archive/issues/71
-* **Minutes Google Doc**: https://docs.google.com/document/d/1q2bFjnf0Y23Ljxoze56Pmrbailaj5-UAqIUqIYVhiIk
+* **Audio Recording**: <https://soundcloud.com/node-foundation/tsc-meeting-2015-08-12>
+* **GitHub Issue**: <https://github.com/nodejs/node-convergence-archive/issues/71>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1q2bFjnf0Y23Ljxoze56Pmrbailaj5-UAqIUqIYVhiIk>
 * _Previous Minutes Google Doc: <https://docs.google.com/document/d/1FBmDczHD4D8jfffc6A8CW-K9mmT0KI8shG6dm_d3jXI>_
 
 ## Agenda
@@ -12,7 +12,7 @@
 Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting.
 
 * Travel assistance amendment (no issue for this)
-* FYI: Collaboration WG: https://github.com/nodejs/collaboration
+* FYI: Collaboration WG: <https://github.com/nodejs/collaboration>
 * Summit recap
 * level-set on repo rename
 * Future: “project lifecycle” (Mikeal) - process by which top level projects are added (libuv, node-gyp, etc), (conferences…)
@@ -51,11 +51,11 @@ Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting
 * Chris Dickinson adding $500 to the travel expenditure
 * Passed unanimously.
 
-### FYI: Collaboration WG: https://github.com/nodejs/collaboration
+### FYI: Collaboration WG: <https://github.com/nodejs/collaboration>
 
 * Steven: new WG coming out of the Summit, Sean (@snostorm) is taking lead on this. One idea under discussion now is to have a multi-timezone meetings for the language working groups.
 * Mikeal: is this going to serve as a collaboration point for the language groups?
-* Steven: https://github.com/nodejs/Intl/issues/9
+* Steven: <https://github.com/nodejs/Intl/issues/9>
 * Rod: beyond the language groups, what are the aims of this new group?
 * Steven: trying to address, or having a place to discuss, common items across working groups.
 * James: filling a need to liaise with the other working groups, acting as an intermediary
@@ -63,7 +63,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting
 ### Summit recap
 
 * Mikeal: 6 sessions in 2 days, not solid answers to problems but a shared understanding of the common problems, feels like we are on the same page from that
-* Mikeal: bigger sessions: what is the Node API and what is the Node platform? V8 release cycle. Errors and the inconsistencies. Kept coming back to the collaboration WG, which is why it exists. Talked about expanding the collaborator base, idea was to do some collaboration sprints to bring new folks up to speed, https://github.com/nodejs/code-and-learn comes from that idea (there is foundation budget for that).
+* Mikeal: bigger sessions: what is the Node API and what is the Node platform? V8 release cycle. Errors and the inconsistencies. Kept coming back to the collaboration WG, which is why it exists. Talked about expanding the collaborator base, idea was to do some collaboration sprints to bring new folks up to speed, <https://github.com/nodejs/code-and-learn> comes from that idea (there is foundation budget for that).
 * Mikeal: there were extensive notes taken, those are being edited now and will be published into the repo(s) and turned into blog posts.
 
 ### level-set on repo rename
@@ -76,7 +76,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting
 
 ### Future: “project lifecycle” (Mikeal) - process by which top level projects are added (libuv, node-gyp, etc), (conferences…)
 
-* Mikeal: the TSC charter states that we will adopt a project lifecycle that will allow us to bring in other _top level projects_. Additionally, the TSC has had to take on board some non-technical work because of its position in the Foundation (voting on expenditure, etc.), a number of TSC members don’t want to be involved in that kind of activity. Have started drafting a new project lifecycle plan which splits off a “Core TSC” that contains the existing TSC members but with a focus on Node.js Core work while the existing TSC will take on board the higher-level foundation work and members can optionally resign if they aren’t interested in that work and we can expand it to non-Core collaborators. https://github.com/nodejs/TSC/tree/lifecycle
+* Mikeal: the TSC charter states that we will adopt a project lifecycle that will allow us to bring in other _top level projects_. Additionally, the TSC has had to take on board some non-technical work because of its position in the Foundation (voting on expenditure, etc.), a number of TSC members don’t want to be involved in that kind of activity. Have started drafting a new project lifecycle plan which splits off a “Core TSC” that contains the existing TSC members but with a focus on Node.js Core work while the existing TSC will take on board the higher-level foundation work and members can optionally resign if they aren’t interested in that work and we can expand it to non-Core collaborators. <https://github.com/nodejs/TSC/tree/lifecycle>
 
 ### Next Meeting
 

--- a/meetings/2015-08-19.md
+++ b/meetings/2015-08-19.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-08-19
-* **GitHub Issue**: https://github.com/nodejs/node/issues/2435
-* **Minutes Google Doc**: https://docs.google.com/document/d/1xsj_4UlrLNxahRvC7SpLtFM3D-Ks6CZEqEM5nyj6bjk
+* **Audio Recording**: <https://soundcloud.com/node-foundation/tsc-meeting-2015-08-19>
+* **GitHub Issue**: <https://github.com/nodejs/node/issues/2435>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1xsj_4UlrLNxahRvC7SpLtFM3D-Ks6CZEqEM5nyj6bjk>
 * _Previous Minutes Google Doc: <https://docs.google.com/document/d/1q2bFjnf0Y23Ljxoze56Pmrbailaj5-UAqIUqIYVhiIk>_
 
 ## Agenda
@@ -53,7 +53,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting
 ### Review of the previous meeting
 
 * Travel assistance amendment (no issue for this)
-* FYI: Collaboration WG: https://github.com/nodejs/collaboration
+* FYI: Collaboration WG: <https://github.com/nodejs/collaboration>
 * Summit recap
 * level-set on repo rename
 * Future: “project lifecycle” (Mikeal) - process by which top level projects are added (libuv, node-gyp, etc), (conferences…)

--- a/meetings/2015-08-26.md
+++ b/meetings/2015-08-26.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-08-26
-* **GitHub Issue**: https://github.com/nodejs/node/issues/2560
-* **Minutes Google Doc**: https://docs.google.com/document/d/1aB76ClCgdjZUw3p-gHq9j6YwU11zWgJ4pmYPEWk6gjE
+* **Audio Recording**: <https://soundcloud.com/node-foundation/tsc-meeting-2015-08-26>
+* **GitHub Issue**: <https://github.com/nodejs/node/issues/2560>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1aB76ClCgdjZUw3p-gHq9j6YwU11zWgJ4pmYPEWk6gjE>
 * _Previous Minutes Google Doc: <https://docs.google.com/document/d/1q2bFjnf0Y23Ljxoze56Pmrbailaj5-UAqIUqIYVhiIk>_
 
 ## Agenda
@@ -44,7 +44,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests in the nodejs or
 ### Review of the previous meeting
 
 * Travel assistance amendment (no issue for this)
-* FYI: Collaboration WG: https://github.com/nodejs/collaboration
+* FYI: Collaboration WG: <https://github.com/nodejs/collaboration>
 * Summit recap
 * level-set on repo rename
 * Future: “project lifecycle” (Mikeal) - process by which top level projects are added (libuv, node-gyp, etc), (conferences…)
@@ -83,13 +83,13 @@ Target ETA for transition: Monday.
 
 ### Node.js v4 Release Timeline [#2522](https://github.com/nodejs/node/issues/2522)
 
-* Rod gave a summary of the proposed release timeline https://github.com/nodejs/node/issues/2522 (and appologised for documenting it as “the” release proposal just for the sake of getting it done).
+* Rod gave a summary of the proposed release timeline <https://github.com/nodejs/node/issues/2522> (and appologised for documenting it as “the” release proposal just for the sake of getting it done).
   - “feature freeze” Friday, 28th of August, cut v4.x branch
   - nodejs.org DNS changeover to new website Monday, 31st of August
   - release Thursday, 3rd of September
   - RC builds between website and release
   - backup release date of Monday, 7th of September if absolutely necessary to punt
-* Discussed the outstanding items in the 4.0.0 milestone: https://github.com/nodejs/node/milestones/4.0.0, some concerning items:
+* Discussed the outstanding items in the 4.0.0 milestone: <https://github.com/nodejs/node/milestones/4.0.0>, some concerning items:
   - mdb support is late and may not get done, might have to be a semver-minor prior to LTS
   - vcbuilt.bat needs to use the new build_release target and we have to verify that all builds have Intl enabled - Steven to work with Rod on this
   - `process.send()` async/sync, Ben said that this is async on all platforms now (was just Windows previously but now it’s cross-platform) but it’s missing a callback so there’s no way of doing back-pressure. No time to add this prior to v4 but could be done as semiver-minor later. Ben agreed to document current behaviour properly in the docs.
@@ -101,7 +101,7 @@ Target ETA for transition: Monday.
 
 ### V8 embedders unified debugger proposal
 
-* Trevor raised https://github.com/nodejs/node/issues/2546 which is a proposal for a unified debugger for V8 embedders using Chromium DevTools.
+* Trevor raised <https://github.com/nodejs/node/issues/2546> which is a proposal for a unified debugger for V8 embedders using Chromium DevTools.
 * Discussion ensued, agreed to leave it for GitHub discussion unless/until there is something the TSC actually needs to make a decision about.
 
 ### Next Meeting

--- a/meetings/2015-09-02.md
+++ b/meetings/2015-09-02.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-09-02
-* **GitHub Issue**: https://github.com/nodejs/node/issues/2654
-* **Minutes Google Doc**: https://docs.google.com/document/d/1rXBdtsD9PJTExNXgzNZ9bez9oOjW45kLPjun4zdt0dY
+* **Audio Recording**: <https://soundcloud.com/node-foundation/tsc-meeting-2015-09-02>
+* **GitHub Issue**: <https://github.com/nodejs/node/issues/2654>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1rXBdtsD9PJTExNXgzNZ9bez9oOjW45kLPjun4zdt0dY>
 * _Previous Minutes Google Doc: <https://docs.google.com/document/d/1aB76ClCgdjZUw3p-gHq9j6YwU11zWgJ4pmYPEWk6gjE>_
 
 ## Agenda

--- a/meetings/2015-09-16.md
+++ b/meetings/2015-09-16.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-09-16
-* **GitHub Issue**: https://github.com/nodejs/node/issues/2898
-* **Minutes Google Doc**: https://docs.google.com/document/d/1RCR2pGOc2d80NNusaX5DZaktWvHEsDUqfEZP-tvexBk
+* **Audio Recording**: <https://soundcloud.com/node-foundation/tsc-meeting-2015-09-16>
+* **GitHub Issue**: <https://github.com/nodejs/node/issues/2898>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1RCR2pGOc2d80NNusaX5DZaktWvHEsDUqfEZP-tvexBk>
 * _Previous Minutes Google Doc: <https://docs.google.com/document/d/1rXBdtsD9PJTExNXgzNZ9bez9oOjW45kLPjun4zdt0dY>_
 
 ## Present

--- a/meetings/2015-09-30.md
+++ b/meetings/2015-09-30.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-09-30
-* **GitHub Issue**: https://github.com/nodejs/node/issues/3126
-* **Minutes Google Doc**: https://docs.google.com/document/d/1RkLAWTIrhD3BTB2rs9_FahWI0C7lt9F8xnQXaueJPIE
+* **Audio Recording**: <https://soundcloud.com/node-foundation/tsc-meeting-2015-09-30>
+* **GitHub Issue**: <https://github.com/nodejs/node/issues/3126>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1RkLAWTIrhD3BTB2rs9_FahWI0C7lt9F8xnQXaueJPIE>
 * _Previous Minutes Google Doc: <https://docs.google.com/document/d/1RCR2pGOc2d80NNusaX5DZaktWvHEsDUqfEZP-tvexBk>_
 
 ## Present
@@ -130,8 +130,8 @@ Ben: We agreed that if it was internal, non-exposed to core,
 Ben: if this is a private dependency, we don’t need it to be fast, so we don’t necessarily need the native deps.
 
 Chris: (Hopped into discussion from minute-taking, hence the bad minutes)
-https://github.com/nodejs/node/pull/1202 - add mask/unmask
-https://github.com/nodejs/node/pull/1319 - add utf8 validator
+<https://github.com/nodejs/node/pull/1202> - add mask/unmask
+<https://github.com/nodejs/node/pull/1319> - add utf8 validator
 
 ### Umbrella Program [#2](https://github.com/nodejs/TSC/pull/2)
 

--- a/meetings/2015-10-07.md
+++ b/meetings/2015-10-07.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-10-07
-* **GitHub Issue**: https://github.com/nodejs/node/issues/3126
-* **Minutes Google Doc**: https://docs.google.com/document/d/1LIrTCdTUjKtb_GGecrJ3Es0rPOpVdpkV5kefJ_p5FGU
+* **Audio Recording**: <https://soundcloud.com/node-foundation/tsc-meeting-2015-10-07>
+* **GitHub Issue**: <https://github.com/nodejs/node/issues/3126>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1LIrTCdTUjKtb_GGecrJ3Es0rPOpVdpkV5kefJ_p5FGU>
 * _Previous Minutes Google Doc: <https://docs.google.com/document/d/1RkLAWTIrhD3BTB2rs9_FahWI0C7lt9F8xnQXaueJPIE>_
 
 ## Present
@@ -60,7 +60,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests in the nodejs or
 
 ### WG: Considering a new HTTP WG [#3214](https://github.com/nodejs/node/issues/3214)
 
-* Discussed the HTTP WG based on James’ comments @ https://github.com/nodejs/node/issues/3234#issuecomment-146293038
+* Discussed the HTTP WG based on James’ comments @ <https://github.com/nodejs/node/issues/3234#issuecomment-146293038>
 * Generally positive, only concerns are regarding decision making power—TSC may not want to hand that off as this is not quite like Streams (in that few people grok the code!) and there are philosophical questions to be resolved about HTTP that the TSC should be involved in.
 
 ### lib,test: deprecate _linklist [#3078](https://github.com/nodejs/node/pull/3078)
@@ -80,7 +80,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests in the nodejs or
 
 * Discussion on the possible difficulty of using 1.0.2 on varied Linux distros
 
-* ubuntu wily (not released) seems to use 1.0.2 - work has been done to package.  1.0.2 is only in Wily - https://launchpad.net/ubuntu/+source/openssl/1.0.2d-0ubuntu1 - https://answers.launchpad.net/ubuntu/+source/openssl/+question/263725 - “My guess is that we will see openssl 1.0.2 from Ubuntu 15.10 onwards (or eventually only starting with 16.04)”
+* ubuntu wily (not released) seems to use 1.0.2 - work has been done to package.  1.0.2 is only in Wily - <https://launchpad.net/ubuntu/+source/openssl/1.0.2d-0ubuntu1> - <https://answers.launchpad.net/ubuntu/+source/openssl/+question/263725> - “My guess is that we will see openssl 1.0.2 from Ubuntu 15.10 onwards (or eventually only starting with 16.04)”
 
 * Concern that allowing 1.0.1 would result in a substandard (insecure?) & untested binary.
 

--- a/meetings/2015-10-14.md
+++ b/meetings/2015-10-14.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-10-14
-* **GitHub Issue**: https://github.com/nodejs/node/issues/3363
+* **Audio Recording**: <https://soundcloud.com/node-foundation/tsc-meeting-2015-10-14>
+* **GitHub Issue**: <https://github.com/nodejs/node/issues/3363>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1tVPxA4Y3n3dmICJFZN2vK93PXjCaUQ-eiN2mvt7zqbE>
 * _Previous Minutes Google Doc: <https://docs.google.com/document/d/1LIrTCdTUjKtb_GGecrJ3Es0rPOpVdpkV5kefJ_p5FGU>_
 
@@ -48,7 +48,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests in the nodejs or
 * James: Worked on the 4.2.0 and 4.2.1 releases. Working on the cgitm smoke-testing tool and http WG.
 * Michael: Worked on adding pLinux to the CI. Looking into running the tests on fips-compliant mode. Investigated some AIX issues.
 * Ben: PRs & Issues, doing some work on the debugger and memory bugs in libuv
-* Jeremiah: PRs & Issues, working on resolving the timers in beforeExit bug: https://github.com/nodejs/node/pull/2795
+* Jeremiah: PRs & Issues, working on resolving the timers in beforeExit bug: <https://github.com/nodejs/node/pull/2795>
 * Trevor: Helped Jeremiah with the beforeExit thing, worked on PRs and Issues. Looking into AsyncWrap improvements.
 * Alexis: Looking into a native module build service. Worked on the Ci a bit.
 * Mikeal: Worked on the Umbrella Program proposal. Helping set up the Node.js Interactive conference.

--- a/meetings/2015-10-21.md
+++ b/meetings/2015-10-21.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Audio Recording**: https://soundcloud.com/node-foundation/tsc-meeting-2015-10-21
-* **GitHub Issue**: https://github.com/nodejs/node/issues/3464
+* **Audio Recording**: <https://soundcloud.com/node-foundation/tsc-meeting-2015-10-21>
+* **GitHub Issue**: <https://github.com/nodejs/node/issues/3464>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1ad8Xlza_B-iWexdlAd1Z5muzBy_HH88t_iSD31OUepA>
 * _Previous Minutes Google Doc: <https://docs.google.com/document/d/1tVPxA4Y3n3dmICJFZN2vK93PXjCaUQ-eiN2mvt7zqbE>_
 
@@ -178,7 +178,7 @@ Stephen: I’m not sure — it looks pretty deeply enmeshed into V8
 Seth: I don’t have answers off the top of my head on that one, I responded on the thread; we don’t currently have a priority to mess
 around with localization. If there’s a design doc that proposes cleaning things up we’d be interested
 
-James: Resource bundle mechanism — \[Note: didn’t get all of this\] “using the same startup sequence as Intl.. so needs to be configured at start time” (https://github.com/nodejs/node/pull/3413 uses ICU’s resource bundle mechanism, which uses the same init path as the core data. ICU does not allow multiple initializations.
+James: Resource bundle mechanism — \[Note: didn’t get all of this\] “using the same startup sequence as Intl.. so needs to be configured at start time” (<https://github.com/nodejs/node/pull/3413> uses ICU’s resource bundle mechanism, which uses the same init path as the core data. ICU does not allow multiple initializations.
 
 Alexis: If the only reason we’re trying to package it is to use npm to install it, maybe we’re complicating this unnecessarily
 

--- a/meetings/2016-01-07.md
+++ b/meetings/2016-01-07.md
@@ -2,7 +2,7 @@
 ## Links
 
 * **Video Recording**: Not available
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/27
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/27>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1_37koaKsVacCB6_iBdZ1qka5UVzKVF3fm6QUBpveuFk>
 * **Previous Minutes Google Doc**: ???
 

--- a/meetings/2016-01-14.md
+++ b/meetings/2016-01-14.md
@@ -3,9 +3,9 @@
 ## Links
 
 * **Video Recording**: Not available
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/31
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/31>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1jYeIgo3rEUyV0haqFQ4pEvo2lDVitJMWNeIXLRrssuM/edit>
-* **Previous Minutes Google Doc**: https://docs.google.com/document/d/1_37koaKsVacCB6_iBdZ1qka5UVzKVF3fm6QUBpveuFk
+* **Previous Minutes Google Doc**: <https://docs.google.com/document/d/1_37koaKsVacCB6_iBdZ1qka5UVzKVF3fm6QUBpveuFk>
 
 ## Present
 

--- a/meetings/2016-01-21.md
+++ b/meetings/2016-01-21.md
@@ -3,9 +3,9 @@
 ## Links
 
 * **Video Recording**: Not available
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/33
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/33>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/13ikZGN-sokY8Lwqc7A6dx6QyeSmfR3lhxqJofPTr9PE>
-* **Previous Minutes Google Doc**: https://docs.google.com/document/d/1jYeIgo3rEUyV0haqFQ4pEvo2lDVitJMWNeIXLRrssuM
+* **Previous Minutes Google Doc**: <https://docs.google.com/document/d/1jYeIgo3rEUyV0haqFQ4pEvo2lDVitJMWNeIXLRrssuM>
 
 ## Present
 

--- a/meetings/2016-01-28.md
+++ b/meetings/2016-01-28.md
@@ -3,7 +3,7 @@
 ## Links
 
 * **Video Recording**: Not available
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/38
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/38>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1WliRr9DCue8MjRMsPrg33eOvOvfbelHKwbwD36N4_Qk>
 * **Previous Minutes Google Doc**: nil_
 

--- a/meetings/2016-02-04.md
+++ b/meetings/2016-02-04.md
@@ -3,7 +3,7 @@
 ## Links
 
 * **Video Recording**: Not available
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/41
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/41>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1wJ0fuc1BcPn1armdR3D5NF6lTGyA3SiBCDktc2p5Voo>
 * **Previous Minutes Google Doc**: nil_
 
@@ -31,7 +31,7 @@ nothing officially covered
 
 ## Minutes
 
-### Express PR https://github.com/nodejs/TSC/pull/39
+### Express PR <https://github.com/nodejs/TSC/pull/39>
 
 James: moved quickly since last week, Doug has decided to contribute a large portion of his modules to the submission. Updated PR today, basic idea is to have a rough TC containing current owners of express, pillarjs, jshtttp org owners \[RV: not sure I have that list correct\]. There are a large number of modules that are included. Lots to be done on the PR still.
 

--- a/meetings/2016-02-11.md
+++ b/meetings/2016-02-11.md
@@ -3,7 +3,7 @@
 ## Links
 
 * **Video Recording**: Not available
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/49
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/49>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1wJ0fuc1BcPn1armdR3D5NF6lTGyA3SiBCDktc2p5Voo>
 * **Previous Minutes Google Doc**: nil_
 
@@ -32,7 +32,7 @@ skipped (we all met yesterday)
 
 ## Review of last meeting
 
-* Express PR https://github.com/nodejs/TSC/pull/39
+* Express PR <https://github.com/nodejs/TSC/pull/39>
 * non-express business
 
 ## Minutes

--- a/meetings/2016-02-18.md
+++ b/meetings/2016-02-18.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Video Recording**: https://www.youtube.com/watch?v=T6wFkZgnNEQ
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/50
+* **Video Recording**: <https://www.youtube.com/watch?v=T6wFkZgnNEQ>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/50>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1S1hzSEB1-_b2cHhcCSXRIiH1irWiWfLS4KawKQMPwvI>
 * **Previous Minutes Google Doc**: <https://docs.google.com/document/d/1P63hrV4WRdaQ5dAf4or0gP8-mBnuSyIdqFlFsFM-MBM>
 
@@ -32,7 +32,7 @@ Note from mikeal: do we need standups in the TSC meeting? can we do a “project
 
 ## Review of last meeting
 
-* Express PR https://github.com/nodejs/TSC/pull/39
+* Express PR <https://github.com/nodejs/TSC/pull/39>
 * non-express business
 
 ## Minutes

--- a/meetings/2016-03-03.md
+++ b/meetings/2016-03-03.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Video Recording**: https://www.youtube.com/watch?v=-vf23GsR6vk
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/57
+* **Video Recording**: <https://www.youtube.com/watch?v=-vf23GsR6vk>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/57>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1MW6CXlvxF0IWbb0tg5W70FAdWai5rkQoe_Jt9LhHMqQ>
 * **Previous Minutes Google Doc**: <https://docs.google.com/document/d/1S1hzSEB1-_b2cHhcCSXRIiH1irWiWfLS4KawKQMPwvI>
 
@@ -48,7 +48,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests from the **nodej
 
 ## Minutes
 
-Dicussed https://github.com/nodejs/TSC/issues/57#issuecomment-191943806 -- and more broad TSC and foundation strategy.
+Dicussed <https://github.com/nodejs/TSC/issues/57#issuecomment-191943806> -- and more broad TSC and foundation strategy.
 
 Alexis gave a brief overview of libuv in the foundation and steps forward.
 

--- a/meetings/2016-03-10.md
+++ b/meetings/2016-03-10.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Video Recording**: https://www.youtube.com/watch?v=UeLv2YTbEfE
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/61
+* **Video Recording**: <https://www.youtube.com/watch?v=UeLv2YTbEfE>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/61>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1Zt6EnkLghHUxqvn8RKz4ewy-uljIdhqU96KHv_uH6oc>
 * **Previous Minutes Google Doc**: <https://docs.google.com/document/d/1MW6CXlvxF0IWbb0tg5W70FAdWai5rkQoe_Jt9LhHMqQ/edit#>
 

--- a/meetings/2016-03-17.md
+++ b/meetings/2016-03-17.md
@@ -4,8 +4,8 @@
 
 ## Links
 
-* **Video Recording**: https://www.youtube.com/watch?v=FTIpDAF2ke4
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/69
+* **Video Recording**: <https://www.youtube.com/watch?v=FTIpDAF2ke4>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/69>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1lFnhNaE2wK0FFyUfDz1LcaBiD3-rW_UKFjUQqqBIZOY>
 * **Previous Minutes Google Doc**: <https://docs.google.com/document/d/1Zt6EnkLghHUxqvn8RKz4ewy-uljIdhqU96KHv_uH6oc>
 

--- a/meetings/2016-03-24.md
+++ b/meetings/2016-03-24.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Video Recording**: https://www.youtube.com/watch?v=aKr1vQVFIFc
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/78
+* **Video Recording**: <https://www.youtube.com/watch?v=aKr1vQVFIFc>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/78>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1IySG1HZz83dKzJsy5EWJNPUNkJ073qvl-fMAHXX0odk>
 * **Previous Minutes Google Doc**: <https://docs.google.com/document/d/1lFnhNaE2wK0FFyUfDz1LcaBiD3-rW_UKFjUQqqBIZOY/edit#>
 

--- a/meetings/2016-04-07.md
+++ b/meetings/2016-04-07.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Video Recording**: https://www.youtube.com/watch?v=O5kwBkhGFPY
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/87
+* **Video Recording**: <https://www.youtube.com/watch?v=O5kwBkhGFPY>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/87>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1pQK1fk7rAjFL8bwQHcmpln9plRqvqcw2Xr4Cp4wTyDo>
 * **Previous Minutes Google Doc**: <https://docs.google.com/document/d/1lFnhNaE2wK0FFyUfDz1LcaBiD3-rW_UKFjUQqqBIZOY>
 
@@ -44,7 +44,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests from the **nodej
 
 - James telling us what was discussed at the board meeting
 
-- Refs: https://github.com/nodejs/TSC/pull/77
+- Refs: <https://github.com/nodejs/TSC/pull/77>
 
 Board had an underlying question of, “what exactly is node core”?
 

--- a/meetings/2016-04-21.md
+++ b/meetings/2016-04-21.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Video Recording**: https://youtu.be/PSyiLJIR7n8
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/94
+* **Video Recording**: <https://youtu.be/PSyiLJIR7n8>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/94>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1iruXOBUlwbtrdNVkhI_MQF3VpBZvBdS5uUAcqVfOnQc>
 * **Previous Minutes Google Doc**: <https://docs.google.com/document/d/1pQK1fk7rAjFL8bwQHcmpln9plRqvqcw2Xr4Cp4wTyDo>
 
@@ -44,7 +44,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests from the **nodej
 
 - James telling us what was discussed at the board meeting
 
-- Refs: https://github.com/nodejs/TSC/pull/77
+- Refs: <https://github.com/nodejs/TSC/pull/77>
 
 Board had an underlying question of, “what exactly is node core”?
 

--- a/meetings/2016-05-05.md
+++ b/meetings/2016-05-05.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Video Recording**: https://www.youtube.com/watch?v=-vf23GsR6vk
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/99
+* **Video Recording**: <https://www.youtube.com/watch?v=-vf23GsR6vk>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/99>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1R2DTBrkmKakDI0UCDTD-2ppmrBHbnXDOaU2IvrN5toQ>
 * **Previous Minutes Google Doc**: <https://docs.google.com/document/d/1iruXOBUlwbtrdNVkhI_MQF3VpBZvBdS5uUAcqVfOnQc>
 

--- a/meetings/2016-05-19.md
+++ b/meetings/2016-05-19.md
@@ -1,3 +1,3 @@
 No meeting minutes taken.
 
-See: https://github.com/nodejs/TSC/issues/103
+See: <https://github.com/nodejs/TSC/issues/103>

--- a/meetings/2016-06-16.md
+++ b/meetings/2016-06-16.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Video Recording**: https://www.youtube.com/watch?v=L9ebH9A75AA
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/110
+* **Video Recording**: <https://www.youtube.com/watch?v=L9ebH9A75AA>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/110>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1WMrf2OmU11zqlu9SAHeKq8dwH1CSnW-eavLZ8kPCAJo>
 * **Previous Minutes Google Doc**: <https://docs.google.com/document/d/1O-nRwKhmKG_vpyGkzlhFe5m5qi-H81cB6nagL4d_7Yw>
 

--- a/meetings/2016-06-30.md
+++ b/meetings/2016-06-30.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Video Recording**: https://youtu.be/NSiOB1XcUDU
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/115
+* **Video Recording**: <https://youtu.be/NSiOB1XcUDU>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/115>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1eUpQNVdupAlsyvVVEnu8za6d8aBhOv9bEZK9FVWm8ds>
 * _Previous Minutes Google Doc: <https://docs.google.com/document/d/1WMrf2OmU11zqlu9SAHeKq8dwH1CSnW-eavLZ8kPCAJo>
 
@@ -34,7 +34,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests from the **nodej
 
 ## Standup
 
-* Michael Dawson - first cut at Define “Node.js core” - Mark II -  https://github.com/nodejs/TSC/issues/113
+* Michael Dawson - first cut at Define “Node.js core” - Mark II -  <https://github.com/nodejs/TSC/issues/113>
 * Jeremiah: William Kapke submitted PRs to all repos in nodejs to update the DCO to 1.1, merged the last of those
 * James: Working on WHAT-WG URL implementation in core
 * Rod: Security release - need to document the process to help share the load because it can be a lot of work. Foundation board meeting.
@@ -52,7 +52,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests from the **nodej
 
 ### Define "Node.js core" [#84](https://github.com/nodejs/TSC/issues/84)
 
-* Michael Dawson on https://github.com/nodejs/TSC/issues/113 (Mark II) tried to make a list of things that we would want to do independently with the board. Didn’t make a distinction between CTC and TSC at this stage:
+* Michael Dawson on <https://github.com/nodejs/TSC/issues/113> (Mark II) tried to make a list of things that we would want to do independently with the board. Didn’t make a distinction between CTC and TSC at this stage:
   * Code/repo changes for existing content under github/nodejs
   * Standards and process regarding contributions (Mikeal: the charter has some overlap here, particularly re single company restrictions, language could be “except as constrained by the charter”)
   * Usage of build tools and infrastructure (Rod: could clarify the language to talk about usage rather than ownership or creation of)

--- a/meetings/2016-07-14.md
+++ b/meetings/2016-07-14.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Video Recording**: https://www.youtube.com/watch?v=UXlzfJ9zPIY
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/118
+* **Video Recording**: <https://www.youtube.com/watch?v=UXlzfJ9zPIY>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/118>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1M29qRvgLU5LedQZ9kpZfWzzlDbNvWB9RolWBcD5ZBco>
 * _Previous Minutes Google Doc: <https://docs.google.com/document/d/1eUpQNVdupAlsyvVVEnu8za6d8aBhOv9bEZK9FVWm8ds>
 
@@ -41,12 +41,12 @@ Extracted from **tsc-agenda** labelled issues and pull requests from the **nodej
 
 ## Minutes
 
-- Update https://github.com/nodejs/node/wiki/Meetings:-Creating-a-Hangouts-On-Air-Event with new instructions
-- Calendar: https://calendar.google.com/calendar/embed?src=kap.co_i17i575te0aes6kaanfjr2e4hs%40group.calendar.google.com
+- Update <https://github.com/nodejs/node/wiki/Meetings:-Creating-a-Hangouts-On-Air-Event> with new instructions
+- Calendar: <https://calendar.google.com/calendar/embed?src=kap.co_i17i575te0aes6kaanfjr2e4hs%40group.calendar.google.com>
 
 ### Define "Node.js core" [#84](https://github.com/nodejs/TSC/issues/84)<br>Define "Node.js core" - Mark II [#113](https://github.com/nodejs/TSC/issues/113)
 
-PR at https://github.com/nodejs/TSC/pull/116 under review
+PR at <https://github.com/nodejs/TSC/pull/116> under review
 
 Michael: PR review was mostly about generalizing it a bit more.
 

--- a/meetings/2016-08-04.md
+++ b/meetings/2016-08-04.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Audio Recording**: https://www.youtube.com/watch?v=deTR-XFnKGQ
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/124
+* **Audio Recording**: <https://www.youtube.com/watch?v=deTR-XFnKGQ>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/124>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1ja56BVVPy946OZlDv1EQBy4TC5he6IQkQtxhE-20X4E>
 * _Previous Minutes Google Doc: <https://docs.google.com/document/d/1M29qRvgLU5LedQZ9kpZfWzzlDbNvWB9RolWBcD5ZBco>
 

--- a/meetings/2016-08-11.md
+++ b/meetings/2016-08-11.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Audio Recording**: https://www.youtube.com/watch?v=DKXD3anBh94
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/127
+* **Audio Recording**: <https://www.youtube.com/watch?v=DKXD3anBh94>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/127>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1Sp78uVB_1NBv9AZk1pXKj-YWmwqtCA6ZqxAE_lsjuk0>
 * _Previous Minutes Google Doc_: <https://docs.google.com/document/d/1ja56BVVPy946OZlDv1EQBy4TC5he6IQkQtxhE-20X4E>
 

--- a/meetings/2016-08-25.md
+++ b/meetings/2016-08-25.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Audio Recording**: https://www.youtube.com/watch?v=IDz3i6bmxhA
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/134
+* **Audio Recording**: <https://www.youtube.com/watch?v=IDz3i6bmxhA>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/134>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1ZMYiM236GgE9MXaqecOCrUWHhXe94dxTbXHutkp3nnA>
 * _Previous Minutes Google Doc: <https://docs.google.com/document/d/1Sp78uVB_1NBv9AZk1pXKj-YWmwqtCA6ZqxAE_lsjuk0>
 
@@ -59,7 +59,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests from the **nodej
 ### TSC Elections - One position or two? [#128](https://github.com/nodejs/TSC/issues/128)
 
 * Discussed current state and how to move forward
-* Important for the TSC to have a seat at the table for Board position elections which will be starting on Monday. There is additional context for this discussion at https://github.com/nodejs/TSC/issues/126
+* Important for the TSC to have a seat at the table for Board position elections which will be starting on Monday. There is additional context for this discussion at <https://github.com/nodejs/TSC/issues/126>
 * Rod: I will try and outline a process for moving forward on GitHub and try and expedite this process.
 
 ### Define "Node.js core" - Mark II [#113](https://github.com/nodejs/TSC/issues/113)
@@ -69,7 +69,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests from the **nodej
 ### Regular roll-up reporting for active working groups [#109](https://github.com/nodejs/TSC/issues/109)
 
 * Mikeal: Jenn is putting together a community newsletter about what’s going on around the place, at a high level. Roll-ups would be pointed to as the newsletter wouldn’t go into detail.
-* Tracy: I put a note in the evangelism repo about contacting Jenn for news items worth reporting. (https://github.com/nodejs/evangelism/issues/238)
+* Tracy: I put a note in the evangelism repo about contacting Jenn for news items worth reporting. (<https://github.com/nodejs/evangelism/issues/238>)
 * Discussed the nature of the newsletter and possible crossover.
 
 ### Investigate moving `nvm` into the foundation [#96](https://github.com/nodejs/TSC/issues/96)

--- a/meetings/2016-09-08.md
+++ b/meetings/2016-09-08.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Audio Recording**: https://www.youtube.com/watch?v=mtCTkakK7RA
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/135
+* **Audio Recording**: <https://www.youtube.com/watch?v=mtCTkakK7RA>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/135>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1ku52mOlqBxyGGMFY9phBwcB9bNMOyjwK3F1qVpNWryE>
 * _Previous Minutes Google Doc: <https://docs.google.com/document/d/1ZMYiM236GgE9MXaqecOCrUWHhXe94dxTbXHutkp3nnA>
 

--- a/meetings/2016-09-22.md
+++ b/meetings/2016-09-22.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Audio Recording**: https://www.youtube.com/watch?v=Y2zBT9t42Fg
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/143
+* **Audio Recording**: <https://www.youtube.com/watch?v=Y2zBT9t42Fg>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/143>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1YOe-9yjpVbsPURcWI2yoJenFQSaMEbMaeurkIRMM938>
 * _Previous Minutes Google Doc: <https://docs.google.com/document/d/1ku52mOlqBxyGGMFY9phBwcB9bNMOyjwK3F1qVpNWryE>
 

--- a/meetings/2016-10-06.md
+++ b/meetings/2016-10-06.md
@@ -2,7 +2,7 @@
 
 ## Links
 
-* **Audio Recording**: https://www.youtube.com/watch?v=Tyf6KKdn98Y
+* **Audio Recording**: <https://www.youtube.com/watch?v=Tyf6KKdn98Y>
 * **GitHub Issue**: [TSC#152](https://github.com/nodejs/TSC/issues/152)
 * **Minutes Google Doc**: <https://docs.google.com/document/d/16-3u9OV7t4E0kVZsZxRtrhTJimZUwzOCbHoCLjsYYas>
 * _Previous Minutes Google Doc: <https://docs.google.com/document/d/1YOe-9yjpVbsPURcWI2yoJenFQSaMEbMaeurkIRMM938>
@@ -34,7 +34,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests from the **nodej
 * Community Travel Fund in 2017 [#151](https://github.com/nodejs/TSC/issues/151)
 * Code & Learn NI NA lead teacher travel fund request: Anna Henningsen [#150](https://github.com/nodejs/TSC/issues/150)
 * Code & Learn NI NA lead teacher travel fund request: Rich Trott [#149](https://github.com/nodejs/TSC/issues/149)
-* Move https://github.com/indutny/llnode to https://github.com/nodejs/llnode [#148](https://github.com/nodejs/TSC/issues/148)
+* Move <https://github.com/indutny/llnode> to <https://github.com/nodejs/llnode> [#148](https://github.com/nodejs/TSC/issues/148)
 * Consider folding TSC into CTC [#146](https://github.com/nodejs/TSC/issues/146)
 * Add scope of responsibility for TSC ("Define Node Core" cont.) [#144](https://github.com/nodejs/TSC/pull/144)
 * charter: revised membership rules [#142](https://github.com/nodejs/TSC/pull/142)
@@ -71,7 +71,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests from the **nodej
 
 * Approved up to $2000 spend for Rich
 
-### Move https://github.com/indutny/llnode to https://github.com/nodejs/llnode [#148](https://github.com/nodejs/TSC/issues/148)
+### Move <https://github.com/indutny/llnode> to <https://github.com/nodejs/llnode> [#148](https://github.com/nodejs/TSC/issues/148)
 
 * Brief discussion about MIT/Apache2, sticking with MIT
 * Jeremiah abstained from vote, no disagreements, passed

--- a/meetings/2016-10-20.md
+++ b/meetings/2016-10-20.md
@@ -30,7 +30,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests from the **nodej
 * Community Travel Fund in 2017 [#151](https://github.com/nodejs/TSC/issues/151)
 * Code & Learn NI NA lead teacher travel fund request: Anna Henningsen [#150](https://github.com/nodejs/TSC/issues/150)
 * Code & Learn NI NA lead teacher travel fund request: Rich Trott [#149](https://github.com/nodejs/TSC/issues/149)
-* Move https://github.com/indutny/llnode to https://github.com/nodejs/llnode [#148](https://github.com/nodejs/TSC/issues/148)
+* Move <https://github.com/indutny/llnode> to <https://github.com/nodejs/llnode> [#148](https://github.com/nodejs/TSC/issues/148)
 * Consider folding TSC into CTC [#146](https://github.com/nodejs/TSC/issues/146)
 * Add scope of responsibility for TSC ("Define Node Core" cont.) [#144](https://github.com/nodejs/TSC/pull/144)
 * charter: revised membership rules [#142](https://github.com/nodejs/TSC/pull/142)

--- a/meetings/2016-11-17.md
+++ b/meetings/2016-11-17.md
@@ -62,7 +62,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests from the
 * @mikeal: Should it be in JS Foundation?
 
 * @joshgav: Is there general consensus on the reasoning given in
-  https://github.com/nodejs/version-management/blob/master/initial_proposal.md?
+  <https://github.com/nodejs/version-management/blob/master/initial_proposal.md>?
 
 * @rvagg: Yes, but we need to know that a group is addressing strategic
   questions and there are sufficient people and effort in it. Then we can
@@ -91,7 +91,7 @@ Next steps:
 
 ### Utilize travel fund for all CTC / TSC members who want to come to Node Interactive [#147](https://github.com/nodejs/TSC/issues/147)
 
-* Michael posted an issue @ https://github.com/nodejs/TSC/issues/166
+* Michael posted an issue @ <https://github.com/nodejs/TSC/issues/166>
 * Rod to follow up with email to everyone on the nodejs/node readme
 
 ### Consider folding TSC into CTC [#146](https://github.com/nodejs/TSC/issues/146)

--- a/meetings/2016-12-15.md
+++ b/meetings/2016-12-15.md
@@ -151,7 +151,7 @@ license, etc.
 ### Utilize travel fund for all CTC / TSC members who want to come to Node Interactive [#147](https://github.com/nodejs/TSC/issues/147)
 
 @mikeal: Those who were approved should fill in the Google doc template and send
-to ap@linuxfoundation.org and CC mikeal.rogers@linuxfoundation.org.
+to <mailto:ap@linuxfoundation.org> and CC <mailto:mikeal.rogers@linuxfoundation.org>.
 
 Might be this:
 <https://drive.google.com/previewtemplate?id=0Ak7JTr_5ZgQBdHVEOG5rX0FYdTNzak5IQnh6cnp0dXc&mode=public&ddrp=1>

--- a/meetings/2017-01-26.md
+++ b/meetings/2017-01-26.md
@@ -43,7 +43,7 @@
 * Community Committee
   * ...migrate Inclusivity Working Group...
     [TSC#179](https://github.com/nodejs/TSC/issues/179)
-  * https://github.com/nodejs/community-committee
+  * <https://github.com/nodejs/community-committee>
 
 ### Review of last meeting
 
@@ -83,9 +83,9 @@ Jan-30. Hopefully will be able to transfer some time next week.
 Discussion Group advised\* not accepting `nvm` till further decisions regarding
 standards and specs such runtime managers should adhere to.
 
-\*See https://github.com/nodejs/TSC/issues/96#issuecomment-264965326 and bottom
+\*See <https://github.com/nodejs/TSC/issues/96#issuecomment-264965326> and bottom
 of
-https://github.com/nodejs/version-management/blob/master/meetings/2016-12-01.md.
+<https://github.com/nodejs/version-management/blob/master/meetings/2016-12-01.md>.
 
 We should make sure this conclusion is clear in the thread and perhaps close it.
 `nvm` could re-apply later.
@@ -183,7 +183,7 @@ Can we find a time which works for Ben, Rod, and American folks?
 
 * ...migrate Inclusivity Working Group...
     [TSC#179](https://github.com/nodejs/TSC/issues/179)
-* https://github.com/nodejs/community-committee
+* <https://github.com/nodejs/community-committee>
 
 No updates.
 

--- a/meetings/2017-02-23.md
+++ b/meetings/2017-02-23.md
@@ -64,7 +64,7 @@ Current proposal is before or after [JSConf.eu](http://2017.jsconf.eu/) in early
 May in Berlin.
 
 Has someone volunteered to coordinate? @eljefedelrodeodeljefe volunteered:
-https://github.com/nodejs/summit/issues/39#issuecomment-278368925
+<https://github.com/nodejs/summit/issues/39#issuecomment-278368925>
 
 @janl has offered space for us at [co-up](http://co-up.de/). Though not
 associated with JSConf.eu it’s used for meetups and the like in Berlin, and it

--- a/meetings/2017-03-09.md
+++ b/meetings/2017-03-09.md
@@ -2,7 +2,7 @@
 
 ## Links
 
-* Audio Recording: https://www.youtube.com/watch?v=aoA9rT4fEG0
+* Audio Recording: <https://www.youtube.com/watch?v=aoA9rT4fEG0>
 * **GitHub Issue**: [TSC#213](https://github.com/nodejs/TSC/issues/213)
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1-5UXZ819jioRGrg9aBa2ZrvjVatyqfGuHDOSWe8nAEY>
 * _Previous Minutes Google Doc_: <https://docs.google.com/document/d/1NWTKxNOdx-3-kfVHe2KL_AycNsl8el216x8Zb1e2G5M>
@@ -68,7 +68,7 @@
 
 * PR 1 ready to go, likely to land this week.
 * Still need feedback from legal committee on PR 2 -
-    https://github.com/nodejs/TSC/pull/174.
+    <https://github.com/nodejs/TSC/pull/174>.
 
 ### charter: revised membership rules [#142](https://github.com/nodejs/TSC/pull/142)
 

--- a/meetings/2017-03-23.md
+++ b/meetings/2017-03-23.md
@@ -120,7 +120,7 @@ Conclusion: Go with simple majority/>50% for everything to minimize friction. As
 ---
 ## Q/A
 
-Unusual posts and snippets coming from https://medium.com/@nodejs RSS feed. @joshgav to investigate and file issue if needed.
+Unusual posts and snippets coming from <https://medium.com/@nodejs> RSS feed. @joshgav to investigate and file issue if needed.
 
 ---
 ## Next Meeting

--- a/meetings/2017-04-06.md
+++ b/meetings/2017-04-06.md
@@ -3,8 +3,8 @@
 ## Links
 
 * **GitHub Issue**: [TSC#227](https://github.com/nodejs/TSC/issues/227)
-* **Minutes Google Doc**: : https://docs.google.com/document/d/1RxoO0WUmlth2oHU-GR6SPDSGCJlmOOGl84WalHIkGHA
-* _Previous Minutes Google Doc_: https://docs.google.com/document/d/1urhinDNJK-EEMziNob8-mlsOEZM_zecluDIgBA6kVOw
+* **Minutes Google Doc**: : <https://docs.google.com/document/d/1RxoO0WUmlth2oHU-GR6SPDSGCJlmOOGl84WalHIkGHA>
+* _Previous Minutes Google Doc_: <https://docs.google.com/document/d/1urhinDNJK-EEMziNob8-mlsOEZM_zecluDIgBA6kVOw>
 
 ## Present
 

--- a/meetings/2017-06-01.md
+++ b/meetings/2017-06-01.md
@@ -3,7 +3,7 @@
 * Date: June 1, 2017
 * Next meeting: June 22, 2017
 * **GitHub Issue**: [TSC#277](https://github.com/nodejs/TSC/issues/277)
-* **Minutes Google Doc**: https://docs.google.com/document/d/1-2V2dZKQzw-2Nyzef4y-vjzdkvPYKYjOgKONdsaNHCw
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1-2V2dZKQzw-2Nyzef4y-vjzdkvPYKYjOgKONdsaNHCw>
 * Previous Minutes Google Doc:<https://docs.google.com/document/d/1-2V2dZKQzw-2Nyzef4y-vjzdkvPYKYjOgKONdsaNHCw/edit>
 
 ## Present
@@ -51,7 +51,7 @@ from the **nodejs org** prior to the meeting.
 ### Bring string_decoder into the foundation [#272](https://github.com/nodejs/readable-stream/issues/272)
 
 * There are no objections from the CTC.  Added comment to TSC issue
-  [#260}(https://github.com/nodejs/TSC/issues/260) to say will
+  [#260}(<https://github.com/nodejs/TSC/issues/260>) to say will
   Be considered to be approved unless there are objections by Monday June 5.
 
 ### Request to move moderation responsibilities to CommComm[#270](https://github.com/nodejs/TSC/issues/270)

--- a/meetings/2017-06-29.md
+++ b/meetings/2017-06-29.md
@@ -4,8 +4,8 @@
 * Date: June 29, 2017
 * Next meeting: July 20 2017 (one week early due to Node Summit)
 * **GitHub Issue**: [TSC#287](https://github.com/nodejs/TSC/issues/287)
-* **Minutes Google Doc**: https://docs.google.com/document/d/1LtgN6guOgqD8PcG8uTeO-tOZKfv9WQniAZHXJeJL8is/edit#
-* Previous Minutes Google Doc:https://docs.google.com/document/d/14zinvyVaYdfb9Avxbv1fOSFDXiJ_7374_P_ZBu9UIEA
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1LtgN6guOgqD8PcG8uTeO-tOZKfv9WQniAZHXJeJL8is/edit>#
+* Previous Minutes Google Doc:<https://docs.google.com/document/d/14zinvyVaYdfb9Avxbv1fOSFDXiJ_7374_P_ZBu9UIEA>
 
 ## Present
 * Bryan Hughes @nebrius (TSC)

--- a/meetings/2017-09-13.md
+++ b/meetings/2017-09-13.md
@@ -2,7 +2,7 @@
 ## Links
 
 * **GitHub Issue**: [TSC#338](https://github.com/nodejs/TSC/issues/338)
-* **Minutes Google Doc**: https://docs.google.com/document/d/1tOeEpEz2Qf7ybjsoFXRrMSpNrEcKIIfnc3eqDYeP0zU/edit?usp=sharing
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1tOeEpEz2Qf7ybjsoFXRrMSpNrEcKIIfnc3eqDYeP0zU/edit?usp=sharing>
 * _Previous Minutes Google Doc: <https://docs.google.com/document/d/1al5l33g9wlNS3fMQHNdpxyhWPoJhLAMtu4ChaAiCmYs>_
 
 ## Present
@@ -111,7 +111,7 @@ We skipped this as we had a packed agenda.
   * Rich, possibly just at impasse, calling for vote
   * Matteo will open an issue to collect votes.
 
-### deps: backport V8 update to 6.1 https://github.com/nodejs/node/pull/15393
+### deps: backport V8 update to 6.1 <https://github.com/nodejs/node/pull/15393>
 * Land 6.1 into 8 LTS
 * V8 team has worked on abi compatible patches (unclear if this
     is complete yet)
@@ -144,6 +144,6 @@ We skipped this as we had a packed agenda.
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2017-09-20.md
+++ b/meetings/2017-09-20.md
@@ -1,9 +1,9 @@
 # Node Foundation TSC Meeting 2017-09-20
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=xwZGpiqhnXA
+* **Recording**: <https://www.youtube.com/watch?v=xwZGpiqhnXA>
 * **GitHub Issue**: [TSC#359](https://github.com/nodejs/TSC/issues/359)
-* **Minutes Google Doc**: https://docs.google.com/document/d/1oMS1G-Tpgx8Ha8FqCb1XCLXSu5yZ6AjO1HmB1clUPaU/edit?usp=sharing
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1oMS1G-Tpgx8Ha8FqCb1XCLXSu5yZ6AjO1HmB1clUPaU/edit?usp=sharing>
 * _Previous Minutes Google Doc: <https://docs.google.com/document/d/1tOeEpEz2Qf7ybjsoFXRrMSpNrEcKIIfnc3eqDYeP0zU>_
 
 ## Present
@@ -56,7 +56,7 @@
   * Briefly discussed, Michael will think about a concrete proposal
     and then bring back to the TSC.
 
-* [#355](https://github.com/nodejs/TSC/issues/355) Vote on the approach for https://github.com/nodejs/node/issues/445
+* [#355](https://github.com/nodejs/TSC/issues/355) Vote on the approach for <https://github.com/nodejs/node/issues/445>
   * Some discussion here. We need 2 more votes to close out the voting.
 
 ### nodejs/security-wg
@@ -84,6 +84,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2017-09-27.md
+++ b/meetings/2017-09-27.md
@@ -1,8 +1,8 @@
 # Node Foundation TSC Meeting 2017-09-27
 ## Links
-* **Recording**: https://www.youtube.com/watch?v=An8EO9dSj6g
+* **Recording**: <https://www.youtube.com/watch?v=An8EO9dSj6g>
 * **GitHub Issue**: [TSC#359](https://github.com/nodejs/TSC/issues/363)
-* **Minutes Google Doc**: https://docs.google.com/document/d/1DRhvfRAbp1EILu3h2iwSi8Efj7ghAE0fdu8X3CvvSGQ/edit?usp=sharing
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1DRhvfRAbp1EILu3h2iwSi8Efj7ghAE0fdu8X3CvvSGQ/edit?usp=sharing>
 * _Previous Minutes Google Doc: <https://docs.google.com/document/d/1oMS1G-Tpgx8Ha8FqCb1XCLXSu5yZ6AjO1HmB1clUPaU>_
 
 ## Present
@@ -117,7 +117,7 @@ No announcements this week
   * Plan for release on Oct 10, giving us the rest of the
     month before LTS
   * Vulnerability in 6.0, 6.1 and later, opt disabled
-    https://github.com/nodejs/node/issues/15564
+    <https://github.com/nodejs/node/issues/15564>
   * 6.2 could be made to be ABI compatible, may want to
     consider pref regressions from turning off opt. Myles
     understands there was already pushback on 6.1.  Before
@@ -141,6 +141,6 @@ No announcements this week
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2017-10-11.md
+++ b/meetings/2017-10-11.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=90azeQn0H6w
+* **Recording**:  <https://www.youtube.com/watch?v=90azeQn0H6w>
 * **GitHub Issue**: [TSC#377](https://github.com/nodejs/TSC/issues/377)
-* **Minutes Google Doc**: https://docs.google.com/document/d/1PkoiLPj1b_ePtCL6IWDSwI-eh1Vzp7sfhu5deoiWM-A/edit?usp=sharing
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1PkoiLPj1b_ePtCL6IWDSwI-eh1Vzp7sfhu5deoiWM-A/edit?usp=sharing>
 * _Previous Minutes Google Doc: <https://docs.google.com/document/d/1DRhvfRAbp1EILu3h2iwSi8Efj7ghAE0fdu8X3CvvSGQ>_
 
 ## Present
@@ -45,7 +45,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests from the **nodej
 
 ### nodejs/build
 
-* https://github.com/nodejs/node/pull/15762
+* <https://github.com/nodejs/node/pull/15762>
   * 8.7 has been updated to 6.1.
   * has escape analysis turned off .
   * due to security vulnerability, debate over whether it affects node
@@ -87,7 +87,7 @@ These were rolled over to the next meeting:
 
 * Who should be in @nodejs/security? Who should have access to the private repo? [#358](https://github.com/nodejs/TSC/issues/358)
 
-* Vote on the approach for https://github.com/nodejs/node/issues/445 [#355](https://github.com/nodejs/TSC/issues/355)
+* Vote on the approach for <https://github.com/nodejs/node/issues/445> [#355](https://github.com/nodejs/TSC/issues/355)
   * believe this has been settled in github
 
 ### nodejs/admin
@@ -116,6 +116,6 @@ These were rolled over to the next meeting:
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2017-10-18.md
+++ b/meetings/2017-10-18.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=JiOn0CLCIAU
+* **Recording**: <https://www.youtube.com/watch?v=JiOn0CLCIAU>
 * **GitHub Issue**: [TSC#384](https://github.com/nodejs/TSC/issues/384)
-* **Minutes Google Doc**: https://docs.google.com/document/d/1ySnvsuJV3wMnPhaHqBLPv0ESxjUaDdaQarkhmDrD3Mc/edit?usp=sharing
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1ySnvsuJV3wMnPhaHqBLPv0ESxjUaDdaQarkhmDrD3Mc/edit?usp=sharing>
 * _Previous Minutes Google Doc: <https://docs.google.com/document/d/1PkoiLPj1b_ePtCL6IWDSwI-eh1Vzp7sfhu5deoiWM-A>_
 
 ## Present
@@ -147,6 +147,6 @@ No announcements this week.
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2017-10-25.md
+++ b/meetings/2017-10-25.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=p1LB6VxKchw
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/396
-* **Minutes Google Doc**: https://docs.google.com/document/d/1ptEaqEG9sI8EhBFqZv1MQhyuEFfq1F81XyXbMqHyN84/
+* **Recording**: <https://www.youtube.com/watch?v=p1LB6VxKchw>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/396>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1ptEaqEG9sI8EhBFqZv1MQhyuEFfq1F81XyXbMqHyN84/>
 
 ## Present
 
@@ -32,7 +32,7 @@
 
 * Update from the moderation team (Forrest)
 
-* Deck used for presentation https://docs.google.com/presentation/d/1cN712pneaa7L6_wVl9-M2OpK_2Am8EbarYyoJxxyyYA/edit#slide=id.p
+* Deck used for presentation <https://docs.google.com/presentation/d/1cN712pneaa7L6_wVl9-M2OpK_2Am8EbarYyoJxxyyYA/edit#slide=id.p>
 
 * 10 members, so far have had to be intervene in 0 issues, though there were 2 requests
   for guidance
@@ -109,10 +109,10 @@
   security-wg team to think about when/if it makes sense to request an official charter.
 * Some floating moderation work that needs to be done, Myles had suggested we set up group
   Across the TSC, CommComm, moderation through work edge cases.  He has opened issue
-  and will take discussion back to the tracker. https://github.com/nodejs/admin/issues/24
+  and will take discussion back to the tracker. <https://github.com/nodejs/admin/issues/24>
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2017-11-01.md
+++ b/meetings/2017-11-01.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=8QUQReLCnwI
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/402
-* **Minutes Google Doc**: https://docs.google.com/document/d/13XLNVP892_NiP_q3sibDG-X2dZABNPBfVZH7tFzT9ng
+* **Recording**: <https://www.youtube.com/watch?v=8QUQReLCnwI>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/402>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/13XLNVP892_NiP_q3sibDG-X2dZABNPBfVZH7tFzT9ng>
 
 ## Present
 * Evan Lucas @evanlucas (TSC)
@@ -61,6 +61,6 @@ No questions today.
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2017-11-08.md
+++ b/meetings/2017-11-08.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=pDsLyrMaHPc
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/413
-* **Minutes Google Doc**: https://docs.google.com/document/d/1VfbhXAC6jipW-TW09jOlFqrflHAwx3Zrt27NKNcj5Ms
+* **Recording**:  <https://www.youtube.com/watch?v=pDsLyrMaHPc>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/413>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1VfbhXAC6jipW-TW09jOlFqrflHAwx3Zrt27NKNcj5Ms>
 
 ## Present
 
@@ -29,7 +29,7 @@
 
 ### Announcements
 
-* Proposal for Collaborators Summit at JSConf EU in June. https://github.com/nodejs/summit/issues/56
+* Proposal for Collaborators Summit at JSConf EU in June. <https://github.com/nodejs/summit/issues/56>
 
 ### nodejs/node
 
@@ -65,7 +65,7 @@ Myles: I’ll add some language to make things clear.
 ### nodejs/summit
 
 * Node.js collaborator summit in Berlin before or after JSConfEU?
-JSConfEU is on June 2nd & 3rd 2018 (Saturday & Sunday). CSSConf is on June 1st 2018 (Friday). See https://github.com/nodejs/summit/issues/56
+JSConfEU is on June 2nd & 3rd 2018 (Saturday & Sunday). CSSConf is on June 1st 2018 (Friday). See <https://github.com/nodejs/summit/issues/56>
 
 ## Q&A, Other
 
@@ -73,6 +73,6 @@ No questions.
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2017-11-15.md
+++ b/meetings/2017-11-15.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=eSgqJg7pu_M
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/418
-* **Minutes Google Doc**: https://docs.google.com/document/d/13XLNVP892_NiP_q3sibDG-X2dZABNPBfVZH7tFzT9ng
+* **Recording**: <https://www.youtube.com/watch?v=eSgqJg7pu_M>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/418>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/13XLNVP892_NiP_q3sibDG-X2dZABNPBfVZH7tFzT9ng>
 
 ## Present
 
@@ -66,7 +66,7 @@ Standards track requires a standards body to write an RFC for the MIME type. It�
 
 Q: Can the Foundation be used as the contact?
 
-Jasnell: tl/dr; version: Mime types can be registered Standards track or Vendor track as described here: https://tools.ietf.org/html/rfc4288#section-3.1. Vendor track is for commercial products, Standards track is for stuff that is of “general" interest. The IESG/IETF may be viewing this in the latter case -- in general, they prefer things *not* to be Vendor track as much as possible. The concern is that Standards track takes longer and requires an RFC to be published, which any one of us could write up. It doesn’t require Board action to push through, so we should get Bradley’s reasoning for why he’d like to see that. Also, fwiw, I’ve written many RFC’s to this point and I’m quite familiar with the process so can help push this forward.
+Jasnell: tl/dr; version: Mime types can be registered Standards track or Vendor track as described here: <https://tools.ietf.org/html/rfc4288#section-3.1>. Vendor track is for commercial products, Standards track is for stuff that is of “general" interest. The IESG/IETF may be viewing this in the latter case -- in general, they prefer things *not* to be Vendor track as much as possible. The concern is that Standards track takes longer and requires an RFC to be published, which any one of us could write up. It doesn’t require Board action to push through, so we should get Bradley’s reasoning for why he’d like to see that. Also, fwiw, I’ve written many RFC’s to this point and I’m quite familiar with the process so can help push this forward.
 
 Myles, James, and Bradley will figure this out in email and either get it done or else bring it back to the TSC next week.
 
@@ -78,6 +78,6 @@ Myles, James, and Bradley will figure this out in email and either get it done o
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2017-11-22.md
+++ b/meetings/2017-11-22.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Recording**:  http://youtu.be/_4KIuXKDL6U
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/425
-* **Minutes Google Doc**: https://docs.google.com/document/d/14_j0sxBJ1wYlrWEaXER1c12kszWuCGKNbNGo-K1vJnc
+* **Recording**:  <http://youtu.be/_4KIuXKDL6U>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/425>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/14_j0sxBJ1wYlrWEaXER1c12kszWuCGKNbNGo-K1vJnc>
 
 ## Present
 
@@ -60,6 +60,6 @@ No questions this week.
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2017-11-29.md
+++ b/meetings/2017-11-29.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=DtYASTx99WM
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/429
-* **Minutes Google Doc**: https://docs.google.com/document/d/1m8AGEN0jiyX7DlnEG5zuMhoc0v9SzGEaciqSeo1DllE
+* **Recording**: <https://www.youtube.com/watch?v=DtYASTx99WM>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/429>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1m8AGEN0jiyX7DlnEG5zuMhoc0v9SzGEaciqSeo1DllE>
 
 ## Present
 
@@ -74,6 +74,6 @@ No questions this week.
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2017-12-06.md
+++ b/meetings/2017-12-06.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=1sHufGWR_WU
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/432
-* **Minutes Google Doc**: https://docs.google.com/document/d/1N029ttRxw92pv1k0Xc0-abkwbHMRW7Ts6r4nFeJbF4M
+* **Recording**:  <https://www.youtube.com/watch?v=1sHufGWR_WU>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/432>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1N029ttRxw92pv1k0Xc0-abkwbHMRW7Ts6r4nFeJbF4M>
 
 ## Present
 
@@ -157,6 +157,6 @@ No questsions this week.
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2017-12-13.md
+++ b/meetings/2017-12-13.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=1sHufGWR_WU
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/435
-* **Minutes Google Doc**: https://docs.google.com/document/d/1oWrjw845TDCAYCZHkYv51oyA_d-jxzcGe0hvwtf1_Io
+* **Recording**: <https://www.youtube.com/watch?v=1sHufGWR_WU>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/435>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1oWrjw845TDCAYCZHkYv51oyA_d-jxzcGe0hvwtf1_Io>
 
 ## Present
 
@@ -81,6 +81,6 @@ Rich: +1
 Later Today: Diagnostics WG
 Next TSC Meeting: 12/20/2017
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2017-12-20.md
+++ b/meetings/2017-12-20.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=Sj2cV2fxwOk
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/447
-* **Minutes Google Doc**: https://docs.google.com/document/d/1q35I8ONS2Aqsjhcci6OJ6vDdak5VngFcChhbmE8aCTg
+* **Recording**:  <https://www.youtube.com/watch?v=Sj2cV2fxwOk>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/447>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1q35I8ONS2Aqsjhcci6OJ6vDdak5VngFcChhbmE8aCTg>
 
 ## Present
 
@@ -25,7 +25,7 @@
 
 ### Announcements
 
-* Matteo submitted a async iterators PR. Check it out! https://github.com/nodejs/node/pull/17755
+* Matteo submitted a async iterators PR. Check it out! <https://github.com/nodejs/node/pull/17755>
 
 ### nodejs/node
 
@@ -73,7 +73,7 @@ Myles: I don’t know if anyone’s had a chance to read through it, but I took 
 
 * Strategic Initiatives - Tracking Issue [#423](https://github.com/nodejs/TSC/issues/423)
 
-Rich: Moderation WG still trying to work out how we get necessary privileges in the near term. See https://github.com/nodejs/admin/issues/33. I am likely to put that issue on the tsc-agenda soon to try to get definite resolution.
+Rich: Moderation WG still trying to work out how we get necessary privileges in the near term. See <https://github.com/nodejs/admin/issues/33>. I am likely to put that issue on the tsc-agenda soon to try to get definite resolution.
 
 Michaël: V8 6.4 is ready to land on master. Still not part of the stable channel (scheduled for Jan 23rd, 2018).
 
@@ -103,6 +103,6 @@ Myles: I’m a fan.
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-01-10.md
+++ b/meetings/2018-01-10.md
@@ -1,9 +1,9 @@
 # Node.js Foundation Technical Steering Committee (TSC) Meeting 2018-01-10
 
 ## Links
-* **Recording**: https://www.youtube.com/watch?v=StjmGRclNi0
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/465
-* **Minutes Google Doc**: https://docs.google.com/document/d/1ShVcDk_-BzwIXOhoV0iECpjJZ53u6-GJrcEc7K1YMqI
+* **Recording**: <https://www.youtube.com/watch?v=StjmGRclNi0>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/465>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1ShVcDk_-BzwIXOhoV0iECpjJZ53u6-GJrcEc7K1YMqI>
 
 ## Present
 * Anna Henningsen @addaleax (TSC)
@@ -111,5 +111,5 @@
 * Questions about GitHub ownership, issue is in the admin repo.
 
 ## Upcoming Meetings
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-01-17.md
+++ b/meetings/2018-01-17.md
@@ -1,8 +1,8 @@
 # Node.js Foundation Technical Steering Committee (TSC) Meeting 2018-01-17
 ## Links
-* **Recording**: https://www.youtube.com/watch?v=050aEhL4L8o
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/471
-* **Minutes Google Doc**: https://docs.google.com/document/d/1xmvGUU06azrXjFN4tgu6w73hRUKEqaiDddDmxRaz0Dg
+* **Recording**: <https://www.youtube.com/watch?v=050aEhL4L8o>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/471>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1xmvGUU06azrXjFN4tgu6w73hRUKEqaiDddDmxRaz0Dg>
 ## Present
 * Anna Henningsen @addaleax (TSC)
 * Colin Ihrig @cjihrig (TSC)
@@ -62,5 +62,5 @@ James: Deprecation issue is particularly important. TSC needs to pay attention t
 Rich/Michael: Already covered. Rich will remove label and possibly close issue.
 ## Q&A, Other
 ## Upcoming Meetings
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-01-31-V8.md
+++ b/meetings/2018-01-31-V8.md
@@ -2,33 +2,33 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=a6YtLIaqMqs
-* **Google Doc**: https://docs.google.com/document/d/1Iw0i8wIrzoc_32gfAw9aAhluS9fsMs9xWwL7tu46K_g
+* **Recording**: <https://www.youtube.com/watch?v=a6YtLIaqMqs>
+* **Google Doc**: <https://docs.google.com/document/d/1Iw0i8wIrzoc_32gfAw9aAhluS9fsMs9xWwL7tu46K_g>
 
 ## Present
 
 ### TSC
-* Ali Sheikh \<ofrobots@google.com>
-* Colin Ihrig \<cjihrig@gmail.com>
-* Franziska Hinkelmann \<franzih@google.com>
-* James M Snell \<jasnell@gmail.com>
-* Matteo Collina \<matteo.collina@nearform.com>
-* Michael Dawson \<michael_dawson@ca.ibm.com>
-* Michaël Zasso \<targos@protonmail.com>
+* Ali Sheikh <mailto:ofrobots@google.com>
+* Colin Ihrig <mailto:cjihrig@gmail.com>
+* Franziska Hinkelmann <mailto:franzih@google.com>
+* James M Snell <mailto:jasnell@gmail.com>
+* Matteo Collina <mailto:matteo.collina@nearform.com>
+* Michael Dawson <mailto:michael_dawson@ca.ibm.com>
+* Michaël Zasso <mailto:targos@protonmail.com>
 
 ### V8
-* Adam Klein \<adamk@google.com>
-* Benedikt Meurer \<bmeurer@google.com>
-* Michael Lippautz \<mlippautz@google.com>
-* Sathya Gunasekaran \<gunasekaran@google.com>
-* Thomas Nattestad \<nattestad@google.com>
-* Yang Guo \<yangguo@google.com>
+* Adam Klein <mailto:adamk@google.com>
+* Benedikt Meurer <mailto:bmeurer@google.com>
+* Michael Lippautz <mailto:mlippautz@google.com>
+* Sathya Gunasekaran <mailto:gunasekaran@google.com>
+* Thomas Nattestad <mailto:nattestad@google.com>
+* Yang Guo <mailto:yangguo@google.com>
 
 ### Other
-* Bradley Farias \<bradley.meck@gmail.com>
-* Muntasir Mallick \<mmallick@ca.ibm.com>
-* Peter Marton \<pmarton@netflix.com>
-* Yunong Xiao \<yunong@netflix.com>
+* Bradley Farias <mailto:bradley.meck@gmail.com>
+* Muntasir Mallick <mailto:mmallick@ca.ibm.com>
+* Peter Marton <mailto:pmarton@netflix.com>
+* Yunong Xiao <mailto:yunong@netflix.com>
 
 ## Summary
 

--- a/meetings/2018-01-31.md
+++ b/meetings/2018-01-31.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=a6YtLIaqMqs
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/478
-* **Minutes Google Doc**: https://docs.google.com/document/d/1R7Z9Rt01fqFddMnllJddezKwGIbaCcrkrGfw5Lhc_1A
+* **Recording**: <https://www.youtube.com/watch?v=a6YtLIaqMqs>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/478>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1R7Z9Rt01fqFddMnllJddezKwGIbaCcrkrGfw5Lhc_1A>
 
 ## Present
 
@@ -77,9 +77,9 @@ Moderation team update:
 * Strategic Initiatives - Tracking Issue [#423](https://github.com/nodejs/TSC/issues/423)
   * N-API
     * bcrypt now has an N-API tagged version and is being used in production.
-      see:https://github.com/nodejs/abi-stable-node/issues/287#issuecomment-360296931
+      see:<https://github.com/nodejs/abi-stable-node/issues/287#issuecomment-360296931>
     * progress being made on integration with  PR expected soon. See:
-      https://github.com/nodejs/abi-stable-node/issues/263#issuecomment-361711077
+      <https://github.com/nodejs/abi-stable-node/issues/263#issuecomment-361711077>
 
   * Modules
     * dynamic import on by default for esm
@@ -116,12 +116,12 @@ Moderation team update:
 ## Q&A, Other
 * JDD: comments that HackerOne has a few bugs, some concern over how secure it is.
 Suggestion is that he opens specific issues in the security-wg repo to raise the concerns.
-* Guy: asking if https://github.com/nodejs/node/issues/18233 would address apm concerns.
+* Guy: asking if <https://github.com/nodejs/node/issues/18233> would address apm concerns.
 * JDD: any plans to use N-API for ESM implementation.  Answer, long term thoughts to use
   N-API for internal implementations but not there yet.
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-02-07.md
+++ b/meetings/2018-02-07.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=hJZzgGZBCXo
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/484
-* **Minutes Google Doc**: https://docs.google.com/document/d/1B6n6G53UxEn5Ulv7sEd3nw6pIC9sh9JDe5GlSBfzdEs/edit
+* **Recording**: <https://www.youtube.com/watch?v=hJZzgGZBCXo>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/484>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1B6n6G53UxEn5Ulv7sEd3nw6pIC9sh9JDe5GlSBfzdEs/edit>
 
 ## Present
 
@@ -32,7 +32,7 @@ There was no significant Moderation Team activity this week.
 ### nodejs/node
 
 * document asserts Weak(Map|Set) behavior #18248**
-  * Discuss is taking place in https://github.com/nodejs/node/issues/18227
+  * Discuss is taking place in <https://github.com/nodejs/node/issues/18227>
   * good to have summary of discussion from PR in that issue.
   * Ruben to add summary and do mini-poll to gauge general TSC direction on this.
   * Anna, because the answer depends on gc, it is always valid to return false. We already
@@ -90,6 +90,6 @@ No questions for this week.
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-02-21.md
+++ b/meetings/2018-02-21.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Recording**:  http://www.youtube.com/watch?v=KhM2MLcChOQ
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/494
-* **Minutes Google Doc**: https://docs.google.com/document/d/1TCUadaWiq8jTC4hHK1-c_OekF9OzCJVTXqIrVwLv0rc/edit
+* **Recording**:  <http://www.youtube.com/watch?v=KhM2MLcChOQ>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/494>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1TCUadaWiq8jTC4hHK1-c_OekF9OzCJVTXqIrVwLv0rc/edit>
 
 ## Present
 
@@ -52,6 +52,6 @@ No questions this week.
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-02-28.md
+++ b/meetings/2018-02-28.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=R2aZin_5tiY
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/496
-* **Minutes Google Doc**: https://docs.google.com/document/d/1KeSzAeHEeuevLSmDFhBE0XV8feicVEao1k8JGTBb0rg
+* **Recording**:  <https://www.youtube.com/watch?v=R2aZin_5tiY>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/496>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1KeSzAeHEeuevLSmDFhBE0XV8feicVEao1k8JGTBb0rg>
 
 ## Present
 
@@ -104,6 +104,6 @@ No questions this week.
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-03-07.md
+++ b/meetings/2018-03-07.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Recording**: https://youtu.be/qG7Ch0EfLVw
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/500
-* **Minutes Google Doc**: https://docs.google.com/document/d/1m70GEwtOyAwzqz_4M5hhrZJwN5RucxggJu2XDNjk-mA/
+* **Recording**: <https://youtu.be/qG7Ch0EfLVw>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/500>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1m70GEwtOyAwzqz_4M5hhrZJwN5RucxggJu2XDNjk-mA/>
 
 ## Present
 
@@ -48,7 +48,7 @@ Collaboration summit [#56](https://github.com/nodejs/summit/issues/56) happening
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
 

--- a/meetings/2018-03-14.md
+++ b/meetings/2018-03-14.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=bFQ3hZXYZoo
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/504
+* **Recording**: <https://www.youtube.com/watch?v=bFQ3hZXYZoo>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/504>
 
 ## Present
 
@@ -54,7 +54,7 @@
       * Both NAN and NAPI now have support for context propagation using the async hooks embedder API
       * If any native module authors would like assistance with handling these changes, they can contact @ofrobots, or look at examples: of native modules already migrated to propagate context correctly fsevents, bcrypt, node-sass
   * V8 currency:
-    * Master is on V8 6.5. Mostly performance improvements. Includes mitigations for spectre and meltdown vulnerabilities. Opened PR to disable those at build time by default: https://github.com/nodejs/node/pull/19222
+    * Master is on V8 6.5. Mostly performance improvements. Includes mitigations for spectre and meltdown vulnerabilities. Opened PR to disable those at build time by default: <https://github.com/nodejs/node/pull/19222>
     * PR wip for V8 6.6 update. This will probably be the version that we ship in Node 10.
     * Will open an issue to discuss whether we want to prepare a forward ABI/API compatibility patch for V8 6.7 or even V8 6.8 to make it easier to upgrade during Node 10's lifecycle.
 
@@ -62,6 +62,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-03-21.md
+++ b/meetings/2018-03-21.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=pJ9Fs_qMuZQ
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/511
+* **Recording**:  <https://www.youtube.com/watch?v=pJ9Fs_qMuZQ>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/511>
 
 ## Present
 
@@ -117,6 +117,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-03-28.md
+++ b/meetings/2018-03-28.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://youtu.be/NSVVyXroQL8
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/513
+* **Recording**:  <https://youtu.be/NSVVyXroQL8>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/513>
 
 ## Present
 
@@ -27,7 +27,7 @@
 * Nominate @mafintosh as a collaborator [#19148](https://github.com/nodejs/node/issues/19148)
 * Tracking Issue for Runtime Deprecation of Buffer constructor [#19079](https://github.com/nodejs/node/issues/19079)
   * Chalker: Migration guide almost ready, where should we put it?
-  * Fhinkel: maybe https://nodejs.org/en/docs/guides/ ?
+  * Fhinkel: maybe <https://nodejs.org/en/docs/guides/> ?
   * Fishrock: guide needs to be in docs or at least linked from docs, and from deprecation list in docs
   * Co-authors: Anna, Joyee, Chalker
   * Needs reviews [#19524](https://github.com/nodejs/node/pull/19524)
@@ -51,6 +51,6 @@ A: Fishrock: Allow people to write JavaScript outside of web browsers (server, d
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-04-04.md
+++ b/meetings/2018-04-04.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=Yl70CnAcHbs
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/516
+* **Recording**:  <https://www.youtube.com/watch?v=Yl70CnAcHbs>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/516>
 
 ## Present
 
@@ -77,7 +77,7 @@
   * modules
     * yesterday 8 hour online summit with presentations/discussion
     * 15-17 members
-    * Videos available: https://www.youtube.com/watch?v=IbPxOaGveXA&list=PLfMzBWSH11xb9LoHLO0q3Yo7HXjMOm11N
+    * Videos available: <https://www.youtube.com/watch?v=IbPxOaGveXA&list=PLfMzBWSH11xb9LoHLO0q3Yo7HXjMOm11N>
 
   * Error messages
   * V8 Currency
@@ -133,6 +133,6 @@
 * why does Michael have node.js background? Michael -> covering up junky background in office for fun.
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-04-11.md
+++ b/meetings/2018-04-11.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=GA2IHHFPRhs
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/518
-* **Minutes Google Doc**: https://docs.google.com/document/d/1vLEQszZq9IfVqbT7K7QD17OC4jXAYchcT7MXI2Ck3es
+* **Recording**: <https://www.youtube.com/watch?v=GA2IHHFPRhs>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/518>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1vLEQszZq9IfVqbT7K7QD17OC4jXAYchcT7MXI2Ck3es>
 
 ## Present
 
@@ -63,6 +63,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-04-18.md
+++ b/meetings/2018-04-18.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://youtu.be/8C8BRsUMeQg
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/520
+* **Recording**: <https://youtu.be/8C8BRsUMeQg>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/520>
 
 ## Present
 
@@ -109,6 +109,6 @@ No questions this week.
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-04-25.md
+++ b/meetings/2018-04-25.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=2VTD47S8HhQ
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/529
+* **Recording**:  <https://www.youtube.com/watch?v=2VTD47S8HhQ>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/529>
 
 ## Present
 
@@ -37,7 +37,7 @@
   * [#257](https://github.com/nodejs/TSC/issues/257)
   * [#492](https://github.com/nodejs/TSC/issues/492)
   * [#490](https://github.com/nodejs/TSC/issues/490)
-* Jeremiah - created trial discord to see how that works for communication. Issue: https://github.com/nodejs/admin/issues/53, Discord link: https://discordapp.com/invite/eF23Jpc
+* Jeremiah - created trial discord to see how that works for communication. Issue: <https://github.com/nodejs/admin/issues/53>, Discord link: <https://discordapp.com/invite/eF23Jpc>
 
 * Michael - reminder about TSC Chair and Director nominations.
 
@@ -87,6 +87,6 @@ No questions this week.
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-05-02.md
+++ b/meetings/2018-05-02.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=X7CgROGtfwY
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/536
+* **Recording**: <https://www.youtube.com/watch?v=X7CgROGtfwY>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/536>
 
 ## Present
 

--- a/meetings/2018-05-09.md
+++ b/meetings/2018-05-09.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=FGlchJAU5UI
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/538
+* **Recording**:  <https://www.youtube.com/watch?v=FGlchJAU5UI>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/538>
 
 ## Present
 
@@ -67,7 +67,7 @@
   * V8 currency
     * Last blocking issue for 6.7 upgrade being fixed upstream thanks to @mmarchini. It was again
       a problem related to us supporting an old Clang version. Issue was opened suggesting we
-      upgrade the Clang version required to build node: https://github.com/nodejs/build/issues/1264
+      upgrade the Clang version required to build node: <https://github.com/nodejs/build/issues/1264>
   * Async Hooks
     * Nearform team spent some time with google team pretty thoroughly and identified a number
       of performance bottlenecks. Matteo will open a PR that improves performance but requires
@@ -90,6 +90,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-05-16.md
+++ b/meetings/2018-05-16.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=o73QKPUEyEU
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/542
+* **Recording**: <https://www.youtube.com/watch?v=o73QKPUEyEU>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/542>
 
 ## Present
 
@@ -51,6 +51,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-05-23.md
+++ b/meetings/2018-05-23.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=5W1o9iHvJGM
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/544
+* **Recording**: <https://www.youtube.com/watch?v=5W1o9iHvJGM>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/544>
 
 ## Present
 * Colin Ihrig @cjihrig (TSC)
@@ -71,7 +71,7 @@
   * Working on policy for adding new APIs and treating them as experimental for some period
     of time.
 * OpenSSL: Rod still pending doc updates, 1.1.1 still not released, date has been pushed out, now last beta listed is 19th of July
-* Workers: https://github.com/nodejs/node/pull/20876
+* Workers: <https://github.com/nodejs/node/pull/20876>
   * Anna submitted initial PR, please take a look.
   * James: need to resolve the namespace, there was some controversy re “workers”, we need
     to resolve this, similar to “fs/promises”, we keep kicking this issue down the road
@@ -85,12 +85,12 @@
 * TSC Governance: Myles not present
 * New Streams API:
   * Matteo: not much progress, some discussion on exit criteria for async iterators
-    https://github.com/nodejs/readable-stream/issues/333
+    <https://github.com/nodejs/readable-stream/issues/333>
 * V8 currency: Targos not here
 * Async Hooks:
   * Matteo: big bug in Async Hooks introduced by optimization of async/await broke Async
     Hooks with async/await, manual backport of V8 fix to 6.7, struggled with 6.6 backport, better
-    to update to 6.7 https://github.com/nodejs/node/pull/19989/commits/2473cab8e2047fe08745d5ae8eed20a4f81a11dc, see https://github.com/nodejs/node/issues/20516.
+    to update to 6.7 <https://github.com/nodejs/node/pull/19989/commits/2473cab8e2047fe08745d5ae8eed20a4f81a11dc>, see <https://github.com/nodejs/node/issues/20516>.
 
 ## Q&A, Other
 
@@ -99,6 +99,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-06-06.md
+++ b/meetings/2018-06-06.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=Tul5kDMcOHE
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/549
+* **Recording**: <https://www.youtube.com/watch?v=Tul5kDMcOHE>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/549>
 
 ## Present
 
@@ -31,7 +31,7 @@
 
 ### Announcements
 
-* Proposal to fold post-mortem WG into Diagnostics WG https://github.com/nodejs/post-mortem/issues/48
+* Proposal to fold post-mortem WG into Diagnostics WG <https://github.com/nodejs/post-mortem/issues/48>
 * Security release next week (on or around June 12)
 * Call for proposals for NodeConf EU closes next Friday
 * Version 10.4.0 of Node.js coming which fixes async-hooks issue
@@ -89,6 +89,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-06-13.md
+++ b/meetings/2018-06-13.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=OxjWOgC1U9k
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/551
+* **Recording**:  <https://www.youtube.com/watch?v=OxjWOgC1U9k>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/551>
 
 ## Present
 
@@ -104,6 +104,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-06-20.md
+++ b/meetings/2018-06-20.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=TyrpGr_9NQc
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/553
+* **Recording**:  <https://www.youtube.com/watch?v=TyrpGr_9NQc>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/553>
 
 ## Present
 
@@ -61,7 +61,7 @@
   * Franziska is it reasonable to wait for Jeremiah to document
   * Michael, Chalker can you run the tool to look for ecosystem usage?
   * Chalker will do that.
-  * Anna, 21102 is PR to make active handles public: https://github.com/nodejs/node/pull/21102
+  * Anna, 21102 is PR to make active handles public: <https://github.com/nodejs/node/pull/21102>
   * Leave on agenda for next week.
 
 * process: add allowedEnvironmentNodeFlags property [#19335](https://github.com/nodejs/node/pull/19335)
@@ -82,7 +82,7 @@
   * Error messages - bulk of remaining ones are in crypto, planning to work on them soon.
   * Streams API - no updates
   * Async hooks - nothing major to report. PR open which may be blocked:
-    https://github.com/nodejs/node/pull/21313
+    <https://github.com/nodejs/node/pull/21313>
   * npm integration - nothing actionable yet
   * open web standards - Gus is going to next TC39 meeting, some good discussion about
     Node.js involvement in WHATWG.
@@ -95,6 +95,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-06-27.md
+++ b/meetings/2018-06-27.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=Lyb7ELXs-gM
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/554
+* **Recording**: <https://www.youtube.com/watch?v=Lyb7ELXs-gM>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/554>
 
 ## Present
 
@@ -62,7 +62,7 @@ Rod, Jon, Refael, and Joyee will set up a meeting to work through this issue.
   * Modules: Lots of stuff! Defining “transparent interop” and maybe not using it. Conversation around hooks. Pluggable loaders.
   * N-API: continued for on doc for node-addon-api and prep for NodeSummit
   * Workers: no news to report this week
-  * Errors: Discussion about previously-removed error code and whether or not they should be restored. The issue is tagged tsc-review. Please take a look. https://github.com/nodejs/node/pull/21491
+  * Errors: Discussion about previously-removed error code and whether or not they should be restored. The issue is tagged tsc-review. Please take a look. <https://github.com/nodejs/node/pull/21491>
   * Governance: not much to report this week, but there has been some movement around LTS/Release team
   * Streams: a little experimentation but nothing to report this week
   * V8 currency: Michael Dawson and Ali raised some small issues and Myles took note.
@@ -80,6 +80,6 @@ Rod, Jon, Refael, and Joyee will set up a meeting to work through this issue.
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-07-12.md
+++ b/meetings/2018-07-12.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=jX_FFG-XC_E
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/565
+* **Recording**:  <https://www.youtube.com/watch?v=jX_FFG-XC_E>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/565>
 
 ## Present
 
@@ -53,7 +53,7 @@
   * New streams API, fs-source/fs-sync cleanup for published modules
   * V8 currency:
     * Update to V8 6.8 waiting for build changes because more recent version of macOS is
-      needed.  Issue here for discussion on moving up to compile on OSX 10.11 - https://github.com/nodejs/build/issues/1358#issuecomment-403639964
+      needed.  Issue here for discussion on moving up to compile on OSX 10.11 - <https://github.com/nodejs/build/issues/1358#issuecomment-403639964>
     * @pmarshall opened PR to patch ABI compatibility with Node 10
     * canary currently broken. Anna is working on a fix.
 * Proposal: add all new core modules under a scope? (too late for http2) [#389](https://github.com/nodejs/TSC/issues/389)
@@ -67,6 +67,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-07-18.md
+++ b/meetings/2018-07-18.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=5GIkWKwBImk
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/571
+* **Recording**: <https://www.youtube.com/watch?v=5GIkWKwBImk>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/571>
 
 ## Present
 
@@ -34,7 +34,7 @@
 * \[v10.x\] Revert "http: always emit close on req and res" [#21809](https://github.com/nodejs/node/pull/21809)
   * Matteo, it's a SemVer Major that slipped through.  3 commits total
   * Michael Z - this broke end of stream but that was fixed with a later PR.
-    https://github.com/nodejs/node/pull/20941
+    <https://github.com/nodejs/node/pull/20941>
   * Matteo, revert in 10.x, leave as is in Master
   * Michael, since reported as breaking by somebody already we should revert. Unfortunate
     because new behavior is probably what you’d expect even if not documented that way.
@@ -43,7 +43,7 @@
 * Password Hashing API [#21766](https://github.com/nodejs/node/issues/21766)
   * Issue reports that new script API in v10.5 may cause people to make mistakes
   * Suggestion is that we should remove it, but that would SemVer major
-  * Discussion going on in the security WG, https://github.com/nodejs/security-wg/issues/339
+  * Discussion going on in the security WG, <https://github.com/nodejs/security-wg/issues/339>
   * We should look to see if there is any usage, since complex may take time for it
     to be adopted.
   * One option is to rename, but that would be SemVer major.
@@ -90,6 +90,6 @@ No questions today.
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-08-01.md
+++ b/meetings/2018-08-01.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=a_0EgpBIA4I
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/576
+* **Recording**:  <https://www.youtube.com/watch?v=a_0EgpBIA4I>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/576>
 
 ## Present
 
@@ -25,7 +25,7 @@
 ### Announcements
 
 *Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
-* readable-stream@3 is coming out soon, check it out with `npm i readable-stream@next` and provide feedback opening issues at https://github.com/nodejs/readable-stream
+* readable-stream@3 is coming out soon, check it out with `npm i readable-stream@next` and provide feedback opening issues at <https://github.com/nodejs/readable-stream>
 
 ### nodejs/build
 
@@ -54,7 +54,7 @@
 ### nodejs/docker-node
 
 * Image without npm nor yarn [#404](https://github.com/nodejs/docker-node/issues/404)
-  * Please comment on https://github.com/nodejs/Release/issues/341
+  * Please comment on <https://github.com/nodejs/Release/issues/341>
 
 ### nodejs/TSC
 
@@ -81,7 +81,7 @@
   * N-API
     * Good Evangelism at Node Summit
     * Continued focus on doc/testing for node-addon-api
-    * Discussion on stability for libuv - https://github.com/libuv/libuv/issues/1931
+    * Discussion on stability for libuv - <https://github.com/libuv/libuv/issues/1931>
 
   * Error messages
     * no updates
@@ -90,7 +90,7 @@
     * Rod to become champion
 
   * New Stream APIs
-    * zlib transform now up as a standalone module on npm: https://github.com/fishrock123/zlib-transform
+    * zlib transform now up as a standalone module on npm: <https://github.com/fishrock123/zlib-transform>
     * some exploration of alternate API options, particularly in using async iterators/generators, but this did not go as well as anticipated (requires double yielding).
 
   * V8 Currently
@@ -108,6 +108,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-08-08.md
+++ b/meetings/2018-08-08.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=QPvC9hOk7qA
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/580
+* **Recording**: <https://www.youtube.com/watch?v=QPvC9hOk7qA>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/580>
 
 ## Present
 
@@ -23,7 +23,7 @@
 ### Announcements
 
 *Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
-* readable-stream@3 is coming out this week, check it out with `npm i readable-stream@next` and provide feedback opening issues at https://github.com/nodejs/readable-stream
+* readable-stream@3 is coming out this week, check it out with `npm i readable-stream@next` and provide feedback opening issues at <https://github.com/nodejs/readable-stream>
 
 ### nodejs/build
 
@@ -91,6 +91,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-08-22.md
+++ b/meetings/2018-08-22.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=1f69vc69AkI
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/587
+* **Recording**:  <https://www.youtube.com/watch?v=1f69vc69AkI>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/587>
 
 ## Present
 
@@ -77,6 +77,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-08-29.md
+++ b/meetings/2018-08-29.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=zfqdJKHUcCM
-* **GitHub Issue**: https://docs.google.com/document/d/1sGHdNAQnFPwny4YTDr0kZYJDer2-L0NXGKJXIxSVhLM/edit
+* **Recording**: <https://www.youtube.com/watch?v=zfqdJKHUcCM>
+* **GitHub Issue**: <https://docs.google.com/document/d/1sGHdNAQnFPwny4YTDr0kZYJDer2-L0NXGKJXIxSVhLM/edit>
 
 ## Present
 
@@ -95,7 +95,7 @@
 * James process to internal bindings
   * lots of progress many PRs, current fall through. Will need deprecation process and along
     with that we’ll need discussion of new APIs. Please follow tracking issue to keep up
-    https://github.com/nodejs/node/issues/22160
+    <https://github.com/nodejs/node/issues/22160>
 
 ### nodejs/admin
 
@@ -105,6 +105,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-09-05.md
+++ b/meetings/2018-09-05.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=FeMWE1b1ucc
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/593
+* **Recording**: <https://www.youtube.com/watch?v=FeMWE1b1ucc>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/593>
 
 ## Present
 * Ali Ijaz Sheikh @ofrobots (TSC)
@@ -102,6 +102,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-09-12.md
+++ b/meetings/2018-09-12.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=siKVqDPUz64
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/597
+* **Recording**: <https://www.youtube.com/watch?v=siKVqDPUz64>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/597>
 
 ## Present
 
@@ -88,7 +88,7 @@
       Shigeki is starting to work on pulling it in. Looks like potential breaking change but should
       be able to work through. Supporting TLS 1.3 may be more problematic though. That might
       Mean that TLS 1.3 may not be available in Node until 11.x.
-      https://github.com/nodejs/node/issues/18770 is the issue to look at.
+      <https://github.com/nodejs/node/issues/18770> is the issue to look at.
 
   * Workers, nothing to report maybe next week
 
@@ -107,7 +107,7 @@
 
   * Open Web standards
     * Spun up repo, some people nominated to the team, discussing how to engage and get
-      started.  https://github.com/nodejs/open-standards/
+      started.  <https://github.com/nodejs/open-standards/>
 
 ## Q&A, Other
 
@@ -115,6 +115,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-09-19.md
+++ b/meetings/2018-09-19.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=H5AXnKMsyoo
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/601
+* **Recording**:  <https://www.youtube.com/watch?v=H5AXnKMsyoo>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/601>
 
 ## Present
 
@@ -67,11 +67,11 @@
     * Some progress was made towards fixing canary (thanks @refack!).
       Need more eyes on the PR: [#22920](https://github.com/nodejs/node/pull/22920)
     * N-API - focus on AsyncWorker, Evangelism, examples and test suite. See
-    https://github.com/nodejs/abi-stable-node/issues/338
+    <https://github.com/nodejs/abi-stable-node/issues/338>
   * Workers
     * Inspector support for workers was added, merged yesterday
     * Rich has opened issue on exit criteria for experimental status
-      https://github.com/nodejs/node/issues/22940, please chime in
+      <https://github.com/nodejs/node/issues/22940>, please chime in
   * Core Promise APIs, have had PRs to improved coverage,
     steady state gaining experience before progressing much further
   * Jeremiah, getting ready to be able to demo further at collaborator summit
@@ -82,7 +82,7 @@
 
 * JS Interactive & Node Community Corner - Questions? [#211](https://github.com/nodejs/admin/issues/211)
   * Matteo, TSC panel, asking for questions issue open to ask for questions in advance:
-    https://github.com/nodejs/TSC/issues/602
+    <https://github.com/nodejs/TSC/issues/602>
 
 ## Q&A, Other
 
@@ -90,6 +90,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-09-26.md
+++ b/meetings/2018-09-26.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=PgzCva61UrU
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/605
+* **Recording**:  <https://www.youtube.com/watch?v=PgzCva61UrU>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/605>
 
 ## Present
 
@@ -65,6 +65,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-10-03.md
+++ b/meetings/2018-10-03.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=ARgtJrgvaOQ
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/608
+* **Recording**:  <https://www.youtube.com/watch?v=ARgtJrgvaOQ>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/608>
 
 ## Present
 
@@ -25,7 +25,7 @@
 
 * To everybody attending the collaborator summit at Node+JS Interaticve.  Please make sure
   to take survey about attendance of sessions in the collaboration summit (Vancouver 2018)
-  https://github.com/nodejs/summit/issues/115
+  <https://github.com/nodejs/summit/issues/115>
 
 ### nodejs/node
 
@@ -53,7 +53,7 @@
       be breaking.
   * Error message - `err.name` is currently formatted as `Error [ERR_CODE]` which breaks web compat
     (at least it breaks Web Platform Tests), See
-    https://github.com/nodejs/node/issues/20253#issuecomment-426576453
+    <https://github.com/nodejs/node/issues/20253#issuecomment-426576453>
 
 ### nodejs/community-committee
 
@@ -66,6 +66,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-10-17.md
+++ b/meetings/2018-10-17.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=oFZFNdv9Jf0
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/612
+* **Recording**:  <https://www.youtube.com/watch?v=oFZFNdv9Jf0>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/612>
 
 ## Present
 
@@ -118,7 +118,7 @@
   * Short board meeting last week, mostly going through the numbers from the conference
     * just under 1000 tickets sold ~20% growth in terms of attendance and funds raised
   * Announced “intent” to merge, had open town hall
-  * Invited to join discussion in nodejs/bootstrap -  https://github.com/nodejs/bootstrap/issues/10
+  * Invited to join discussion in nodejs/bootstrap -  <https://github.com/nodejs/bootstrap/issues/10>
 
 * Strategic Initiatives - Tracking Issue [#423](https://github.com/nodejs/TSC/issues/423)
   * Modules
@@ -158,6 +158,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-10-24.md
+++ b/meetings/2018-10-24.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=ZeVKDRQfSyU
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/615
+* **Recording**:  <https://www.youtube.com/watch?v=ZeVKDRQfSyU>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/615>
 
 ## Present
 
@@ -51,6 +51,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-10-31.md
+++ b/meetings/2018-10-31.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=EK494IEUFOQ
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/618
+* **Recording**:  <https://www.youtube.com/watch?v=EK494IEUFOQ>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/618>
 
 ## Present
 
@@ -25,9 +25,9 @@
 *Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * New collaborator nominations
-  * Peter Marshall (https://github.com/nodejs/node/issues/23849)
-  * Ouyang Yadong (https://github.com/nodejs/node/issues/23955)
-  * Masashi Hirano (https://github.com/nodejs/node/issues/23850)
+  * Peter Marshall (<https://github.com/nodejs/node/issues/23849>)
+  * Ouyang Yadong (<https://github.com/nodejs/node/issues/23955>)
+  * Masashi Hirano (<https://github.com/nodejs/node/issues/23850>)
 
 ### nodejs/node
 
@@ -48,7 +48,7 @@
 * Strategic Initiatives - Tracking Issue [#423](https://github.com/nodejs/TSC/issues/423)
   * Modules
     * tentative phase 2, includes some bits like improving overall experience for interop with cjs
-    * https://github.com/nodejs/modules/blob/master/doc/plan-for-new-modules-implementation.md
+    * <https://github.com/nodejs/modules/blob/master/doc/plan-for-new-modules-implementation.md>
 
   * N-API
     * Workshop at NodeConfEU
@@ -82,10 +82,10 @@
 
 * Steven K - is there  slack channel
   * No official Node.js project channel.
-  * There is node-slackers, which is a partner community see: https://github.com/nodejs/community-committee/blob/master/PARTNER_COMMUNITIES.md
+  * There is node-slackers, which is a partner community see: <https://github.com/nodejs/community-committee/blob/master/PARTNER_COMMUNITIES.md>
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-11-07.md
+++ b/meetings/2018-11-07.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=R7-SIfsEKoY
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/622
+* **Recording**: <https://www.youtube.com/watch?v=R7-SIfsEKoY>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/622>
 
 ## Present
 
@@ -22,7 +22,7 @@
 
 Welcome to our new collaborators @psmarshall and @shisama!
 
-* Ouyang Yadong (@oyyd) nominated to be a collaborator (https://github.com/nodejs/node/issues/23955)
+* Ouyang Yadong (@oyyd) nominated to be a collaborator (<https://github.com/nodejs/node/issues/23955>)
 
 *Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
@@ -43,7 +43,7 @@ Welcome to our new collaborators @psmarshall and @shisama!
 
 OpenSSL (Rod): Getting close to 1.1.1 to land thanks to Sam Roberts, Shigeki, and others. Ironing out edge cases on the lesser used platforms. Getting close to a mergable state!
 
-New Streams API (Jeremiah): Nothing significant to report. Next part requires reliance on the Streams WG and some members there are tied up. If there is someone with Streams 3 knowledge who wants to help build an adapter for that, please volunteer. See https://github.com/Fishrock123/bob/issues/18
+New Streams API (Jeremiah): Nothing significant to report. Next part requires reliance on the Streams WG and some members there are tied up. If there is someone with Streams 3 knowledge who wants to help build an adapter for that, please volunteer. See <https://github.com/Fishrock123/bob/issues/18>
 
 V8 Currency (Michaël): Nothing to report this week.
 
@@ -55,6 +55,6 @@ Async Hooks (Ali): Performance hooks, moving to get rid of the destroy hook so w
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-11-14.md
+++ b/meetings/2018-11-14.md
@@ -3,7 +3,7 @@
 ## Links
 
 * **Recording**:  N/A In person meeting cancelled.
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/630
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/630>
 
 ## Present
 
@@ -43,6 +43,6 @@ N/A In person meeting cancelled.
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-12-05.md
+++ b/meetings/2018-12-05.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=Us6oQKNu_o8
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/637
-* **Minutes Google Doc**: https://docs.google.com/document/d/1zllgnvztB0FarZXFOmn3AnfTOZxpcS-lcLlmE2QDnXg/edit
+* **Recording**: <https://www.youtube.com/watch?v=Us6oQKNu_o8>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/637>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1zllgnvztB0FarZXFOmn3AnfTOZxpcS-lcLlmE2QDnXg/edit>
 
 ## Present
 * Сковорода Никита Андреевич @ChALkeR (TSC)
@@ -25,7 +25,7 @@
 
 * HTTP/1 request destroy behavior change on framing error [#24586](https://github.com/nodejs/node/issues/24586)
   * Express broken because of recent behavior change in the case of a parse error
-  * Broke the dependency on-finished module that is not in CITGM, and it is neither covered in the express test suite (https://github.com/nodejs/citgm/issues/631)
+  * Broke the dependency on-finished module that is not in CITGM, and it is neither covered in the express test suite (<https://github.com/nodejs/citgm/issues/631>)
   * Need better support and coverage for these, back to the issue tracker
 * Fixing child_process module to check values passed strictly to the options object [#24267](https://github.com/nodejs/node/pull/24267)
   * The options object can be polluted via the Object prototype which can lead to security vulnerability
@@ -46,6 +46,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-12-12.md
+++ b/meetings/2018-12-12.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=gqSmf5szUfQ
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/639
+* **Recording**: <https://www.youtube.com/watch?v=gqSmf5szUfQ>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/639>
 
 ## Present
 
@@ -49,12 +49,12 @@
 
 * Strategic Initiatives - Tracking Issue [#423](https://github.com/nodejs/TSC/issues/423)
   * Modules - Quite a bit of discussion happening right now in two break out proposals
-    https://github.com/GeoffreyBooth/node-import-file-specifier-resolution-proposal
+    <https://github.com/GeoffreyBooth/node-import-file-specifier-resolution-proposal>
 
     A proposal to utilize metadata to determine the module type of a package allowing
     for us to support importing both esm and cjs modules.
 
-    https://github.com/jkrems/proposal-pkg-exports/
+    <https://github.com/jkrems/proposal-pkg-exports/>
 
     An alternative approach to the current Node.js resolution algorithm. Meta Data in
     package.json would be used to identify exports. Compatible with [import-map
@@ -70,12 +70,12 @@
   * Governance - we started a project board to track responsibilities of various
     stakeholders within the proposed foundation. We will be using this artifact to
     help determine how many Top-Level committees there will be and what they
-    will be responsible for. https://github.com/nodejs/bootstrap/projects/1
+    will be responsible for. <https://github.com/nodejs/bootstrap/projects/1>
 
-  * Open Web Standards - https://github.com/nodejs/node/pull/21551
+  * Open Web Standards - <https://github.com/nodejs/node/pull/21551>
 
     Introducing a namespace to node. This has implications to other runtimes.
-    https://github.com/nodejs/node/issues/24894
+    <https://github.com/nodejs/node/issues/24894>
 
     Dynamic Modules proposal. This proposal would allow spec compliant named imports
     from  CJS modules. TC39 and V8 want to ensure we have consensus within node
@@ -103,6 +103,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-12-19.md
+++ b/meetings/2018-12-19.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=Sbn8fbvcBhU
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/641
+* **Recording**:  <https://www.youtube.com/watch?v=Sbn8fbvcBhU>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/641>
 
 ## Present
 
@@ -96,6 +96,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-01-02.md
+++ b/meetings/2019-01-02.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=4Ra_aQLIhVo
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/644
+* **Recording**:  <https://www.youtube.com/watch?v=4Ra_aQLIhVo>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/644>
 
 ## Present
 
@@ -39,6 +39,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-01-16.md
+++ b/meetings/2019-01-16.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: http://www.youtube.com/watch?v=gDhSIWWX148
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/650
+* **Recording**: <http://www.youtube.com/watch?v=gDhSIWWX148>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/650>
 
 ## Present
 * Daniel Bevenius @danbev (TSC)
@@ -37,6 +37,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-01-23.md
+++ b/meetings/2019-01-23.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=qamraECS-EM
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/655
+* **Recording**: <https://www.youtube.com/watch?v=qamraECS-EM>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/655>
 
 ## Present
 
@@ -41,7 +41,7 @@
     but Gabriel ‘volunteered’ to confirm process and comment in 651 on what specifically to
     do.
   * Gabriel will also create a new issue to continue discussion around whether we want
-    to assign bits etc. (PoC is in https://github.com/nodejs/node/pull/25539)
+    to assign bits etc. (PoC is in <https://github.com/nodejs/node/pull/25539>)
 
 * Tracking issue for updating TSC on Board Meetings [#476](https://github.com/nodejs/TSC/issues/476)
   * No Myles today so no update.
@@ -60,6 +60,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-01-30.md
+++ b/meetings/2019-01-30.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=Lxia75XIXpI
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/659
+* **Recording**:  <https://www.youtube.com/watch?v=Lxia75XIXpI>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/659>
 
 ## Present
 * Ali Ijaz Sheikh @ofrobots (TSC)
@@ -57,6 +57,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-02-14.md
+++ b/meetings/2019-02-14.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Recording**: https://youtu.be/b8FeRjXC67g
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/664
-* **Minutes Google Doc**: https://docs.google.com/document/d/1ow99XN_btUNt-z-aTa7NCPbB4jKM3g8HCHGREAsJ1xk
+* **Recording**: <https://youtu.be/b8FeRjXC67g>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/664>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1ow99XN_btUNt-z-aTa7NCPbB4jKM3g8HCHGREAsJ1xk>
 
 ## Present
 
@@ -26,7 +26,7 @@ Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs
 
 * process: improve nextTick performance [#25461](https://github.com/nodejs/node/pull/25461)
 
-Matteo proposed https://github.com/nodejs/node/pull/25461#discussion_r256348109 to resolve the @apapirovski objection. No one objects.
+Matteo proposed <https://github.com/nodejs/node/pull/25461#discussion_r256348109> to resolve the @apapirovski objection. No one objects.
 
 ### nodejs/TSC
 
@@ -35,7 +35,7 @@ Matteo proposed https://github.com/nodejs/node/pull/25461#discussion_r256348109 
 Matteo: Some updates from myles recently to the bootstrap wg.
 Matteo: People should check this stuff out if they are interested in the governance of the new foundation, it is important.
 
-See https://github.com/nodejs/bootstrap/tree/master/proposals
+See <https://github.com/nodejs/bootstrap/tree/master/proposals>
 
 * Strategic Initiatives - Tracking Issue [#423](https://github.com/nodejs/TSC/issues/423)
 
@@ -45,13 +45,13 @@ See https://github.com/nodejs/bootstrap/tree/master/proposals
   - Streams: Jeremiah beginning to look at what a pull stream api would look like for libuv.
   - Async-Hooks: weakrefs & domain silliness
   - Open Standards:
-  - Core Promise APIs: new PR opened by Matteo - generate a promise out of a ‘once’ eventemitter event: https://github.com/nodejs/node/pull/26078.
+  - Core Promise APIs: new PR opened by Matteo - generate a promise out of a ‘once’ eventemitter event: <https://github.com/nodejs/node/pull/26078>.
   - Python & GYP: Made most core python scripts be compat with both python 2 & 3. Working on gyp core now. Trying to get both python 2 & 3 into the build/test matrix in CI.
 
 ## Q&A, Other
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-02-20.md
+++ b/meetings/2019-02-20.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=3ZO7llo6p0M
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/668
+* **Recording**: <https://www.youtube.com/watch?v=3ZO7llo6p0M>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/668>
 
 ## Present
 
@@ -51,7 +51,7 @@
 
 * Tracking issue for updating TSC on Board Meetings [#476](https://github.com/nodejs/TSC/issues/476)
   * Board meeting on Friday Feb 22nd.
-  * Items here: https://github.com/nodejs/TSC/projects/1
+  * Items here: <https://github.com/nodejs/TSC/projects/1>
     * licences for non-code
     * Travel fund for collab summit. Has been matched to last year but we may have
       more people since the scope is larger (includes JS project members as well)
@@ -79,6 +79,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-03-14.md
+++ b/meetings/2019-03-14.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=kJ1P0sQ9pBw
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/673
+* **Recording**: <https://www.youtube.com/watch?v=kJ1P0sQ9pBw>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/673>
 
 ## Present
 
@@ -26,7 +26,7 @@
 
 *Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
-* Matteo, call for proposals for NodeConfEU open, please join: https://sessionize.com/nodeconf-eu-2019/.
+* Matteo, call for proposals for NodeConfEU open, please join: <https://sessionize.com/nodeconf-eu-2019/>.
 
 ### nodejs/node
 
@@ -108,17 +108,17 @@
 ### nodejs/admin
 
 * Checklist to address changes due to move to OpenJS Foundation [311](https://github.com/nodejs/admin/issues/311)
-  * https://docs.google.com/spreadsheets/d/1bLTnriy4sCnoOb7yTC0QWuApuGC8lChCcr_7A3UxEPc/edit#gid=0
+  * <https://docs.google.com/spreadsheets/d/1bLTnriy4sCnoOb7yTC0QWuApuGC8lChCcr_7A3UxEPc/edit#gid=0>
 
 ### build
 
 * Platform/compiler proposal for 12.x from Build WG.
-  * Rod provided an overview of https://docs.google.com/spreadsheets/d/1bLTnriy4sCnoOb7yTC0QWuApuGC8lChCcr_7A3UxEPc/edit#gid=0
+  * Rod provided an overview of <https://docs.google.com/spreadsheets/d/1bLTnriy4sCnoOb7yTC0QWuApuGC8lChCcr_7A3UxEPc/edit#gid=0>
 
 ## Q&A, Other
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-03-27.md
+++ b/meetings/2019-03-27.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=_2Z8c8Uhf9k
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/676
+* **Recording**:  <https://www.youtube.com/watch?v=_2Z8c8Uhf9k>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/676>
 
 ## Present
 
@@ -24,12 +24,12 @@
 
 * Node.js 12 is coming (end of April)! If you have breaking changes that you
   want to land, they will require TSC approval.
-  https://github.com/nodejs/Release/issues/417
+  <https://github.com/nodejs/Release/issues/417>
 * Collaborator Summit will be at the end of May in Berlin (right before JSConf
   EU). There is an issue for the Call for Sessions.
-  https://github.com/nodejs/summit/issues/149
+  <https://github.com/nodejs/summit/issues/149>
 * Proposal for updating supported platforms etc. for Node.js 12.
-  https://github.com/nodejs/node/pull/26714
+  <https://github.com/nodejs/node/pull/26714>
   * gcc 6
   * Almost no feedback on macOS support proposal. Build minimum is 10.13 and
       XCode 10 with minimum support run on 10.11. (Rich says that seems
@@ -38,8 +38,8 @@
       want to be locked into supporting Python 2 for 18 months or whatever after
       it goes EOL.
 * Currently 30 open pull requests labeled semver-major. Attention, TSC folks!
-  https://github.com/nodejs/node/search?q=is%3Apr+is%3Aopen+label%3Asemver-major&type=Issues
-* New ESM implementation proposed! https://github.com/nodejs/node/pull/26745
+  <https://github.com/nodejs/node/search?q=is%3Apr+is%3Aopen+label%3Asemver-major&type=Issues>
+* New ESM implementation proposed! <https://github.com/nodejs/node/pull/26745>
 
 ### nodejs/admin
 
@@ -47,7 +47,7 @@
   * One thing to get consensus on is how to select voting representatives on
     CPC. Gireesh has an alternative to treat TSC and CommComm less disjointed
     and more of a unified voice. Discussion to continue in issue tracker.
-    https://github.com/nodejs/admin/issues/316
+    <https://github.com/nodejs/admin/issues/316>
 
 ### nodejs/TSC
 
@@ -56,7 +56,7 @@
   * V8 Currency: 7.4 is about to land on master which is the version that should
     be in Node.js 12.
   * Python 3 and GYP: A lot of work done to make GYP compatible with Python 3.
-    There’s a PR being worked on. https://github.com/nodejs/node/pull/26620
+    There’s a PR being worked on. <https://github.com/nodejs/node/pull/26620>
   * N-API: thread-safe function backports have landed in v8.x.
   * Streams: No significant movement since last time.
 
@@ -66,6 +66,6 @@ No questions.
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-04-10.md
+++ b/meetings/2019-04-10.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=ATLTrJCIS0A
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/688
+* **Recording**:  <https://www.youtube.com/watch?v=ATLTrJCIS0A>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/688>
 
 ## Present
 
@@ -24,7 +24,7 @@
     Attending. Right before JSConfEU 30, 31st of May. Lots of links in the notes
     github.com/nodejs/summit.  If you want to use the travel fund and a member of a project
     in OpenJS foundation please apply. Call For Proposals:
-    https://github.com/nodejs/summit/issues/149. Register: https://github.com/nodejs/summit/issues/152
+    <https://github.com/nodejs/summit/issues/149>. Register: <https://github.com/nodejs/summit/issues/152>
 
 ### nodejs/node
 
@@ -68,6 +68,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-04-17.md
+++ b/meetings/2019-04-17.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=LiuRaDfTmVw
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/691
+* **Recording**: <https://www.youtube.com/watch?v=LiuRaDfTmVw>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/691>
 
 ## Present
 
@@ -105,6 +105,6 @@ Build Resources
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-04-24.md
+++ b/meetings/2019-04-24.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=31wQvrGt5Hg
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/695
+* **Recording**: <https://www.youtube.com/watch?v=31wQvrGt5Hg>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/695>
 
 ## Present
 
@@ -31,16 +31,16 @@
   * Issue is already closed.  Vuln in node-tar, fixed in version 4.X but node-gyp was not
     using that.  Update for node-gyp was semver-major.  Node-gyp version 4.x is now released
     so immediate issue was addressed. If people want a fix in node-gyp version 3.x it would
-    need a change in node-tar first, discussion is ongoing: https://github.com/npm/node-tar/issues/212#issuecomment-486331373
+    need a change in node-tar first, discussion is ongoing: <https://github.com/npm/node-tar/issues/212#issuecomment-486331373>
   * Was not an exploitable issue for node-gyp itself.
   * Issue was only open for 12 days, so no real problem in terms of timing either.
   * @chalker mentions that the vulnerability in node-tar did not effect node-gyp’s use of tar
-  * https://github.com/nodejs/node-gyp/pull/1718#issuecomment-485610857 is relevant
+  * <https://github.com/nodejs/node-gyp/pull/1718#issuecomment-485610857> is relevant
 
 ### nodejs/node
 
 * Piping w/ spawn is broken in Node 11 [#27097](https://github.com/nodejs/node/issues/27097)
-  * Anna came up with fix: https://github.com/nodejs/node/pull/27373/.
+  * Anna came up with fix: <https://github.com/nodejs/node/pull/27373/>.
   * agenda tag removed.
 
 ### nodejs/TSC
@@ -48,11 +48,11 @@
 * Call for Papers (CFP) review process for Node+JS Interactive - Sarah from Foundation.
   * Making a few changes to the CFP review process
   * Had a CFP review committee last year, hoping to make it broader this year
-  * Want to make sure there is an open invitation to participate: https://github.com/openjs-foundation/bootstrap/issues/148
+  * Want to make sure there is an open invitation to participate: <https://github.com/openjs-foundation/bootstrap/issues/148>
   * Have 2 co-chairs who will be final decision makers on content:
     * Tracy Hinds
     * Christian Bromann
-  * https://docs.google.com/document/d/1c0y-XSssZdEZGyCo0FVU6Wnd2TM3Ye-63xi18xjKVGM/edit
+  * <https://docs.google.com/document/d/1c0y-XSssZdEZGyCo0FVU6Wnd2TM3Ye-63xi18xjKVGM/edit>
 
   * There has been some discussion around changing the name of the conference.  Two options
     being discussed.
@@ -101,6 +101,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-05-15.md
+++ b/meetings/2019-05-15.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=kVZT46Z7epw
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/704
+* **Recording**: <https://www.youtube.com/watch?v=kVZT46Z7epw>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/704>
 
 ## Present
 
@@ -22,7 +22,7 @@
 
 *Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
-* Myles - Call for submissions for Node+JS Interactive is open, please submit. https://events.linuxfoundation.org/events/nodejs-interactive-2019/program/call-for-proposals-cfp/
+* Myles - Call for submissions for Node+JS Interactive is open, please submit. <https://events.linuxfoundation.org/events/nodejs-interactive-2019/program/call-for-proposals-cfp/>
 
 ### nodejs/node
 
@@ -70,6 +70,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-06-05.md
+++ b/meetings/2019-06-05.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=2oGbXx4fJMQ
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/714
+* **Recording**:  <https://www.youtube.com/watch?v=2oGbXx4fJMQ>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/714>
 
 ## Present
 
@@ -62,6 +62,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-06-19.md
+++ b/meetings/2019-06-19.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=ve9x5aanbfU
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/717
+* **Recording**: <https://www.youtube.com/watch?v=ve9x5aanbfU>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/717>
 
 ## Present
 
@@ -23,7 +23,7 @@
 
 *Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
-* https://github.com/nodejs/node/issues/27731 - Nominating Jiawen Geng @gengjiawen to be a Collaborator . Gireesh and Matteo will be onboarding Jiawen on 06/20
+* <https://github.com/nodejs/node/issues/27731> - Nominating Jiawen Geng @gengjiawen to be a Collaborator . Gireesh and Matteo will be onboarding Jiawen on 06/20
 
 ### nodejs/node
 
@@ -39,7 +39,7 @@
 ### nodejs/TSC
 
 * Nominating @BethGriggs to the TSC [718](https://github.com/nodejs/TSC/pull/718)
-  * FYI - https://github.com/nodejs/TSC/issues/718
+  * FYI - <https://github.com/nodejs/TSC/issues/718>
   * Michael will add Beth to observers
 
 * doc: update TSC charter [#698](https://github.com/nodejs/TSC/pull/698)
@@ -61,6 +61,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-06-26.md
+++ b/meetings/2019-06-26.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=B2DyWTJWk6c
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/722
+* **Recording**:  <https://www.youtube.com/watch?v=B2DyWTJWk6c>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/722>
 
 ## Present
 
@@ -62,6 +62,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-07-03.md
+++ b/meetings/2019-07-03.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=eeZgxDfZHUY
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/725
+* **Recording**:  <https://www.youtube.com/watch?v=eeZgxDfZHUY>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/725>
 
 ## Present
 
@@ -91,13 +91,13 @@
     * Myles believe we can.
   * Streams
     * Could things going on related to streams initiatives in general
-    * PR open for `stream.Transform.by()` with current streams to allow better use with async generators https://github.com/nodejs/node/pull/28501
-    * streamx was recently created  https://github.com/mafintosh/streamx - “streams4 -ish”
+    * PR open for `stream.Transform.by()` with current streams to allow better use with async generators <https://github.com/nodejs/node/pull/28501>
+    * streamx was recently created  <https://github.com/mafintosh/streamx> - “streams4 -ish”
     * Bob streams, in time since JSConfEU, streams3 adaptor so you can pipe back/form
       between existing streams, now working on a full automated tests suite
-    * https://github.com/Fishrock123/bob likely becoming spec repo, still considering best time to pull into Node.js org
+    * <https://github.com/Fishrock123/bob> likely becoming spec repo, still considering best time to pull into Node.js org
   * Open Web standards
-    * https://github.com/openjs-foundation/standards
+    * <https://github.com/openjs-foundation/standards>
     * Biweekly meeting for 10PM UTC
     * First meeting of OpenJS standards team yesterday
       * Really high level discussion of the mechanics of how to do things
@@ -113,6 +113,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-07-10.md
+++ b/meetings/2019-07-10.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=msjIxL_2DzA
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/728
+* **Recording**:  <https://www.youtube.com/watch?v=msjIxL_2DzA>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/728>
 
 ## Present
 
@@ -50,12 +50,12 @@
 * Strategic Initiatives - Tracking Issue [#423](https://github.com/nodejs/TSC/issues/423)
   * N-API - backports for N-API 5 are underway
     * Gabriel found modules with several hundreds of thousands of downloads/month,
-      https://github.com/nodejs/abi-stable-node/issues/346#issuecomment-508648674
+      <https://github.com/nodejs/abi-stable-node/issues/346#issuecomment-508648674>
 
 ## Q&A, Other
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-07-24.md
+++ b/meetings/2019-07-24.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=6Y_lSGZSkZc
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/734
+* **Recording**: <https://www.youtube.com/watch?v=6Y_lSGZSkZc>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/734>
 
 ## Present
 
@@ -26,7 +26,7 @@
 * Rich: 12.7.0 released
 * Michael: OpenJS project mailing list is a great way to keep up with what's going on at the CPC. Jory does a
   great job of sending out a summary after each meeting as well as including other things of note: 
-  https://lists.openjsf.org/g/projects
+  <https://lists.openjsf.org/g/projects>
 * Jerimiah: doing review of youtube account access
 
 ### nodejs/node
@@ -49,8 +49,8 @@
     * cclaus will start giving us updates to review through updated markdown file to highlight
       blockers or where help is needed.
   * Streams - Jeremiah has had time to work on it has made
-    * Progress update: https://github.com/Fishrock123/bob/issues/40.
-    * Trying to organize meeting around effort to discuss some of the key issues.  https://github.com/Fishrock123/bob/issues/43
+    * Progress update: <https://github.com/Fishrock123/bob/issues/40>.
+    * Trying to organize meeting around effort to discuss some of the key issues.  <https://github.com/Fishrock123/bob/issues/43>
     * Planning to move into Node.js org soon
 * V8 currency
   * Michaël Zasso: nothing special to report this week
@@ -62,6 +62,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-07-29.md
+++ b/meetings/2019-07-29.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=pkx1S0Jlymk
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/738
+* **Recording**:  <https://www.youtube.com/watch?v=pkx1S0Jlymk>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/738>
 
 ## Present
 
@@ -63,11 +63,11 @@
   * Two new Foundation Members
     * VINCIT (Silver)
     * SAUCELABS (Silver)
-  * Recording of public meeting: https://www.youtube.com/watch?v=VDA72_ZuQDo
+  * Recording of public meeting: <https://www.youtube.com/watch?v=VDA72_ZuQDo>
   * Node+JS Interactive update (CFP notifications this week)
   * Update on transition (CPC operating regularly, working on key policies)
-  * Links for info/participation - https://openjsf.org/collaboration
-  * mailing list - projects@lists.openjsf.org
+  * Links for info/participation - <https://openjsf.org/collaboration>
+  * mailing list - <mailto:projects@lists.openjsf.org>
   * Travel fund proposal
   * Marketing Update (+43% in LinkedIn follows, needs investigation)
 
@@ -77,7 +77,7 @@
   * Core promise APIs
     * No update
   * New streams
-    * Last week’s July progress update https://github.com/Fishrock123/bob/issues/40 *
+    * Last week’s July progress update <https://github.com/Fishrock123/bob/issues/40> *
   * V8 - 7.6 is stable, will update the PR by the end of the week and work on integration in
     Node.js 12. Canary is fine.
 * Quic/HTTP3
@@ -90,6 +90,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-08-07.md
+++ b/meetings/2019-08-07.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=HZsAWJgaaB0
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/740
+* **Recording**: <https://www.youtube.com/watch?v=HZsAWJgaaB0>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/740>
 
 ## Present
 
@@ -62,10 +62,10 @@ HTTP/3 (James): QUIC support: Things are moving along. Issues getting it to work
 
 Startup Resources: No one present
 
-Build (Rich): Please take a look at https://github.com/nodejs/node/pull/28858 and help get that across the finish line.
+Build (Rich): Please take a look at <https://github.com/nodejs/node/pull/28858> and help get that across the finish line.
 
 ### nodejs/admin
 
 * Tracking issue for update on CPC and Board Meetings [#395](https://github.com/nodejs/admin/issues/395)
 
-Myles: Biggest thing with the CPC this week were the landing of the official process for new projects applying to the Foundation. Other big thing is discussion about moving administration of the travel fund out of Node.js admin and into OpenJS. This does not mean Node.js can’t have its own separate travel fund, but it would be a smaller fund for non-Foundation-related activity. Also, checkout https://lists.openjsf.org and sign up for stuff you’re interested in. As for the board, the next board meeting is the 23rd. If anyone has something to be brought to the board, now is the time to raise it. Since Michael Dawson is out of office, feel free to ping Myles instead (who is Google’s rep on the board).
+Myles: Biggest thing with the CPC this week were the landing of the official process for new projects applying to the Foundation. Other big thing is discussion about moving administration of the travel fund out of Node.js admin and into OpenJS. This does not mean Node.js can’t have its own separate travel fund, but it would be a smaller fund for non-Foundation-related activity. Also, checkout <https://lists.openjsf.org> and sign up for stuff you’re interested in. As for the board, the next board meeting is the 23rd. If anyone has something to be brought to the board, now is the time to raise it. Since Michael Dawson is out of office, feel free to ping Myles instead (who is Google’s rep on the board).

--- a/meetings/2019-08-14.md
+++ b/meetings/2019-08-14.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=m995AZDge_Q
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/744
+* **Recording**:  <https://www.youtube.com/watch?v=m995AZDge_Q>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/744>
 
 ## Present
 
@@ -25,7 +25,7 @@
 
 *Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
-* Security release coming out tomorrow. Links with all details: https://nodejs.org/en/blog/vulnerability/aug-2019-security-releases/
+* Security release coming out tomorrow. Links with all details: <https://nodejs.org/en/blog/vulnerability/aug-2019-security-releases/>
 
 ### nodejs/node
 
@@ -61,7 +61,7 @@
     * Finished backport of 7.6 for Node 12. Should land in next minor
   * Build Resources - windows temp directory thing mentioned last week was landed. Focus
     is on fixing widows test strategy.
-  * Python 3 strategic initiative: https://github.com/nodejs/node/issues/25789
+  * Python 3 strategic initiative: <https://github.com/nodejs/node/issues/25789>
     * Only used in the build phases, due to gyp and python code in node repo for tests etc.
       * Longer term we may get rid of this dependency.
     * Goal is to be able to support both Python 2 and Python 3 by end of year
@@ -84,7 +84,7 @@
     * existing issue on GYP3 in board, believe we have answer from Foundation and Matteo
       has communicated back.
   * Discussion on moving the travel fund up to the OpenJS/CPC level, approvals done by
-    CPC members: https://github.com/nodejs/admin/issues/398.
+    CPC members: <https://github.com/nodejs/admin/issues/398>.
     * No concerns/issues raised in the meeting.
     * Raised awareness that if anybody does have concerns/issues please post in issue or
       reach out to Matteo or Michael.
@@ -93,6 +93,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-08-21.md
+++ b/meetings/2019-08-21.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: http://www.youtube.com/watch?v=3ptcfxss1qU
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/747
+* **Recording**: <http://www.youtube.com/watch?v=3ptcfxss1qU>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/747>
 
 ## Present
 
@@ -80,7 +80,7 @@
 
 * stream: don't emit error after destroy() [#29197](https://github.com/nodejs/node/pull/29197)
   * Related conversation/issue:
-    * https://github.com/nodejs/node/pull/29205#issuecomment-523237246
+    * <https://github.com/nodejs/node/pull/29205#issuecomment-523237246>
   * Were added recently, lots of context.  Lets ask TSC to review and discuss next week.
 
 ### nodejs/TSC
@@ -94,11 +94,11 @@
 
 ## Strategic Initiatives
 
-https://github.com/nodejs/TSC/blob/master/Strategic-Initiatives.md
+<https://github.com/nodejs/TSC/blob/master/Strategic-Initiatives.md>
 
 * Modules
   * Making good progress
-  * proposal to require ESM, not convinced this can be done in non-breaking way: https://github.com/nodejs/modules/issues/371
+  * proposal to require ESM, not convinced this can be done in non-breaking way: <https://github.com/nodejs/modules/issues/371>
 
 * N-API
   * Working on workshop for Node+JS interactive

--- a/meetings/2019-08-28.md
+++ b/meetings/2019-08-28.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=p1YKTVXn8Sg
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/750
+* **Recording**:  <https://www.youtube.com/watch?v=p1YKTVXn8Sg>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/750>
 
 ## Present
 
@@ -32,7 +32,7 @@
         opened up to other projects.
     * Org of summit and repo will move CPC org
 * Board
-  * Link to the public board meeting: https://www.youtube.com/watch?v=krND7nWRUqE
+  * Link to the public board meeting: <https://www.youtube.com/watch?v=krND7nWRUqE>
   * Of note, date for next years Node+JS Interactive (2020) may shift. Possibly late spring/early
       summer, October also might be considered. Event space availability is one constraint.
 
@@ -83,19 +83,19 @@
 * Core promise APIs
   * Have been slowly progressing to add to Event Emitter, getting back to have more time on this
   * Also working on proposal for Emitter, ask if people can look at PR
-    https://github.com/nodejs/node/pull/27867
+    <https://github.com/nodejs/node/pull/27867>
 
 * New Stream APIs
   * Nothing new to mention this time
 
 * Python3
-  * Claus has flagged that  https://github.com/nodejs/node/issues/29246 needs help
+  * Claus has flagged that  <https://github.com/nodejs/node/issues/29246> needs help
 
 * Build Resources
   * OpenJS infra meeting
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-09-11.md
+++ b/meetings/2019-09-11.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=lxcc9StuoPQ
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/753
+* **Recording**:  <https://www.youtube.com/watch?v=lxcc9StuoPQ>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/753>
 
 ## Present
 
@@ -38,7 +38,7 @@
   * Michael: added
     * heads up that summit repo moved over, proposal to have support for surveys move over
       to OpenJS org as well.
-    * work on CoC handling. Check it out here if you are interested: https://github.com/openjs-foundation/cross-project-council/pull/271
+    * work on CoC handling. Check it out here if you are interested: <https://github.com/openjs-foundation/cross-project-council/pull/271>
 
 * Board
   * nothing new to report this week.  Nothing in admin project board trackikng project requests to
@@ -89,7 +89,7 @@
     likely that will move for a vote next week.
 
 * build: ongoing list of actions for Python 3 compatibility [#25789](https://github.com/nodejs/node/issues/25789)
-  * Today is a red letter day because our Travis CI tests all passed on Python 3. nodejs/node#29451 -> https://travis-ci.com/nodejs/node/builds/126947698 Thanks to all who have been involved!
+  * Today is a red letter day because our Travis CI tests all passed on Python 3. nodejs/node#29451 -> <https://travis-ci.com/nodejs/node/builds/126947698> Thanks to all who have been involved!
   * We are far from done with our port to Python 3 but passing these tests is an important milestone.
   * The WIP PR nodejs/node#29451 is an amalgam of several different PRs that need to be upstreamed/downstreamed/sidestreamed/pairstreamed so all help is greatly appreciated.
   * nodejs/node#25789 is our ongoing list of todos. My sense is that nodejs/node#2587 should be reviewed and landed. nodejs/node-gyp#1844 should be fixed to pass the tests and then reviewed and landed.
@@ -144,6 +144,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-09-18.md
+++ b/meetings/2019-09-18.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=c1f-T4GvFqU
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/755
+* **Recording**:  <https://www.youtube.com/watch?v=c1f-T4GvFqU>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/755>
 
 ## Present
 
@@ -104,7 +104,7 @@ Michael to post that in the recert issue and to ask rest of TSC members to vote.
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
 ~

--- a/meetings/2019-09-25.md
+++ b/meetings/2019-09-25.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=YarfwDtaANw
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/758
+* **Recording**:  <https://www.youtube.com/watch?v=YarfwDtaANw>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/758>
 
 ## Present
 
@@ -52,14 +52,14 @@
   * [ ] tap2junit: v0.1.5 release (nodejs/tap2junit#12) to the Python Packaging Index    [PyPI](https://pypi.org/project/tap2junit)
     * repo moved to nodejs org, was blocking being able to run jenkins testing. PR
       to make python 3 compatible.
-  * [ ] node-gyp: release so that npm can pick it up https://github.com/nodejs/node-gyp/issues/1791#issuecomment-533715634
+  * [ ] node-gyp: release so that npm can pick it up <https://github.com/nodejs/node-gyp/issues/1791#issuecomment-533715634>
     * working on doing round trip. Blocked by OSX bug. Christian is working on that.
   * [ ] re-vendor npm's gyp back into nodejs/node **/deps/npm/node_modules/node-gyp**
   * [ ] Travis CI does not test ./configure --ninja test #29415   ***help needed***
     * Sam, some discussion about testing configure options, not all are tested.  Some tested
       in docker. Question is why this one?  Less vital if the tap2junit lands.
   * [ ] node-gyp: Accept Python 3 by default (_semver-major_) nodejs/node-gyp#1844 (macOS fails)
-  * Sam: call-for-volunteers  -- the nodejs/node-gyp team could use more people involved, and that the  https://github.com/refack/GYP3 project does as well. https://github.com/nodejs/node-gyp/issues/1791 has more information. Without more engagement, this situation will slowly get worse.
+  * Sam: call-for-volunteers  -- the nodejs/node-gyp team could use more people involved, and that the  <https://github.com/refack/GYP3> project does as well. <https://github.com/nodejs/node-gyp/issues/1791> has more information. Without more engagement, this situation will slowly get worse.
 ### nodejs/TSC
 
 * TSC representation on Moderation Team [#757](https://github.com/nodejs/TSC/issues/757)
@@ -99,6 +99,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-10-16.md
+++ b/meetings/2019-10-16.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=ZDNU8_FEEvQ
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/766
+* **Recording**:  <https://www.youtube.com/watch?v=ZDNU8_FEEvQ>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/766>
 
 ## Present
 
@@ -129,9 +129,9 @@
       * Should node protect against that hazzard.
   * Chalker can you provide links to some of the issues:
   * Myles:
-    * https://github.com/graphql/graphql-js/issues/1479
-    * https://github.com/webpack/webpack/issues/7973
-    * https://github.com/facebook/create-react-app/issues/5234
+    * <https://github.com/graphql/graphql-js/issues/1479>
+    * <https://github.com/webpack/webpack/issues/7973>
+    * <https://github.com/facebook/create-react-app/issues/5234>
   * Rich
     * Urgency?
   * Myles
@@ -145,6 +145,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-10-23.md
+++ b/meetings/2019-10-23.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=LnzUQGF8FCo
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/768
+* **Recording**: <https://www.youtube.com/watch?v=LnzUQGF8FCo>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/768>
 
 ## Present
 * Anatoli Papirovski @apapirovski (TSC)
@@ -42,7 +42,7 @@ CPC: focus is on onboarding new projects, but also new projects as well. This in
 * Modules WG put together explainer doc
 * Modules WG have joined to be available to answer any questions.
 * Michael: how many people have had time to read the explainer doc.
-  * This is the doc: https://docs.google.com/document/d/1rgXyCQP6S694MzkXla8rbRwqCSY9Eb2lFIOgLZoEw5k/edit#
+  * This is the doc: <https://docs.google.com/document/d/1rgXyCQP6S694MzkXla8rbRwqCSY9Eb2lFIOgLZoEw5k/edit>#
 * Geoffrey: Modules meeting is later today so if you have time to read and
   want to ask questions you can possibly attend.
 * Jeremiah: This issue is very complicated so hard for someone outside of the
@@ -115,6 +115,6 @@ CPC: focus is on onboarding new projects, but also new projects as well. This in
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-11-06.md
+++ b/meetings/2019-11-06.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=XCX5qfuT8tw
-* **Minutes Google Doc**: https://github.com/nodejs/TSC/issues/773
+* **Recording**: <https://www.youtube.com/watch?v=XCX5qfuT8tw>
+* **Minutes Google Doc**: <https://github.com/nodejs/TSC/issues/773>
 
 ## Present
 
@@ -30,12 +30,12 @@
 *Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * Board Update - nothing on the project board for items to bring to the board
-  * https://github.com/nodejs/admin/projects/1
+  * <https://github.com/nodejs/admin/projects/1>
   * A number of policies (IP, trademark etc.) agreed/will be published soon.
 
 * CPC Update
   * CoC PR to move to Stage 3 (adoption) some discussion/input from new projects
-    * https://github.com/openjs-foundation/cross-project-council/pull/379
+    * <https://github.com/openjs-foundation/cross-project-council/pull/379>
   * Existing project onboarding (Joe/Matteo leading for Node.js)
 
 ### nodejs/node
@@ -75,6 +75,6 @@ No leads present from any of the other strategic initiatives
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-11-20.md
+++ b/meetings/2019-11-20.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://youtu.be/yTIZKW2wFnI
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/777
+* **Recording**: <https://youtu.be/yTIZKW2wFnI>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/777>
 
 ## Present
 
@@ -28,7 +28,7 @@
 
 * CPC
   * Focus is on onboarding
-    * https://github.com/openjs-foundation/project-onboarding/issues/1
+    * <https://github.com/openjs-foundation/project-onboarding/issues/1>
 
 * Board
   * meeting this week
@@ -50,16 +50,16 @@
 * N-API - preparing for workshop and 2.0 version of node-addon-api
 * Core promise APIs - massive PR that has been open for 6 months, is close to being ready to
   land. Will add experimental promise support for event handlers.  PR helps address common
-  problem that developers run into.  Please review/comment: https://github.com/nodejs/node/pull/27867
+  problem that developers run into.  Please review/comment: <https://github.com/nodejs/node/pull/27867>
 * V8 Currency - nothing of note
 * Python 3 & Gyp - still some dusty corners, not all google tooling supports python 3
 * cmake - Michael mentioned this. Ben has been looking at it any may start working to push it
   forward.  Want to make sure there is agreement that it is a reasonable way to move forward
   and we had some discussion in the meeting around that. Please comment in the issue
-  If you have any concerns. https://github.com/nodejs/TSC/issues/648
+  If you have any concerns. <https://github.com/nodejs/TSC/issues/648>
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-11-27.md
+++ b/meetings/2019-11-27.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=Pj2WOID9vNI
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/780
+* **Recording**:  <https://www.youtube.com/watch?v=Pj2WOID9vNI>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/780>
 
 ## Present
 
@@ -79,10 +79,10 @@
     a report instead of pinging the champion.
   * Rich: +1
   * Michael Dawson: would be great if this is PR’ed into the meeting template:
-    https://github.com/nodejs/create-node-meeting-artifacts/tree/master/templates
+    <https://github.com/nodejs/create-node-meeting-artifacts/tree/master/templates>
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2019-12-04.md
+++ b/meetings/2019-12-04.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://youtu.be/WZ4QQGKQUnI
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/785
+* **Recording**:  <https://youtu.be/WZ4QQGKQUnI>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/785>
 
 ## Present
 * Beth Griggs @BethGriggs (TSC)
@@ -57,9 +57,9 @@
 * Michael - N-API: working on workshop  NJSI next week.  node-addon-api 2.0 released
 
 * Core Promise APIs
-  * Landed event emitter, promise rejections https://github.com/nodejs/node/pull/27867
+  * Landed event emitter, promise rejections <https://github.com/nodejs/node/pull/27867>
 
-* V8: 9 issues to fix for update to 8.0. Help needed. https://github.com/nodejs/node-v8/issues/127
+* V8: 9 issues to fix for update to 8.0. Help needed. <https://github.com/nodejs/node-v8/issues/127>
   * compilation failures
   * freeBSD, smartos, windows and IBM
 
@@ -74,6 +74,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-01-08.md
+++ b/meetings/2020-01-08.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://youtu.be/owCRMkiAWWY
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/796
+* **Recording**:  <https://youtu.be/owCRMkiAWWY>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/796>
 * **Minutes Google Doc**: $MINUTES_DOC$
 
 ## Present
@@ -25,7 +25,7 @@
 ### Announcements
 
 * Matteo.  Work for next collaborator summit is starting (Austin in July). If you want to get
-  involved this is the issue to look at: https://github.com/openjs-foundation/summit/issues/236
+  involved this is the issue to look at: <https://github.com/openjs-foundation/summit/issues/236>
 
 ### CPC and Board Meeting Updates
 
@@ -45,7 +45,7 @@
   * PR to add runkit embed to our documentation
   * Matteo, added to agenda as we should discuss a new dependency for our repo
   * If outage, then just looks the same as it would today.
-  * Background: https://github.com/nodejs/website-redesign/issues/12
+  * Background: <https://github.com/nodejs/website-redesign/issues/12>
   * There are some concerns from the TSC.
     * Its the first external dependency and there was some discussion about the risk of code/JavaScript
       that comes from outside the repo
@@ -101,6 +101,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-01-15.md
+++ b/meetings/2020-01-15.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://youtu.be/OUWOgaQEebY
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/801
+* **Recording**: <https://youtu.be/OUWOgaQEebY>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/801>
 
 ## Present
 
@@ -31,10 +31,10 @@
 * Michael: vote underway at board level for one-off approval to cover travel request (see admin repo) is
   underway to cover as we don't have the 2020 allocation finaliazed yet
 * Some discussion of travel fund at OpenJS level, if you have thoughts/concerns chime in on
-  https://github.com/openjs-foundation/cross-project-council/pull/441
+  <https://github.com/openjs-foundation/cross-project-council/pull/441>
 * Cross project Code of conduct team is going to be formed to discuss current proposal as MVP and then
   what cross project extensions might make sense in terms of moderation. If you are interested, please
-  join in: https://github.com/openjs-foundation/cross-project-council/issues/432
+  join in: <https://github.com/openjs-foundation/cross-project-council/issues/432>
 
 ### nodejs/node
 
@@ -80,6 +80,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-01-22.md
+++ b/meetings/2020-01-22.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://youtu.be/n3bS_3tcffU
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/804
+* **Recording**:  <https://youtu.be/n3bS_3tcffU>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/804>
 
 ## Present
 
@@ -46,7 +46,7 @@
   * Francisco, is our guest this week to give us an overview and answer questions.
     * Discussed within ComComm in the context of the website. Would be good to allow
       examples/code to be runnable in documentation
-    * The PR is a sample adding runkit to crypto doc: https://github.com/nodejs/node/pull/22831
+    * The PR is a sample adding runkit to crypto doc: <https://github.com/nodejs/node/pull/22831>
     * One of key impetus is to get people involved earlier.  This would allow things to be tried out
       immediately with the nightly docs allowing you to run/test out new code without having to
       download the docs.
@@ -71,10 +71,10 @@
   * Other users
     * npm already has this on their site (has button that says try on runkit)
     * ExpressJS and KoA already has fully integrated versions
-    * js: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match
-    * go: https://golang.org/pkg/net/http/?m=all#example_FileServer
-    * lodash: https://lodash.com/docs/4.17.15#drop
-    * rust: https://doc.rust-lang.org/std/char/fn.from_u32.html
+    * js: <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match>
+    * go: <https://golang.org/pkg/net/http/?m=all#example_FileServer>
+    * lodash: <https://lodash.com/docs/4.17.15#drop>
+    * rust: <https://doc.rust-lang.org/std/char/fn.from_u32.html>
 
 * doc: add example for cipher.update() [#28373](https://github.com/nodejs/node/pull/28373)
   * Defer to next time
@@ -100,6 +100,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-02-05.md
+++ b/meetings/2020-02-05.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=p5fIPf94GuY
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/810
-* **Minutes Google Doc**: https://docs.google.com/document/d/1OmKotKXE12zGi3sTa8EkGdM4Ocpkrgy2M8BuFhTIK_0
+* **Recording**: <https://www.youtube.com/watch?v=p5fIPf94GuY>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/810>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1OmKotKXE12zGi3sTa8EkGdM4Ocpkrgy2M8BuFhTIK_0>
 
 ## Present
 
@@ -76,6 +76,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-02-19.md
+++ b/meetings/2020-02-19.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://youtu.be/4tz8KsW_l9s
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/820
+* **Recording**: <https://youtu.be/4tz8KsW_l9s>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/820>
 
 ## Present
 
@@ -96,6 +96,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-02-26.md
+++ b/meetings/2020-02-26.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://youtu.be/43IjoATGL0U
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/827
+* **Recording**:  <https://youtu.be/43IjoATGL0U>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/827>
 
 ## Present
 
@@ -89,6 +89,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-03-11.md
+++ b/meetings/2020-03-11.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://youtu.be/bS_HHW8wsSM
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/834
+* **Recording**: <https://youtu.be/bS_HHW8wsSM>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/834>
 
 ## Present
 
@@ -36,7 +36,7 @@
   SemVer major cutoff. After that point majors require no objections from the TSC to land in v14.x.
 
 * Matteo: Progressing with collaborator summit, proposals are open at
-  https://github.com/openjs-foundation/summit. Depending on situation
+  <https://github.com/openjs-foundation/summit>. Depending on situation
   may be virtual an option depending on what happens with Covid-19.
 
 ### nodejs/node
@@ -71,7 +71,7 @@
     way to support versioning for different streams (have not looked at it lately)
   * Tobias, right not believe all on one branch.
   * Anatoli, would possibly be motivation for having our own repo
-    * From Matteo, some versioning in different versions: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node
+    * From Matteo, some versioning in different versions: <https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node>
   * Tobias, what is the biggest concern. Using too new types or too old ?
   * Matteo, as TS user have no way to know if my module will compile on different versions
     of Node.js
@@ -113,6 +113,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-03-18.md
+++ b/meetings/2020-03-18.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://youtu.be/krd8TtkSfWI
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/838
+* **Recording**:  <https://youtu.be/krd8TtkSfWI>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/838>
 
 ## Present
 
@@ -27,7 +27,7 @@
 ### Announcements
 
 * Michael: Foundation info on OpenJS World status in context of COVID-19,
-  https://openjsf.org/blog/2020/03/17/openjs-world-and-the-covid-19-novel-coronavirus-situation/
+  <https://openjsf.org/blog/2020/03/17/openjs-world-and-the-covid-19-novel-coronavirus-situation/>
 
 ### CPC and Board Meeting Updates
 
@@ -35,7 +35,7 @@
 
 * Board
   * Guidance on member companies provided additional directed funding documented here:
-    https://openjsf.org/about/project-funding-opportunities/
+    <https://openjsf.org/about/project-funding-opportunities/>
 
 * CPC
   * OpenJS foundation is looking for new content for blog (deep technical content)
@@ -46,7 +46,7 @@
   * Continuing activity on projects joining
   * Chartering of the standards team in progress, will be “supporting” role as opposed where the
     standards work takes place.
-  * Collaboration Network - https://github.com/openjs-foundation/cross-project-council/pull/497
+  * Collaboration Network - <https://github.com/openjs-foundation/cross-project-council/pull/497>
 
 ### nodejs/node
 
@@ -108,6 +108,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-04-01.md
+++ b/meetings/2020-04-01.md
@@ -3,7 +3,7 @@
 ## Links
 
 * **Recording**:
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/842
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/842>
 
 ## Present
 
@@ -86,6 +86,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-04-08.md
+++ b/meetings/2020-04-08.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://youtu.be/2om4bZws47A
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/846
+* **Recording**: <https://youtu.be/2om4bZws47A>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/846>
 
 ## Present
 
@@ -84,6 +84,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-04-16.md
+++ b/meetings/2020-04-16.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://youtu.be/Q4fwAlOOa4g
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/848
+* **Recording**:  <https://youtu.be/Q4fwAlOOa4g>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/848>
 
 ## Present
 
@@ -69,7 +69,7 @@
 - V8 8.1 is now stable. v14.0.0 will go out with it as planned.
 - V8 8.3 will enter beta tomorrow. @mmarchini is working on the update for master [here](https://github.com/nodejs/node/pull/32831).
   - There's an open question about ABI-breaking changes in it: do we want to include some of them in v14.0.0 to make it easier to upgrade V8 in a future minor release of v14.x? We only have a few days left to do that.
-- Canary is in a relatively good shape. We've got one test failure to investigate (related to WeakRefs, an experimental JS feature): https://github.com/nodejs/node-v8/issues/156
+- Canary is in a relatively good shape. We've got one test failure to investigate (related to WeakRefs, an experimental JS feature): <https://github.com/nodejs/node-v8/issues/156>
 
 ### QUIC
 
@@ -107,11 +107,11 @@
 
 ### Startup Performance
 * PR open to add more data in the startup snapshot by
-  default.https://github.com/nodejs/node/pull/32761. Some discussion would be good if those
+  default.<https://github.com/nodejs/node/pull/32761>. Some discussion would be good if those
   familiar with C++ could jump into the discussion.
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-04-23.md
+++ b/meetings/2020-04-23.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://youtu.be/Da79AzGNiDE
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/852
+* **Recording**:  <https://youtu.be/Da79AzGNiDE>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/852>
 
 ## Present
 
@@ -63,7 +63,7 @@
 
 * http: align with stream.Writable [31818](https://github.com/nodejs/node/pull/31818)
   * Rich has asked for TSC consensus or not on overriding the objection. See
-    https://github.com/nodejs/node/pull/31818#issuecomment-618180372
+    <https://github.com/nodejs/node/pull/31818#issuecomment-618180372>
 
 ### nodejs/docker-node
 
@@ -104,6 +104,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-04-29.md
+++ b/meetings/2020-04-29.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://youtu.be/ZZz8wG05GJg
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/856
+* **Recording**:  <https://youtu.be/ZZz8wG05GJg>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/856>
 
 ## Present
 
@@ -104,6 +104,6 @@
   * Myles, we have loaders, but they can change.  Ask is for people to join in the discussion
     on the loaders side, need more support there.
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-05-07.md
+++ b/meetings/2020-05-07.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Recording**: https://youtu.be/dMHjPXMdSQM (wrong account but better
+* **Recording**: <https://youtu.be/dMHjPXMdSQM> (wrong account but better
   than  nothing)
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/860
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/860>
 
 ## Present
 
@@ -40,7 +40,7 @@
   * active discussion in issue, lets let it go for another week.
 
 * process: Throw exception on --unhandled-rejections=default [#33021](https://github.com/nodejs/node/pull/33021)
-  * Matheus is working on survey, please comment, https://github.com/nodejs/TSC/pull/857
+  * Matheus is working on survey, please comment, <https://github.com/nodejs/TSC/pull/857>
   * Question, hopefully ready for leave for next week
   * Leave on agenda while we work on it.
 
@@ -70,7 +70,7 @@
 ## Strategic Initiatives
 
 * V8 Currency:
-  * V8 8.3 PR is ready to land on master. Waiting for stable upstream release. https://github.com/nodejs/node/pull/32831
+  * V8 8.3 PR is ready to land on master. Waiting for stable upstream release. <https://github.com/nodejs/node/pull/32831>
 
 * Promises:
   * There are some discussion around Thenable and AsyncLocalStorage in nodejs/node#33189.
@@ -92,6 +92,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-05-14.md
+++ b/meetings/2020-05-14.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://youtu.be/1GatHafSXBg
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/863
+* **Recording**:  <https://youtu.be/1GatHafSXBg>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/863>
 
 ## Present
 
@@ -33,7 +33,7 @@
 
 * src,win: Replacement of unsupported versions of Windows runtime exit. [#33108](https://github.com/nodejs/node/pull/33108)
 * Dispute of "block running on EOL Windows versions #31954" - Alternative Suggestion [#33034](https://github.com/nodejs/node/issues/33034)
-  * https://github.com/nodejs/node/pull/33176
+  * <https://github.com/nodejs/node/pull/33176>
   * James, raised concern about env variable, but happy given explanations.
   * In general TSC would be happy with 33176
 
@@ -67,7 +67,7 @@
 * Node.js future directions - any interest in online or in person summit? [#797](https://github.com/nodejs/TSC/issues/797)
   * Summit session proposed, taking of agenda.
   * James: possibly related, Tierney opened issue about review contribution process and
-    policies. https://github.com/nodejs/TSC/issues/864.  Might be worth time doing a
+    policies. <https://github.com/nodejs/TSC/issues/864>.  Might be worth time doing a
     collaborator survey based on kubernetes survey.
 
 ### nodejs/admin
@@ -92,8 +92,8 @@
   * No update since last week.
 
 * V8 Currency (@targos)
-  * V8 8.3 landed on master. Backport open for v14.x: https://github.com/nodejs/node/pull/33376
-  * Canary (V8 8.4) compiler error on Visual Studio 2017: https://github.com/nodejs/node-v8/issues/157
+  * V8 8.3 landed on master. Backport open for v14.x: <https://github.com/nodejs/node/pull/33376>
+  * Canary (V8 8.4) compiler error on Visual Studio 2017: <https://github.com/nodejs/node-v8/issues/157>
   * Discussion around whether we should drop Visual Studio, Matteo should we just build with
     clang ?
   * Michael Z will ping windows team as we still need it for 14.x that does support VS 2017
@@ -119,6 +119,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-05-21.md
+++ b/meetings/2020-05-21.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://youtu.be/TtB4UOLORWk
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/868
+* **Recording**: <https://youtu.be/TtB4UOLORWk>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/868>
 
 ## Present
 
@@ -32,7 +32,7 @@
 
 * src,win: Replacement of unsupported versions of Windows runtime exit. [#33108](https://github.com/nodejs/node/pull/33108)
 * Dispute of "block running on EOL Windows versions #31954" - Alternative Suggestion [#33034](https://github.com/nodejs/node/issues/33034)
-  * Looks like it’s progressing in https://github.com/nodejs/node/pull/33176, nothing
+  * Looks like it’s progressing in <https://github.com/nodejs/node/pull/33176>, nothing
     to discuss in the meeting.
 
 * process: Throw exception on --unhandled-rejections=default [#33021](https://github.com/nodejs/node/pull/33021)
@@ -57,9 +57,9 @@
 ## Strategic Initiatives
 
 * Startup time
-- Relanding the blocking v8 patch https://chromium-review.googlesource.com/c/v8/v8/+/2212085
-- https://github.com/nodejs/node/pull/32761 was closed though the technical disagreement is still not settled (for differences between https://github.com/nodejs/node/pull/32761 and https://github.com/nodejs/node/pull/32984, see the discussions in https://docs.google.com/document/d/15bu038I36oILq5t4Qju1sS2nKudVB6NSGWz00oD48Q8/edit?usp=sharing, would love more input there to break the tie). As @jasnell mentioned in https://github.com/nodejs/node/pull/32761#issuecomment-628972927 I think this reveals that we have some issues with the current process. Some points that I can think of
-  - There should've been a better way to communicate about active efforts to avoid duplication of work and competition. In this case there were occasional updates in the tracking issue https://github.com/nodejs/node/issues/17058, related PRs and meetings, but those were not visible enough and still lead to conflicts
+- Relanding the blocking v8 patch <https://chromium-review.googlesource.com/c/v8/v8/+/2212085>
+- <https://github.com/nodejs/node/pull/32761> was closed though the technical disagreement is still not settled (for differences between <https://github.com/nodejs/node/pull/32761> and <https://github.com/nodejs/node/pull/32984>, see the discussions in <https://docs.google.com/document/d/15bu038I36oILq5t4Qju1sS2nKudVB6NSGWz00oD48Q8/edit?usp=sharing>, would love more input there to break the tie). As @jasnell mentioned in <https://github.com/nodejs/node/pull/32761#issuecomment-628972927> I think this reveals that we have some issues with the current process. Some points that I can think of
+  - There should've been a better way to communicate about active efforts to avoid duplication of work and competition. In this case there were occasional updates in the tracking issue <https://github.com/nodejs/node/issues/17058>, related PRs and meetings, but those were not visible enough and still lead to conflicts
   - We need more reviewers for certain tasks or certain subsystems, ideally more than two people (to break the tie when there are technical disagreements) and from more than one party (to avoid bias). I don't think it's a good idea to always escalate these to TSC, because not all of us are interested in or familiar with the same part of the code base, and so we don't always get the attention we ask for if the disagreement involves substantial amount of reading or context. Maybe a team + CODEOWNERS structure can help
   - When the change involves substantial amount of work, maybe starting a design doc first to seek high-level and more abstract inputs before jumping in to do the actual implementation would be a good idea. I can see this may be a double edged sword but this works relatively well in V8 (though sometimes prototyping is still necessary to keep the technical discussion realistic)
 
@@ -72,6 +72,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-06-04.md
+++ b/meetings/2020-06-04.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://youtu.be/Jj8_dqQOC00
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/873
+* **Recording**: <https://youtu.be/Jj8_dqQOC00>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/873>
 
 ## Present
 
@@ -59,11 +59,11 @@
   * No update this week.
 
 * Startup performance
-  * re-landed V8 patch https://chromium-review.googlesource.com/c/v8/v8/+/2212085
+  * re-landed V8 patch <https://chromium-review.googlesource.com/c/v8/v8/+/2212085>
   * rebased snapshot PR, just waiting on process discussion.
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-07-02.md
+++ b/meetings/2020-07-02.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://youtu.be/PMIvxAnYE34
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/888
+* **Recording**: <https://youtu.be/PMIvxAnYE34>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/888>
 
 ## Present
 
@@ -62,12 +62,12 @@
 
 ## Strategic Initiatives
 
-* build resources - meeting to be scheduled in next week or so with build team/Linux Foundation IT team for further exploration/discussion - https://github.com/nodejs/build/issues/2354
+* build resources - meeting to be scheduled in next week or so with build team/Linux Foundation IT team for further exploration/discussion - <https://github.com/nodejs/build/issues/2354>
 * No major update on modules
 * QUIC/HTTP3 - experimental, landed in core, going through a lot of changes
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-07-09.md
+++ b/meetings/2020-07-09.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://youtu.be/QSJHvgI0oAI
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/890
+* **Recording**:  <https://youtu.be/QSJHvgI0oAI>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/890>
 
 ## Present
 
@@ -26,7 +26,7 @@
 * Kickoff of “Next 10 years of Node.js” at collab summit, follow on: [#34260](https://github.com/nodejs/node/issues/34260)
 
 * A number of collaborator nominations that have been approved and 3 in flight. For details
-  check out: https://github.com/nodejs/TSC/issues/890#issuecomment-654929527
+  check out: <https://github.com/nodejs/TSC/issues/890#issuecomment-654929527>
 
 ### CPC and Board Meeting Updates
 
@@ -72,6 +72,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-07-16.md
+++ b/meetings/2020-07-16.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://youtu.be/yVMhtWJDl-Q
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/893
+* **Recording**:  <https://youtu.be/yVMhtWJDl-Q>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/893>
 
 ## Present
 
@@ -17,22 +17,22 @@
 ### Announcements
 
 * We have three new collaborators:
-  - https://github.com/nodejs/node/issues/34100
-  - https://github.com/nodejs/node/issues/34099
-  - https://github.com/nodejs/node/issues/34098
+  - <https://github.com/nodejs/node/issues/34100>
+  - <https://github.com/nodejs/node/issues/34099>
+  - <https://github.com/nodejs/node/issues/34098>
 * and ~~four~~ three further nominations that have been accepted:
-  - https://github.com/nodejs/node/issues/34121
-  - https://github.com/nodejs/node/issues/34168
-  - https://github.com/nodejs/node/issues/34242
-  - ~~https://github.com/nodejs/node/issues/34241~~
+  - <https://github.com/nodejs/node/issues/34121>
+  - <https://github.com/nodejs/node/issues/34168>
+  - <https://github.com/nodejs/node/issues/34242>
+  - ~~<https://github.com/nodejs/node/issues/34241>~~
 * plus one pending:
-  - https://github.com/nodejs/node/issues/34369
+  - <https://github.com/nodejs/node/issues/34369>
 
 ### CPC and Board Meeting Updates
 
 *Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
-* FYI - changes to Foundation bylaws approved recently and published. See https://github.com/openjs-foundation/cross-project-council/issues/590 for some info about changes.
+* FYI - changes to Foundation bylaws approved recently and published. See <https://github.com/openjs-foundation/cross-project-council/issues/590> for some info about changes.
 
 ### nodejs/node
 
@@ -69,7 +69,7 @@
 ## Strategic Initiatives
 
 * Startup performance
-  * Joyee: opened https://bugs.chromium.org/p/v8/issues/detail?id=10704, rebased nodejs/node#32984 and made it work around that v8 issue while trying to fix it in the upstream. Would appreciate more reviews for that PR to land..
+  * Joyee: opened <https://bugs.chromium.org/p/v8/issues/detail?id=10704>, rebased nodejs/node#32984 and made it work around that v8 issue while trying to fix it in the upstream. Would appreciate more reviews for that PR to land..
   * Danbev: I've started to review nodejs/node#32984 and will continue tomorrow. I also hope to have time to take a closer look at @addaleax suggestion but I only have tomorrow before a month of PTO.
 
 * No update on build resources since last week.
@@ -77,14 +77,14 @@
 * No major updates from modules
 
 * Updates on V8 currency:
-  - V8 8.4 landed on master. Release notes: https://v8.dev/blog/v8-release-84
-  - Backport PR to v14.x is open: https://github.com/nodejs/node/pull/34356
-  - WIP update to V8 8.5: https://github.com/nodejs/node/pull/34337. The new cppgc is causing some issues with cross-compilation and Windows.
+  - V8 8.4 landed on master. Release notes: <https://v8.dev/blog/v8-release-84>
+  - Backport PR to v14.x is open: <https://github.com/nodejs/node/pull/34356>
+  - WIP update to V8 8.5: <https://github.com/nodejs/node/pull/34337>. The new cppgc is causing some issues with cross-compilation and Windows.
 
 * QUIC initiative update: work is ongoing.
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-08-06.md
+++ b/meetings/2020-08-06.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://www.youtube.com/watch?v=dSUmfk4mlRE
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/900
+* **Recording**: <https://www.youtube.com/watch?v=dSUmfk4mlRE>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/900>
 
 ## Present
 
@@ -23,7 +23,7 @@
 
 ### Announcements
 
-* Unhandled Rejection Survey draft (https://github.com/nodejs/TSC/issues/902): Comments/feedback welcome. Proposal to prepare a blog post to share with the survey and increase visibility. But we also don’t want to delay the survey. Will have to shorten or remove summary because SurveyMonkey only allows 4000 characters. So maybe the summary can be a blog post? Either way, the survey is almost ready. Please review.
+* Unhandled Rejection Survey draft (<https://github.com/nodejs/TSC/issues/902>): Comments/feedback welcome. Proposal to prepare a blog post to share with the survey and increase visibility. But we also don’t want to delay the survey. Will have to shorten or remove summary because SurveyMonkey only allows 4000 characters. So maybe the summary can be a blog post? Either way, the survey is almost ready. Please review.
 
 ### CPC and Board Meeting Updates
 
@@ -55,10 +55,10 @@
   * Conversations around design decisions related to file extension resolution have picked up again. At the moment there is nothing actionable
   * Discussions regarding package.exports has resulted in feedback that some developers were surprisingly broken on 12.x when they were unflagged. A discussion is being brought to the Release WG
   * Top-Level Await was unflagged on master. It is currently blocked from landing on 14.x until specific behavior around rejections is agreed upon
-* V8 Currency: Update to V8 8.5 (and beyond) is still blocked on https://github.com/nodejs/node-v8/issues/161 because of a build issue on Windows. It is not clear what we can do to fix it.
+* V8 Currency: Update to V8 8.5 (and beyond) is still blocked on <https://github.com/nodejs/node-v8/issues/161> because of a build issue on Windows. It is not clear what we can do to fix it.
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-08-13.md
+++ b/meetings/2020-08-13.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://youtu.be/XV6AI4AdnM0
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/907
+* **Recording**:  <https://youtu.be/XV6AI4AdnM0>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/907>
 
 ## Present
 
@@ -60,10 +60,10 @@
 
 ## Strategic Initiatives
 
-Mary, new strategic initiative around our build toolchain, see - https://github.com/nodejs/TSC/issues/901
+Mary, new strategic initiative around our build toolchain, see - <https://github.com/nodejs/TSC/issues/901>
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-08-27.md
+++ b/meetings/2020-08-27.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://youtu.be/Cy_zrjLDvas
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/911
+* **Recording**: <https://youtu.be/Cy_zrjLDvas>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/911>
 
 ## Present
 
@@ -35,7 +35,7 @@
 
 * Rename default branch from "master" to "main" or something similar [#33864](https://github.com/nodejs/node/issues/33864)
   * Mary, github added feature to add new default for new repositories
-  * We should enable it. https://github.com/nodejs/admin/issues/543, no objections
+  * We should enable it. <https://github.com/nodejs/admin/issues/543>, no objections
     Ruben will do.
 
 * process: Change default --unhandled-rejections=throw [#33021](https://github.com/nodejs/node/pull/33021)
@@ -58,7 +58,7 @@
         that is used for the project.
     * The question is not which is best, but how to best let the co-exist.
     * He’s going to take us through the package-manager-manager flow, shared screen
-  * Chalker - https://github.com/tribou/words/blob/master/package.json#L7-L11 (random repo from gh search)
+  * Chalker - <https://github.com/tribou/words/blob/master/package.json#L7-L11> (random repo from gh search)
     * is why I think that this should be a separate field because versions can
       already be specified and are already specified and this change adds a pm
       restriction, while version range restriction is already there
@@ -73,6 +73,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-09-03.md
+++ b/meetings/2020-09-03.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://youtu.be/rvEC_hKqRdw
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/915
+* **Recording**: <https://youtu.be/rvEC_hKqRdw>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/915>
 
 ## Present
 
@@ -78,13 +78,13 @@
 
 * build - no update,
 * Modules - open discussion on Node.js/node on module export patterns, don’t have consensus
-  if it should land - https://github.com/nodejs/node/pull/34718, would like to get feedback from
+  if it should land - <https://github.com/nodejs/node/pull/34718>, would like to get feedback from
   TSC members.
 * Future of build chain, repository created, issues starting to be populated.
-* next ten years of Node.js - please take a look if you have a chance https://github.com/nodejs/next-10/pull/11/files
+* next ten years of Node.js - please take a look if you have a chance <https://github.com/nodejs/next-10/pull/11/files>
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-09-16.md
+++ b/meetings/2020-09-16.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://youtu.be/oh3fNmediRk
-* **GitHub Issue** :https://github.com/nodejs/TSC/issues/922
+* **Recording**:  <https://youtu.be/oh3fNmediRk>
+* **GitHub Issue** :<https://github.com/nodejs/TSC/issues/922>
 
 ## Present
 
@@ -84,6 +84,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-09-24.md
+++ b/meetings/2020-09-24.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://www.youtube.com/watch?v=HdSUED_vYpo
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/929
+* **Recording**:  <https://www.youtube.com/watch?v=HdSUED_vYpo>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/929>
 
 ## Present
 
@@ -108,6 +108,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-10-01.md
+++ b/meetings/2020-10-01.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://youtu.be/PWMMhJbMzc8
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/933
+* **Recording**: <https://youtu.be/PWMMhJbMzc8>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/933>
 
 ## Present
 
@@ -84,6 +84,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-10-08.md
+++ b/meetings/2020-10-08.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**:  https://youtu.be/Bv__hu8K7tw
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/935
+* **Recording**:  <https://youtu.be/Bv__hu8K7tw>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/935>
 
 ## Present
 
@@ -80,6 +80,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-10-29.md
+++ b/meetings/2020-10-29.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://youtu.be/tKQRw8fAClo
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/942
+* **Recording**: <https://youtu.be/tKQRw8fAClo>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/942>
 
 ## Present
 
@@ -81,6 +81,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-11-11.md
+++ b/meetings/2020-11-11.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://youtu.be/z4n-K0m_cro
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/949
+* **Recording**: <https://youtu.be/z4n-K0m_cro>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/949>
 
 ## Present
 
@@ -53,6 +53,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2020-12-09.md
+++ b/meetings/2020-12-09.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://youtu.be/lp414_XqY7E
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/957
+* **Recording**: <https://youtu.be/lp414_XqY7E>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/957>
 
 ## Present
 
@@ -44,12 +44,12 @@
 ## Strategic Initiatives
 
 * Startup
-  * Joyee, just figuring out integration of bindings (and BaseObjects) in the snapshot, see https://github.com/nodejs/node/issues/35930
+  * Joyee, just figuring out integration of bindings (and BaseObjects) in the snapshot, see <https://github.com/nodejs/node/issues/35930>
 * Build resources
   * No update
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2021-01-14.md
+++ b/meetings/2021-01-14.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://youtu.be/7lULAuw0GXM
-* **GitHub Issue**:https://github.com/nodejs/TSC/issues/963
+* **Recording**: <https://youtu.be/7lULAuw0GXM>
+* **GitHub Issue**:<https://github.com/nodejs/TSC/issues/963>
 
 ## Present
 
@@ -66,7 +66,7 @@
 
 * Publish packages to GitHub Registry [#1410](https://github.com/nodejs/docker-node/pull/1410)
   * No objections from TSC, Michael will add comment to issue
-  * TSC members should go approve token approval request: https://github.com/nodejs/admin/issues/581
+  * TSC members should go approve token approval request: <https://github.com/nodejs/admin/issues/581>
 
 ### nodejs/admin
 
@@ -88,6 +88,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2021-02-04.md
+++ b/meetings/2021-02-04.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://youtu.be/dwHau_D3AzY
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/967
+* **Recording**: <https://youtu.be/dwHau_D3AzY>
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/967>
 
 ## Present
 
@@ -21,7 +21,7 @@
 
 ### Announcements
 
-* Node.js user survey, https://www.surveymonkey.com/r/nodesurvey21
+* Node.js user survey, <https://www.surveymonkey.com/r/nodesurvey21>
 
 ### CPC and Board Meeting Updates
 
@@ -69,7 +69,7 @@
   * Should it be a strategic initiative, it is important to ship it.
     * Looking for volunteer to be Champion.
   * Michael Z, people already think we support it.
-    * Has M1, but there is v8 issue that needs to be fixed: https://github.com/nodejs/node/issues/37061
+    * Has M1, but there is v8 issue that needs to be fixed: <https://github.com/nodejs/node/issues/37061>
 
 ### nodejs/security-wg
 
@@ -79,11 +79,11 @@
 ## Strategic Initiatives
 
 * Core Promise APIS
-  * Michael Z - new PR to add promise API for crypto: https://github.com/nodejs/node/pull/37218
+  * Michael Z - new PR to add promise API for crypto: <https://github.com/nodejs/node/pull/37218>
 
 * V8 currency
   * Issue with latest V8.8, debug build flaky on linux.  Looking for help as not quite sure what to
-    do.  Otherwise should be ready to go. Issue is at the end of  https://github.com/nodejs/node/pull/36139
+    do.  Otherwise should be ready to go. Issue is at the end of  <https://github.com/nodejs/node/pull/36139>
 
 * QUIC
   * was removed from the codebase, will be some news soon
@@ -97,6 +97,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2021-02-25.md
+++ b/meetings/2021-02-25.md
@@ -2,8 +2,8 @@
 
 ## Links
 
-* **Recording**: https://youtu.be/7WJ1p-W56nY
-* **GitHub Issue**:https://github.com/nodejs/TSC/issues/972
+* **Recording**: <https://youtu.be/7WJ1p-W56nY>
+* **GitHub Issue**:<https://github.com/nodejs/TSC/issues/972>
 
 ## Present
 
@@ -95,9 +95,9 @@
   * All known issues on Apple M1 are fixed
   * We updated yesterday to V8 8.9 (will be promoted to stable next week)
 * Joyee - startup performance
-  * Landed PR to support for BindingData in the snapshot: https://github.com/nodejs/node/pull/36943
-  * Going through other embedder objects to support in  the snapshot: https://github.com/nodejs/node/issues/37476
-  * Working on class instance member initialization support in the snapshot in V8: https://bugs.chromium.org/p/v8/issues/detail?id=10704
+  * Landed PR to support for BindingData in the snapshot: <https://github.com/nodejs/node/pull/36943>
+  * Going through other embedder objects to support in  the snapshot: <https://github.com/nodejs/node/issues/37476>
+  * Working on class instance member initialization support in the snapshot in V8: <https://bugs.chromium.org/p/v8/issues/detail?id=10704>
 * Build Resources
   * No update
 * Future of Build Toolchain
@@ -105,6 +105,6 @@
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+* **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/io.js/2014-10-09.md
+++ b/meetings/io.js/2014-10-09.md
@@ -1,6 +1,6 @@
 - Contribution Policy was merged last week.
 
-- Concerns about https://github.com/node-forward/node/issues/2 have been brought
+- Concerns about <https://github.com/node-forward/node/issues/2> have been brought
   up, it effects almost every line and will make merges with Joyent
   unnecessarily painful in the short term. The consensus was to put it on the
   back burner.
@@ -58,4 +58,4 @@
 - The video of TC meetings doesn't include the chat so we need to be aware of
   that when using it during the calls.
 
-Video of the call is https://www.youtube.com/watch?v=fNW_tu2QnpA
+Video of the call is <https://www.youtube.com/watch?v=fNW_tu2QnpA>

--- a/meetings/io.js/2014-10-15.md
+++ b/meetings/io.js/2014-10-15.md
@@ -4,7 +4,7 @@
 
 * Openssl upgrade / openssl 1.0.1j, disabling SSL3 support
 * Status of the build system & release automation
-* https://github.com/node-forward/node/pull/14 - refine TC percentage rules - CONTRIBUTING.md
+* <https://github.com/node-forward/node/pull/14> - refine TC percentage rules - CONTRIBUTING.md
 * Items preventing node-forward from releasing v0.12.
 * Node Forward release cycle/schedule.
 * (Maybe discuss v8 3.29 in node-forward vs 3.28 in joyent/node, and merging them? ...just a suggestion)
@@ -13,8 +13,8 @@
 
 ## Links
 
-* **Google Hangouts Video**: https://youtu.be/Jfwnzl6kZsc
-* **Original Minutes Google Doc**: https://docs.google.com/a/vagg.org/document/d/18l01PO2Rb3OZXWMcIkZ_sU4f1JKP2LKOwjuiENkg37M
+* **Google Hangouts Video**: <https://youtu.be/Jfwnzl6kZsc>
+* **Original Minutes Google Doc**: <https://docs.google.com/a/vagg.org/document/d/18l01PO2Rb3OZXWMcIkZ_sU4f1JKP2LKOwjuiENkg37M>
 
 ## Minutes
 
@@ -31,7 +31,7 @@
 
 * Fedor: **OpenSSL upgrade to 1.0.1j done in a branch**, build bots reporting OK, ready to merge. SSLv3 disabled completely in joyent/node 0.12 because the protocol is broken--attack comes from downgrade request from TLS to SSLv3. 0.10 has a runtime flag to enable it via process arguments (`--enable-ssl3`).
 * Rod (representing the build group): tried Jenkins and BuildBot. Neither are great, but right now they’re working on getting something to work now, although eventually they’d like a great build system. There are build bots running for most platforms right now, except OS X (but there’s commitment from voxer to sponsor machines). Building branches works, but PRs doesn’t. This week some basic useful stuff should be available.
-  - https://github.com/graydon/bors - rust
+  - <https://github.com/graydon/bors> - rust
   - Benchmarks? Make a CI target just for benchmarks so we can track it over time. Not run on every PR, perhaps manually triggered, perhaps time triggered. http-simple? Fedor: large nightly benchmarks would be nice. Start with Linux, a single consistent box running the suite (doing a release too).
 * **Refine TC percentage**: pull node-forward/node#14. TC is short two people without Joyent & is small. 2 of 6 people are from Strongloop. #14 allows changing to 33% to allow the current TC to not be in violation for the time being and then change it back to 20% when we can. Consensus has been relatively easy, no votes have been needed thus far so there isn’t much concern.
 * **Release cycle**: time based releases? node-forward discussion have strong consensus for a desire to move to semver and also a quicker release cycle.
@@ -39,5 +39,5 @@
   - Discussion on **native API compatibility**, NAN or NAN-like or something more brave like having ABI compatibility. Ben: “You can’t forecast the future, the abstraction will break”.
   - **Supporting old versions**: deal with it when the project has “prior releases”. Defer discussion on exactly the model until the project is ready to make proper releases. Move discussion to GitHub.
 * **V8 3.29**, Fedor: joyent/node has 3.28, node-forward/node has 3.29. Trevor & Fedor agreed to put 3.29 in joyent/node pending agreement with TJ.
-* **node-forward website**, Mikeal: there is a website, http://nodeforward.org/
+* **node-forward website**, Mikeal: there is a website, <http://nodeforward.org/>
   - Forrest suggests a help repo to replace what the mailing list works, he has offered to help support that.

--- a/meetings/io.js/2014-12-10.md
+++ b/meetings/io.js/2014-12-10.md
@@ -2,23 +2,23 @@
 
 ## Agenda
 
-Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeting.
 
-* @chrisdickinson nomination to TC https://github.com/nodejs/io.js/issues/51
-* Move readable-stream to iojs org and make authoritative source for io.js to pull _from_ https://github.com/nodejs/io.js/issues/55
-* Deprecate domains https://github.com/nodejs/io.js/issues/66
-* Decide how to go forward with caine https://github.com/nodejs/io.js/issues/117
-* Is it io.js, IO.js, or something else? https://github.com/nodejs/io.js/issues/118
+* @chrisdickinson nomination to TC <https://github.com/nodejs/io.js/issues/51>
+* Move readable-stream to iojs org and make authoritative source for io.js to pull _from_ <https://github.com/nodejs/io.js/issues/55>
+* Deprecate domains <https://github.com/nodejs/io.js/issues/66>
+* Decide how to go forward with caine <https://github.com/nodejs/io.js/issues/117>
+* Is it io.js, IO.js, or something else? <https://github.com/nodejs/io.js/issues/118>
 * Build automation update
 * extending options from a prototype
-https://github.com/nodejs/io.js/issues/62
+<https://github.com/nodejs/io.js/issues/62>
 * Separate I/O tests from simple, so simple tests can be run in parallel
-* Statement / stance from TC on exposing a Promises API https://github.com/nodejs/io.js/issues/11
+* Statement / stance from TC on exposing a Promises API <https://github.com/nodejs/io.js/issues/11>
 
 ## Links
 
-* **Google Hangouts Video**: https://youtu.be/X2wxaHgsPxQ
-* **GitHub Issue**: https://github.com/nodejs/io.js/issues/112
+* **Google Hangouts Video**: <https://youtu.be/X2wxaHgsPxQ>
+* **GitHub Issue**: <https://github.com/nodejs/io.js/issues/112>
 
 ## Minutes
 
@@ -33,13 +33,13 @@ https://github.com/nodejs/io.js/issues/62
 
 ### @chrisdickinson nomination to TC
 
-https://github.com/nodejs/io.js/issues/51
+<https://github.com/nodejs/io.js/issues/51>
 
 **Unanimous decision to add Chris to TC**
 
 ### Move readable-stream to iojs org and make authoritative source for io.js to pull _from_
 
-https://github.com/nodejs/io.js/issues/55
+<https://github.com/nodejs/io.js/issues/55>
 
 * Chris expressed concerns on doing this, but a -0 for now, give it a go and see how it works
 * Discussed the potential difference with joyent/node
@@ -52,21 +52,21 @@ https://github.com/nodejs/io.js/issues/55
 
 ### Deprecate domains
 
-https://github.com/nodejs/io.js/issues/66
+<https://github.com/nodejs/io.js/issues/66>
 
 * Trevor: domains are horrible but we don’t have a good alternative yet
 * Ben: +1 on removal but don’t have a good story on what to tell people to use
 * Bert: -1, would rather clean up docs to be honest about how it doesn’t do what it was hoped to
 * Trevor: domains inhibit progress because of their invasiveness
 * Discussed how to document concerns etc.
-* Discussed https://github.com/nodejs/io.js/pull/15 which adjusts the domain.run() API
+* Discussed <https://github.com/nodejs/io.js/pull/15> which adjusts the domain.run() API
 * Agreed:
   - Accept PR #15
   - **Document that domains are on the way out: soft deprecation** (no util.deprecate())
 
 ### Decide how to go forward with Caine (bot)
 
-https://github.com/nodejs/io.js/issues/117
+<https://github.com/nodejs/io.js/issues/117>
 
 * Fedor talked about _what_ caine is and _why_ it exists: too many emails from the repo, want to set up a system where relevant people are pulled into particular issues rather than having to subscribe to the repo for all notifications
 * Chris: primary concern with having an automated bot is the incoming experience for users (like having a join bot on IRC)
@@ -76,11 +76,11 @@ https://github.com/nodejs/io.js/issues/117
 
 ### Is it io.js, IO.js, or something else?
 
-https://github.com/nodejs/io.js/issues/118
+<https://github.com/nodejs/io.js/issues/118>
 
 * Ben: lowercase is “objectively superior” (j/k)
 * No disagreements, the name is “io.js”
-* Ben: binary name suggestion “iojs” with symlink to “node”, lots of discussion in https://github.com/nodejs/io.js/issues/43
+* Ben: binary name suggestion “iojs” with symlink to “node”, lots of discussion in <https://github.com/nodejs/io.js/issues/43>
 * **No disagreements, binary name will be “iojs”**
 * Ben: how do we handle it on Windows? .bat file (problems with arg forwarding), small .exe
 * Agreed to open a new issue to discuss Windows compat (Ben)
@@ -88,15 +88,15 @@ https://github.com/nodejs/io.js/issues/118
 ### Build automation update
 
 Rod gave a summary of build project status:
-- Containerized build system is being improved by an active team in the https://github.com/nodejs/build-containers repo, on target to enable automatic PR tests and status reports back to GitHub (will likely just be Linux distros for the forseeable future)
+- Containerized build system is being improved by an active team in the <https://github.com/nodejs/build-containers> repo, on target to enable automatic PR tests and status reports back to GitHub (will likely just be Linux distros for the forseeable future)
 - Next step is to enable committers to be able to trigger full builds across the build cluster
 - Aiming for more automation for a mid-January release, have concerns about Windows and OSX signing and the need for signing keys and how complex they are.
 - Chris Lea is working towards nightly builds for .deb-based systems (RHEL / Fedora based systems could come later but the assumption is that people running those systems are _less_ likely to want nightlies)
-- https://github.com/nodejs/io.js/issues/13 is an ARM build failure that still needs attention to have ARM part of the build mix and not constantly fail (see https://jenkins-node-forward.nodesource.com for some ARM failures)
+- <https://github.com/nodejs/io.js/issues/13> is an ARM build failure that still needs attention to have ARM part of the build mix and not constantly fail (see <https://jenkins-node-forward.nodesource.com> for some ARM failures)
 
 ### Extending options from a prototype
 
-https://github.com/nodejs/io.js/issues/62
+<https://github.com/nodejs/io.js/issues/62>
 
 * Chris is asking for input
 * Ben: we’re currently only looking at the object’s own properties, and ignoring properties on the prototype.
@@ -112,7 +112,7 @@ https://github.com/nodejs/io.js/issues/62
 
 ### Statement / stance from TC on exposing a Promises API
 
-https://github.com/nodejs/io.js/issues/11
+<https://github.com/nodejs/io.js/issues/11>
 
 * Rod: can we come up with some kind of statement from the TC regarding the possibility of adding a Promises API to core, even if it’s vague
 * Bert: there’s a convergence of functionality around Promises that are making them more useful in conjunction with other ES6/ES7 features, TC should be _open_ to adding a Promises API in the future
@@ -127,7 +127,7 @@ https://github.com/nodejs/io.js/issues/11
 
 ### Working with nvm, nvmw and similar installation managers
 
-https://github.com/nodejs/io.js/issues/40
+<https://github.com/nodejs/io.js/issues/40>
 
 * Ben: suggested a dist.iojs.org for hosting binaries
 * Ben: suggested a release.txt

--- a/meetings/io.js/2014-12-17.md
+++ b/meetings/io.js/2014-12-17.md
@@ -2,17 +2,17 @@
 
 ## Links
 
-* **Google Hangouts Video**: https://www.youtube.com/watch?v=7s-VJLQEWXg
-* **GitHub Issue**: https://github.com/nodejs/io.js/issues/163
-* **Original Minutes Google Doc**: https://docs.google.com/document/d/1PoqGfxpfTFKv5GcKmhMM2siZpPjT9Ba-ooBi-ZbYNi0
+* **Google Hangouts Video**: <https://www.youtube.com/watch?v=7s-VJLQEWXg>
+* **GitHub Issue**: <https://github.com/nodejs/io.js/issues/163>
+* **Original Minutes Google Doc**: <https://docs.google.com/document/d/1PoqGfxpfTFKv5GcKmhMM2siZpPjT9Ba-ooBi-ZbYNi0>
 
 ## Agenda
 
-Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeting.
 
-* Bundle tick processor with iojs #158 https://github.com/nodejs/io.js/issues/158
-* Release Cycle Proposal #168 https://github.com/nodejs/io.js/issues/168
-* Module search security #176 https://github.com/nodejs/io.js/pull/176
+* Bundle tick processor with iojs #158 <https://github.com/nodejs/io.js/issues/158>
+* Release Cycle Proposal #168 <https://github.com/nodejs/io.js/issues/168>
+* Module search security #176 <https://github.com/nodejs/io.js/pull/176>
 * Dealing with feature requests
 
 ## Review of last meeting
@@ -37,7 +37,7 @@ Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting
 
 ### Bundle tick processor with iojs #158
 
-https://github.com/nodejs/io.js/issues/158
+<https://github.com/nodejs/io.js/issues/158>
 
 * Bert: important because it’s tied to the version of V8, not practical to put it in npm because one is needed for each version
 * Isaac: this is minimal and shouldn’t set a standard for just adding more stuff to core (i.e. keep core minimal), so +1
@@ -46,7 +46,7 @@ https://github.com/nodejs/io.js/issues/158
 
 ### Release Cycle Proposal #168
 
-https://github.com/nodejs/io.js/issues/168
+<https://github.com/nodejs/io.js/issues/168>
 
 * Bert & Isaac discussed how this feeds into the ability to have frequent releases. Discussed semver plays into this.
 * Rod: consensus seems to be around having stability, predictability, lead-time but more frequent releases.
@@ -54,7 +54,7 @@ https://github.com/nodejs/io.js/issues/168
 
 ### Module search security #176
 
-https://github.com/nodejs/io.js/pull/176
+<https://github.com/nodejs/io.js/pull/176>
 
 * Limiting node_modules search path to $HOME as a top-level
 * Isaac ~ -1 on this because EACCES already happens when you don’t have permission

--- a/meetings/io.js/2014-12-30.md
+++ b/meetings/io.js/2014-12-30.md
@@ -2,18 +2,18 @@
 
 ## Links
 
-* **Google Hangouts Video**: https://youtu.be/O6607HTsiDE
-* **GitHub Issue**: https://github.com/nodejs/io.js/issues/211
-* **Original Minutes Google Doc**: https://docs.google.com/document/d/1KLfX2MZQbVSIaD2lBVqOFK0Kap4uFz9cTGihnpTuvPE
+* **Google Hangouts Video**: <https://youtu.be/O6607HTsiDE>
+* **GitHub Issue**: <https://github.com/nodejs/io.js/issues/211>
+* **Original Minutes Google Doc**: <https://docs.google.com/document/d/1KLfX2MZQbVSIaD2lBVqOFK0Kap4uFz9cTGihnpTuvPE>
 
 ## Agenda
 
-Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeting.
 
-* sys: Remove after 3 years of deprecation #182 https://github.com/nodejs/io.js/pull/182
-* module: force require('process') to return a reference to process #206 https://github.com/nodejs/io.js/pull/206
-* File copyright policy #216 https://github.com/nodejs/io.js/pull/216
-* Rename v0.12 to v1.0.0 https://github.com/nodejs/io.js/issues/218
+* sys: Remove after 3 years of deprecation #182 <https://github.com/nodejs/io.js/pull/182>
+* module: force require('process') to return a reference to process #206 <https://github.com/nodejs/io.js/pull/206>
+* File copyright policy #216 <https://github.com/nodejs/io.js/pull/216>
+* Rename v0.12 to v1.0.0 <https://github.com/nodejs/io.js/issues/218>
 * Merge strategy (v0.10 and joyent/node)
 
 ## Minutes
@@ -29,7 +29,7 @@ Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting
 
 ### sys: Remove after 3 years of deprecation #182
 
-https://github.com/nodejs/io.js/pull/182
+<https://github.com/nodejs/io.js/pull/182>
 
 * Ben: what sort of strategy to take? Deprecated only in the docs but no warning. Looking for an official deprecation policy.
 * Bert: suggest we could properly deprecate but not a good case for removing it completely, Chris agreed
@@ -44,9 +44,9 @@ https://github.com/nodejs/io.js/pull/182
 
 ### module: force require('process') to return a reference to process #206
 
-https://github.com/nodejs/io.js/pull/206
+<https://github.com/nodejs/io.js/pull/206>
 
-* #157 has a long discussion on this: https://github.com/nodejs/io.js/issues/157
+* #157 has a long discussion on this: <https://github.com/nodejs/io.js/issues/157>
 * Chris: +1 on a PR adding this
 * Trevor: it just returns a global, no point
 * Bert: not the way that JS adds new features; discussed the new Intl addition to joyent/node, in favor of making more things requirable rather than adding new globals all the time
@@ -61,14 +61,14 @@ https://github.com/nodejs/io.js/pull/206
 
 ### File copyright policy #216
 
-https://github.com/nodejs/io.js/pull/216
+<https://github.com/nodejs/io.js/pull/216>
 
 * Rod asked if there are any strong opinions about how to handle this
 * **Group agreed that Rod will take this issue and seek legal advice to find a way forward**
 
 ### Rename v0.12 to v1.0.0
 
-https://github.com/nodejs/io.js/issues/218
+<https://github.com/nodejs/io.js/issues/218>
 
 * Trevor: concerns about 1.0 vs 1.x branch naming with maintaining semver releases while also doing LTS, 1.x effectively becomes master until a 2.0 comes along.
 * Bert: -1

--- a/meetings/io.js/2015-01-07.md
+++ b/meetings/io.js/2015-01-07.md
@@ -2,19 +2,19 @@
 
 ## Links
 
-* **Google Hangouts Video**: https://youtu.be/XnbooCfASA0
-* **GitHub Issue**: https://github.com/nodejs/io.js/issues/230
-* **Original Minutes Google Doc**: https://docs.google.com/document/d/1j7Sdui5DqHE8GZHxuoAaoIQ4jlntacZI285OCfVa-Eo
+* **Google Hangouts Video**: <https://youtu.be/XnbooCfASA0>
+* **GitHub Issue**: <https://github.com/nodejs/io.js/issues/230>
+* **Original Minutes Google Doc**: <https://docs.google.com/document/d/1j7Sdui5DqHE8GZHxuoAaoIQ4jlntacZI285OCfVa-Eo>
 
 ## Agenda
 
-Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeting.
 
-* Invite Colin Ihrig to the TC #223 https://github.com/nodejs/io.js/issues/223
-* File copyright policy #216 https://github.com/nodejs/io.js/issues/216
-* Doc: clarified & split up contribution docs #233 https://github.com/nodejs/io.js/pull/233
-* Governance: Add new Collaborators #234 https://github.com/nodejs/io.js/issues/234
-* deps: upgrade v8 to 3.31.74.1 #243 https://github.com/nodejs/io.js/pull/243
+* Invite Colin Ihrig to the TC #223 <https://github.com/nodejs/io.js/issues/223>
+* File copyright policy #216 <https://github.com/nodejs/io.js/issues/216>
+* Doc: clarified & split up contribution docs #233 <https://github.com/nodejs/io.js/pull/233>
+* Governance: Add new Collaborators #234 <https://github.com/nodejs/io.js/issues/234>
+* deps: upgrade v8 to 3.31.74.1 #243 <https://github.com/nodejs/io.js/pull/243>
 * Build
 * Intl - defaults
 * Merge v0.10
@@ -42,7 +42,7 @@ Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting
 * colin: triaging issues in io.js and joyent/node.  helping with merge of 0.12 to 0.10
 * isaac: no io.js, vacation
 * mikeal: nada
-* rod: build build build ci ci ci.  re-did all the build slaves on Jenkins, introduced a bunch more.  Ansible scripts for linux machines (CentOS 5,6,7, Ubuntu all LTS + Current 14.10 +32bit versions, 2 ARM v7s one virtual one physical, 2 of each Windows 2012,2008, a couple interim OS X machines more permanent ones coming from Voxer soon).  https://github.com/nodejs/build Still lacking specific Jenkins setup and secrets.  Working on release process.
+* rod: build build build ci ci ci.  re-did all the build slaves on Jenkins, introduced a bunch more.  Ansible scripts for linux machines (CentOS 5,6,7, Ubuntu all LTS + Current 14.10 +32bit versions, 2 ARM v7s one virtual one physical, 2 of each Windows 2012,2008, a couple interim OS X machines more permanent ones coming from Voxer soon).  <https://github.com/nodejs/build> Still lacking specific Jenkins setup and secrets.  Working on release process.
     mikeal: issue re release?
     rod: not yet, a lot of little bugs to get CI working consistently.  No grand plan for what’s in release yet.
 
@@ -56,7 +56,7 @@ Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting
 
 ### Invite Colin Ihrig to the TC #223
 
-https://github.com/nodejs/io.js/issues/223
+<https://github.com/nodejs/io.js/issues/223>
 
 Asked for vote
 
@@ -66,7 +66,7 @@ Some discussion about TC member addition process
 
 ### File copyright policy #216
 
-https://github.com/nodejs/io.js/issues/216
+<https://github.com/nodejs/io.js/issues/216>
 
 * Rod: got feedback from NodeSource GC on this, recommendation is to keep the copyright but removal of the license notice is acceptable
 * Mikeal & Isaac: removing the copyright should be OK because we have full git record of who made & edited the file, it’s a PITA
@@ -76,7 +76,7 @@ https://github.com/nodejs/io.js/issues/216
 
 ### Doc: clarified & split up contribution docs #233
 
-https://github.com/nodejs/io.js/pull/233
+<https://github.com/nodejs/io.js/pull/233>
 
 * Rod: discussed changes introduced in #233, this is in TC because there are some minor modifications to the governance structure. Recommended that we deal with further changes to governance as a separate discussion.
 * Fedor: remove caine block from CONTRIBUTING.md
@@ -86,7 +86,7 @@ https://github.com/nodejs/io.js/pull/233
 
 ### Governance: Add new Collaborators #234
 
-https://github.com/nodejs/io.js/issues/234
+<https://github.com/nodejs/io.js/issues/234>
 
 Rod discussed the generation of the list of proposed collaborators.
 
@@ -106,7 +106,7 @@ Long discussion:
 
 ### deps: upgrade v8 to 3.31.74.1 #243
 
-https://github.com/nodejs/io.js/pull/243
+<https://github.com/nodejs/io.js/pull/243>
 
 * Ben: clean compile, apparently a clean upgrade. It does break postmortem support so Ben removed it completely. Asked who was using it.
 * Ben: adds new features:
@@ -124,7 +124,7 @@ https://github.com/nodejs/io.js/pull/243
 
 Rod rambled on about build & release:
 
-* Lots of minor test failures to take care of and make sure there are no serious blockers: https://jenkins-iojs.nodesource.com/job/iojs+any-pr+multi/
+* Lots of minor test failures to take care of and make sure there are no serious blockers: <https://jenkins-iojs.nodesource.com/job/iojs+any-pr+multi/>
 * is osx 32-bit necessary? group agreed to leave it out.
 * binary naming: Ben currently taking care of renaming, Bert will help out with a solution for windows
 * release blobs:

--- a/meetings/io.js/2015-01-13.md
+++ b/meetings/io.js/2015-01-13.md
@@ -2,17 +2,17 @@
 
 ## Links
 
-* **Google Hangouts Video**: https://youtu.be/N-hksruPx7o
-* **GitHub Issue**: https://github.com/nodejs/io.js/issues/300
-* **Original Minutes Google Doc**: https://docs.google.com/document/d/1HDUayYxTjolYZhu_hGm9hc-6MGAwWrHlNGT2Zo708ck
+* **Google Hangouts Video**: <https://youtu.be/N-hksruPx7o>
+* **GitHub Issue**: <https://github.com/nodejs/io.js/issues/300>
+* **Original Minutes Google Doc**: <https://docs.google.com/document/d/1HDUayYxTjolYZhu_hGm9hc-6MGAwWrHlNGT2Zo708ck>
 
 ## Agenda
 
-Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeting.
 
-* File copyright policy #216 https://github.com/nodejs/io.js/issues/216
-* governance: Add new Collaborators #234 https://github.com/nodejs/io.js/issues/234
-* The state of ES6 on io.js _(re V8 upgrade policy)_ #251 https://github.com/nodejs/io.js/issues/251
+* File copyright policy #216 <https://github.com/nodejs/io.js/issues/216>
+* governance: Add new Collaborators #234 <https://github.com/nodejs/io.js/issues/234>
+* The state of ES6 on io.js _(re V8 upgrade policy)_ #251 <https://github.com/nodejs/io.js/issues/251>
   Quick recap:
   - Whether if it is ok to release 1.0.0 with V8 3.31.74 minus ES6 Classes and Object Literals Extensions, considering that the initial version of io.js will be "beta" quality and probably the stable version will coincide with the stable release of V8 3.31 (~6 weeks), which will have these features reinstated.
   - How to handle V8 updates with semver so that if the same issue arised with a different timing it could mean a bump to 2.0.0.
@@ -20,7 +20,7 @@ Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting
     * Different version naming (e.g. 1.x+v8beta, 1.x+v8dev, 1.x+v8canary)
     * Avoid BC by moving from tip-of-stable-Chrome-branch to the next tip-of-stable-Chrome-branch (~6 weeks release cycle)
   - How do nightly builds fit into the process.
-* 1.0.0 release checklist https://github.com/nodejs/io.js/issues/302
+* 1.0.0 release checklist <https://github.com/nodejs/io.js/issues/302>
 
 ## Minutes
 
@@ -42,24 +42,24 @@ Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting
 
 ### Review of last meeting
 
-* Invite Colin Ihrig to the TC #223 https://github.com/nodejs/io.js/issues/223
-* File copyright policy #216 https://github.com/nodejs/io.js/issues/216
-* Doc: clarified & split up contribution docs #233 https://github.com/nodejs/io.js/pull/233
-* Governance: Add new Collaborators #234 https://github.com/nodejs/io.js/issues/234
-* deps: upgrade v8 to 3.31.74.1 #243 https://github.com/nodejs/io.js/pull/243
+* Invite Colin Ihrig to the TC #223 <https://github.com/nodejs/io.js/issues/223>
+* File copyright policy #216 <https://github.com/nodejs/io.js/issues/216>
+* Doc: clarified & split up contribution docs #233 <https://github.com/nodejs/io.js/pull/233>
+* Governance: Add new Collaborators #234 <https://github.com/nodejs/io.js/issues/234>
+* deps: upgrade v8 to 3.31.74.1 #243 <https://github.com/nodejs/io.js/pull/243>
 * Build & release (& Intl)
 
 ### File copyright policy #216
 
-https://github.com/nodejs/io.js/issues/216
+<https://github.com/nodejs/io.js/issues/216>
 
-Rod: prepared a proposed new LICENSE file, needed for release, adds a new license block for io.js at the top, shifts the Joyent copyright block down but still acknowledges their claim on inherited work. https://github.com/nodejs/io.js/pull/294
+Rod: prepared a proposed new LICENSE file, needed for release, adds a new license block for io.js at the top, shifts the Joyent copyright block down but still acknowledges their claim on inherited work. <https://github.com/nodejs/io.js/pull/294>
 
 Group agreed to merge for now until a better (or more legally appropriate) solution is proposed.
 
 ### governance: Add new Collaborators #234
 
-https://github.com/nodejs/io.js/issues/234
+<https://github.com/nodejs/io.js/issues/234>
 
 Rod asked if we should punt to next meeting since the group was small and we’re 1.0.0 obsessed.
 
@@ -67,7 +67,7 @@ Group agreed.
 
 ### The state of ES6 on io.js _(re V8 upgrade policy)_ #251
 
-https://github.com/nodejs/io.js/issues/251
+<https://github.com/nodejs/io.js/issues/251>
 
 Rod: this is about V8 version matching and V8 version stability. We’re going live with 3.31.
 
@@ -77,7 +77,7 @@ Group agreed to stick with 3.31, too late to do otherwise. Come up with a more s
 
 ### v1.0.0 release checklist
 
-https://github.com/nodejs/io.js/issues/302
+<https://github.com/nodejs/io.js/issues/302>
 
 * Rod will land LICENSE change after meeting
 * Bert spoke about the v0.10 and the things that remain unmerged
@@ -87,10 +87,10 @@ https://github.com/nodejs/io.js/issues/302
   - re timers slowness - Bert and Ben don’t like the 0.10 fix, need to find our own - not landing in 1.0.0, probably our own fix in 1.0.1
 * Bert spoke about node.exe, has code for it but it’s crashy, could release with a symlink for 1.0.0. Asked for input on the approach.
 * Discussed node-gyp - Ben to PR node-gyp (and maybe land a modified version in io.js codebase) for iojs.org/dist/vx.y.z/... for source tarball.
-  - discussed process.versions.iojs property, https://github.com/nodejs/io.js/issues/269 - group agreed to do nothing on this. Rod to find discussion or create issue to have discussion on this.
+  - discussed process.versions.iojs property, <https://github.com/nodejs/io.js/issues/269> - group agreed to do nothing on this. Rod to find discussion or create issue to have discussion on this.
   - discussed visual assets not being in the repo, currently copied by CI manually into src, Rod to land a PR with them
 * Rod: Changelog, we don’t have one.
-  - https://github.com/joyent/node/wiki/API-changes-between-v0.10-and-v0.12
+  - <https://github.com/joyent/node/wiki/API-changes-between-v0.10-and-v0.12>
   - Rod: is it a blocker? Ben: not per-se but very good to have.
   - Rod: proposed to come up with something on GitHub and ask for people to take work. Trevor will do Buffer, Chris streams, Bert child processes.
 

--- a/meetings/io.js/2015-01-21.md
+++ b/meetings/io.js/2015-01-21.md
@@ -2,19 +2,19 @@
 
 ## Links
 
-* **Google Hangouts Video**: http://www.youtube.com/watch?v=OUoWlIshY9s
-* **GitHub Issue**: https://github.com/nodejs/io.js/issues/509
-* **Original Minutes Google Doc**: https://docs.google.com//document/d/1yOS17cUt7QUHJXxdVmEpS1ZS_N32HMO9QTHb2qL-KHk
+* **Google Hangouts Video**: <http://www.youtube.com/watch?v=OUoWlIshY9s>
+* **GitHub Issue**: <https://github.com/nodejs/io.js/issues/509>
+* **Original Minutes Google Doc**: <https://docs.google.com//document/d/1yOS17cUt7QUHJXxdVmEpS1ZS_N32HMO9QTHb2qL-KHk>
 
 ## Agenda
 
-Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeting.
 
-* Invite Domenic Denicola to the TC Meetings (https://github.com/nodejs/io.js/issues/403)
-* Governance: Add new collaborators (https://github.com/nodejs/io.js/issues/234)
-* Stabilization and Release Cycles and Process (https://github.com/nodejs/io.js/issues/405)
-  * also: the state of ES6 on io.js (re: V8 upgrade policy) (https://github.com/nodejs/io.js/issues/251)
-* doc: bump punycode api stability to ‘stable’ (https://github.com/nodejs/io.js/issues/470)
+* Invite Domenic Denicola to the TC Meetings (<https://github.com/nodejs/io.js/issues/403>)
+* Governance: Add new collaborators (<https://github.com/nodejs/io.js/issues/234>)
+* Stabilization and Release Cycles and Process (<https://github.com/nodejs/io.js/issues/405>)
+  * also: the state of ES6 on io.js (re: V8 upgrade policy) (<https://github.com/nodejs/io.js/issues/251>)
+* doc: bump punycode api stability to ‘stable’ (<https://github.com/nodejs/io.js/issues/470>)
 * Working group reports
   * Streams
   * Website
@@ -40,7 +40,7 @@ Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting
 * Ben: Fixing bugs, reviewing PRs, maintenance
 * Chris: Cleaning up points where core reaches in to private state of streams, TLS bug with New Relic
 * Colin: Reviewing PRs, moving vars to ES6 consts
-* Fedor: Commenting, working on replacement for GYP, written in C: https://github.com/indutny/pyg
+* Fedor: Commenting, working on replacement for GYP, written in C: <https://github.com/indutny/pyg>
 * Isaac: npm stuff, some streams discussing
 * Mikeal: Website WG, social media accounts, facebook, G+, etc.
 * Domenic: Changelog & Release, clarifying V8 stuff
@@ -58,13 +58,13 @@ Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting
 
 ### Invite Domenic Denicola to the TC Meetings
 
-(https://github.com/nodejs/io.js/issues/403)
+(<https://github.com/nodejs/io.js/issues/403>)
 
 Enough agreement on GitHub and in private communications amongst TC. **Done.**
 
 ### Governance: Add new collaborators
 
-(https://github.com/nodejs/io.js/issues/234)
+(<https://github.com/nodejs/io.js/issues/234>)
 
 * Mikeal: Proposed Chris leads an onboarding process, do a Hangout with a group of people from the original list who are willing to go through the process and take them in the first week and iterate from there.
 * Bert: +1 for an onboarding process, more interested in handing out voting rights to a larger group.
@@ -84,7 +84,7 @@ Passed
 
 ### Stabilization and Release Cycles and Process
 
-(https://github.com/nodejs/io.js/issues/405)
+(<https://github.com/nodejs/io.js/issues/405>)
 
 #### V8
 
@@ -125,13 +125,13 @@ Passed
 
 ### also: the state of ES6 on io.js (re: V8 upgrade policy)
 
-(https://github.com/nodejs/io.js/issues/251)
+(<https://github.com/nodejs/io.js/issues/251>)
 
 Part of previous discussion
 
 ### doc: bump punycode api stability to ‘stable’
 
-(https://github.com/nodejs/io.js/issues/470)
+(<https://github.com/nodejs/io.js/issues/470>)
 
 * **Agreement**
 
@@ -140,7 +140,7 @@ Part of previous discussion
 * Mikeal and Chris to semi-formalise the model
 * Mikeal: 6 people actively engaged and growing, “could not be going better”
 * Chris: streams group has initial set of members, some discussions going on, first meeting pending
-  * initial set of members: https://github.com/nodejs/readable-stream/issues/97#issuecomment-70399923
+  * initial set of members: <https://github.com/nodejs/readable-stream/issues/97#issuecomment-70399923>
 * Rod:
   - The Docker sub-group is going great and has even got the docker-iojs images accepted as the official Docker "iojs" images.
   - Other "build" efforts are all release-focused for now, trying to streamline the process to make it possible to have multiple people able to cut releases.

--- a/meetings/io.js/2015-01-28.md
+++ b/meetings/io.js/2015-01-28.md
@@ -2,13 +2,13 @@
 
 ## Links
 
-* **Google Hangouts Video**: http://www.youtube.com/watch?v=k27NObxy0ps
-* **GitHub Issue**: https://github.com/nodejs/io.js/issues/565
-* **Original Minutes Google Doc**: https://docs.google.com/document/d/1IIfubVivCORgP0nQfo8Mf4gXhwBrndRm9cwmNGBXmtE
+* **Google Hangouts Video**: <http://www.youtube.com/watch?v=k27NObxy0ps>
+* **GitHub Issue**: <https://github.com/nodejs/io.js/issues/565>
+* **Original Minutes Google Doc**: <https://docs.google.com/document/d/1IIfubVivCORgP0nQfo8Mf4gXhwBrndRm9cwmNGBXmtE>
 
 ## Agenda
 
-Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeting.
 
 * governance: Add new Collaborators [#234](https://github.com/nodejs/io.js/issues/234) / feedback and more contribs / @chrisdickinson
 * Stabilization and Release Cycles and Process [#405](https://github.com/nodejs/io.js/issues/405) / further discussion / @iojs/tc
@@ -52,11 +52,11 @@ Apologies from:
 
 ### Review of last meeting
 
-* Invite Domenic Denicola to the TC Meetings (https://github.com/nodejs/io.js/issues/403)
-* Governance: Add new collaborators (https://github.com/nodejs/io.js/issues/234)
-* Stabilization and Release Cycles and Process (https://github.com/nodejs/io.js/issues/405)
-  * also: the state of ES6 on io.js (re: V8 upgrade policy) (https://github.com/nodejs/io.js/issues/251)
-* doc: bump punycode api stability to ‘stable’ (https://github.com/nodejs/io.js/issues/470)
+* Invite Domenic Denicola to the TC Meetings (<https://github.com/nodejs/io.js/issues/403>)
+* Governance: Add new collaborators (<https://github.com/nodejs/io.js/issues/234>)
+* Stabilization and Release Cycles and Process (<https://github.com/nodejs/io.js/issues/405>)
+  * also: the state of ES6 on io.js (re: V8 upgrade policy) (<https://github.com/nodejs/io.js/issues/251>)
+* doc: bump punycode api stability to ‘stable’ (<https://github.com/nodejs/io.js/issues/470>)
 * Working group reports
   * Streams
   * Website
@@ -69,7 +69,7 @@ Apologies from:
 * Chris: Onboarded 2 groups of 4 new collaborators last week. (first group: @vkurchatkin, @micnic, @seishun, @brendanashworth, second group: @evanlucas, @Fishrock123, @Qard, @thlorenz)
   - 30 min summary of how everything works, gov, git, etc.
   - took exit poll to get reactions
-  - notes here: https://gist.github.com/chrisdickinson/80df88b9089c19e0459e
+  - notes here: <https://gist.github.com/chrisdickinson/80df88b9089c19e0459e>
 * Rod: how do we iterate?
 * Chris: Do it again next week with ~4 more
 * Discussed timezones and how that works
@@ -82,7 +82,7 @@ Apologies from:
 
 Moved straight to Chris’ proposal:
 
-* Chris discussed thoughts in his proposal @ https://github.com/nodejs/io.js/issues/630
+* Chris discussed thoughts in his proposal @ <https://github.com/nodejs/io.js/issues/630>
 * Mikeal: would rather not have a static number/list of supported versions, let that be dynamic as people & companies step up to help support them
 * Ben: “stable” and “next” would be easiest to reason about
 * Chris: “dev” is for ad-hoc semver releases, replaces nightlies with a better train system.

--- a/meetings/io.js/2015-02-04.md
+++ b/meetings/io.js/2015-02-04.md
@@ -2,13 +2,13 @@
 
 ## Links
 
-* **Google Hangouts Video**: http://www.youtube.com/watch?v=k27NObxy0ps
-* **GitHub Issue**: https://github.com/nodejs/io.js/issues/509
-* **Original Minutes Google Doc**: https://docs.google.com/document/d/1IIfubVivCORgP0nQfo8Mf4gXhwBrndRm9cwmNGBXmtE
+* **Google Hangouts Video**: <http://www.youtube.com/watch?v=k27NObxy0ps>
+* **GitHub Issue**: <https://github.com/nodejs/io.js/issues/509>
+* **Original Minutes Google Doc**: <https://docs.google.com/document/d/1IIfubVivCORgP0nQfo8Mf4gXhwBrndRm9cwmNGBXmtE>
 
 ## Agenda
 
-Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeting.
 
 * assert: don't compare object `prototype` property [#636](https://github.com/nodejs/io.js/pull/636) _and_  assert: introduce `deepStrictEqual` [#639](https://github.com/nodejs/io.js/pull/639) / @vkurchatkin
 * Release PGP key strategy and policy [#709](https://github.com/nodejs/io.js/issues/709)
@@ -47,10 +47,10 @@ Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting
 * dgram: implicit binds should be exclusive [#325](https://github.com/nodejs/io.js/issues/325) / minor version bump / @bnoordhuis
 * buffer: implement `iterable` interface [#525](https://github.com/nodejs/io.js/issues/525)  / minor version bump / @bnoordhuis
 * replace util.isType() with typeof [#607](https://github.com/nodejs/io.js/issues/607) / general use of util.is*() in core re perf
-* docs: lower the maximum stability level to "stable" (https://github.com/nodejs/io.js/pull/633)
-* maintain our own package registries for io.js related packages (https://github.com/nodejs/io.js/issues/640#issuecomment-71882645)
-* Working Groups PR (https://github.com/nodejs/io.js/pull/599)
-* Remove “unstable” from messaging (https://github.com/nodejs/website/issues/108)
+* docs: lower the maximum stability level to "stable" (<https://github.com/nodejs/io.js/pull/633>)
+* maintain our own package registries for io.js related packages (<https://github.com/nodejs/io.js/issues/640#issuecomment-71882645>)
+* Working Groups PR (<https://github.com/nodejs/io.js/pull/599>)
+* Remove “unstable” from messaging (<https://github.com/nodejs/website/issues/108>)
 * Node.js and io.js should not break each other (no, they shouldn't)
 * Working group reports
 

--- a/meetings/io.js/2015-02-18.md
+++ b/meetings/io.js/2015-02-18.md
@@ -2,14 +2,14 @@
 
 ## Links
 
-* **Public YouTube feed**: http://www.youtube.com/watch?v=jeBPYLJ2_Yc
-* **Google Plus Event page**: https://plus.google.com/events/ccrkam8uup1k8qbo0fmcea0n2v4
-* **GitHub Issue**: https://github.com/nodejs/io.js/issues/509
-* **Original Minutes Google Doc**: https://docs.google.com/document/d/1JnujRu6Rfnp6wvbvwCfxXnsjLySunQ_yah91pkvSFdQ
+* **Public YouTube feed**: <http://www.youtube.com/watch?v=jeBPYLJ2_Yc>
+* **Google Plus Event page**: <https://plus.google.com/events/ccrkam8uup1k8qbo0fmcea0n2v4>
+* **GitHub Issue**: <https://github.com/nodejs/io.js/issues/509>
+* **Original Minutes Google Doc**: <https://docs.google.com/document/d/1JnujRu6Rfnp6wvbvwCfxXnsjLySunQ_yah91pkvSFdQ>
 
 ## Agenda
 
-Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeting.
 
 * util: fixed behavior of isObject() [#822](https://github.com/nodejs/io.js/issues/822) / @chrisdickinson / major version release
 * Translate installers for OS X and Windows [#819](https://github.com/nodejs/io.js/issues/819) / @rvagg / maintenance overhead
@@ -17,7 +17,7 @@ Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting
 * Implement unhandled rejection tracking [#758](https://github.com/nodejs/io.js/issues/758) / @rvagg / how can we help this land
 * Logo / Brand Treatment
 [website/181](https://github.com/nodejs/website/issues/181) @ mikeal
-https://www.behance.net/gallery/23269525/IOJS-logo-concept
+<https://www.behance.net/gallery/23269525/IOJS-logo-concept>
 * Stability Policy/Statement & Roadmap
 [#725](https://github.com/nodejs/io.js/issues/725) / @mikeal
 [roadmap/14](https://github.com/nodejs/roadmap/issues/14) / @mikeal
@@ -98,9 +98,9 @@ https://www.behance.net/gallery/23269525/IOJS-logo-concept
 
 ### Logo / Brand Treatment
 [website/181](https://github.com/nodejs/website/issues/181) @ mikeal
-https://www.behance.net/gallery/23269525/IOJS-logo-concept
+<https://www.behance.net/gallery/23269525/IOJS-logo-concept>
 
-* Mikeal discussed the proposed website changes and logo choice @ https://www.behance.net/gallery/23269525/IOJS-logo-concept
+* Mikeal discussed the proposed website changes and logo choice @ <https://www.behance.net/gallery/23269525/IOJS-logo-concept>
 * Some discussion about choice of logo, no strong opinions on design
 * Rod: may be best to let the website group make this choice because they are more qualified from a design perspective
 * Chris: design group could be asked to come up with a few options and present them for selection
@@ -120,7 +120,7 @@ https://www.behance.net/gallery/23269525/IOJS-logo-concept
 * Bert: concerned about this being a reflection of the way we work rather than enforcing new behaviors
 * Discussion around breaking / removing APIs and how firm this policy is going forward
 * Rod asked for specific things that need to be resolved now vs punting to a later meeting
-* Mikeal: https://github.com/nodejs/roadmap/commit/190690a1b5f206c22f64adc3d29d10c4b08cb8cd
+* Mikeal: <https://github.com/nodejs/roadmap/commit/190690a1b5f206c22f64adc3d29d10c4b08cb8cd>
 * Group discussed presentations, no major objections so the blessing was given for Mikeal to move forward with ratifying that, expect further discussion on the broader topic next meeting.
 
 ### Next meeting

--- a/meetings/io.js/2015-03-04.md
+++ b/meetings/io.js/2015-03-04.md
@@ -2,14 +2,14 @@
 
 ## Links
 
-* **Public YouTube feed**: http://www.youtube.com/watch?v=vxX2CkFPEtk
-* **Google Plus Event page**: https://plus.google.com/events/c9ijr7edl14im7dspk5njktmjq4
-* **GitHub Issue**: https://github.com/nodejs/io.js/issues/1053
-* **Original Minutes Google Doc**: https://docs.google.com/document/d/1RoIE68l8B2iWLdEPM7ApSN2FxFDd3OY0wfTeqUh-K9w
+* **Public YouTube feed**: <http://www.youtube.com/watch?v=vxX2CkFPEtk>
+* **Google Plus Event page**: <https://plus.google.com/events/c9ijr7edl14im7dspk5njktmjq4>
+* **GitHub Issue**: <https://github.com/nodejs/io.js/issues/1053>
+* **Original Minutes Google Doc**: <https://docs.google.com/document/d/1RoIE68l8B2iWLdEPM7ApSN2FxFDd3OY0wfTeqUh-K9w>
 
 ## Agenda
 
-Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeting.
 
 * lib: fix process.send() sync i/o regression [#774](https://github.com/nodejs/io.js/issues/774) / @bnoordhuis
 * iojs: introduce internal modules [#848](https://github.com/nodejs/io.js/issues/848) / @chrisdickinson / @trevnorris / (@vkurchatkin)
@@ -52,7 +52,7 @@ Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting
 * Implement unhandled rejection tracking [#758](https://github.com/nodejs/io.js/issues/758) / @rvagg / how can we help this land
 * Logo / Brand Treatment
   [website/181](https://github.com/nodejs/website/issues/181) @ mikeal
-  https://www.behance.net/gallery/23269525/IOJS-logo-concept
+  <https://www.behance.net/gallery/23269525/IOJS-logo-concept>
 * Stability Policy/Statement & Roadmap
   [#725](https://github.com/nodejs/io.js/issues/725) / @mikeal
   [roadmap/14](https://github.com/nodejs/roadmap/issues/14) / @mikeal

--- a/meetings/io.js/2015-03-18.md
+++ b/meetings/io.js/2015-03-18.md
@@ -2,14 +2,14 @@
 
 ## Links
 
-* **Public YouTube feed**: http://www.youtube.com/watch?v=tQwVcuYCiZ4
-* **Google Plus Event page**: https://plus.google.com/events/cneon2drmol62u4drm8aegjnrkk
-* **GitHub Issue**: https://github.com/nodejs/io.js/issues/1187
-* **Original Minutes Google Doc**: https://docs.google.com/document/d/1It6PTEBQ7OjW8P88hCLoXvcWKA3Q8dY2eYEHIF6FvS4
+* **Public YouTube feed**: <http://www.youtube.com/watch?v=tQwVcuYCiZ4>
+* **Google Plus Event page**: <https://plus.google.com/events/cneon2drmol62u4drm8aegjnrkk>
+* **GitHub Issue**: <https://github.com/nodejs/io.js/issues/1187>
+* **Original Minutes Google Doc**: <https://docs.google.com/document/d/1It6PTEBQ7OjW8P88hCLoXvcWKA3Q8dY2eYEHIF6FvS4>
 
 ## Agenda
 
-Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeting.
 
 * [#1134](https://github.com/nodejs/io.js/pull/1134) Add Docker working group
 * [#1140](https://github.com/nodejs/io.js/pull/1140) Revert stream base / @piscisaureus / merge policy questions
@@ -48,7 +48,7 @@ Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting
 ### [#1134](https://github.com/nodejs/io.js/pull/1134) Add Docker working group
 
 * Rod: originally conceived to be a “sub-WG” of Build WG but this makes sense because there is little overlap with the Build team or skills required for the Build team.
-* Rod: this group is already maintaining official Docker images or io.js located at https://github.com/nodejs/docker-iojs which are also the “official” Docker images for io.js.
+* Rod: this group is already maintaining official Docker images or io.js located at <https://github.com/nodejs/docker-iojs> which are also the “official” Docker images for io.js.
 
 ### [#1140](https://github.com/nodejs/io.js/pull/1140) Revert stream base / @piscisaureus / merge policy questions
 

--- a/meetings/io.js/2015-04-01.md
+++ b/meetings/io.js/2015-04-01.md
@@ -2,14 +2,14 @@
 
 ## Links
 
-* **Public YouTube feed**: http://www.youtube.com/watch?v=B1pTT60E73M
-* **Google Plus Event page**: https://plus.google.com/events/cneon2drmol62u4drm8aegjnrkk
-* **GitHub Issue**: https://github.com/nodejs/io.js/issues/1311
-* **Original Minutes Google Doc**: https://docs.google.com/document/d/1iEzSiQpB3me-x1R0_FzlMtGuPmgxR2x7NMITp779690
+* **Public YouTube feed**: <http://www.youtube.com/watch?v=B1pTT60E73M>
+* **Google Plus Event page**: <https://plus.google.com/events/cneon2drmol62u4drm8aegjnrkk>
+* **GitHub Issue**: <https://github.com/nodejs/io.js/issues/1311>
+* **Original Minutes Google Doc**: <https://docs.google.com/document/d/1iEzSiQpB3me-x1R0_FzlMtGuPmgxR2x7NMITp779690>
 
 ## Agenda
 
-Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeting.
 
 * reconciliation update (Mikeal and Bert)
 * doc: add NAN WG [#1226](https://github.com/nodejs/io.js/issues/1226)
@@ -53,7 +53,7 @@ Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting
 
 ### Reconciliation update (Mikeal and Bert)
 
-* Mikeal: getting close to a really good position where the governance structures can be merged between io.js and joyent/node. New working group structure and relationship with “TSC”. People can engage @ https://github.com/joyent/nodejs-advisory-board/ with active PRs @ https://github.com/joyent/nodejs-advisory-board/pull/30 & https://github.com/joyent/nodejs-advisory-board/pull/33
+* Mikeal: getting close to a really good position where the governance structures can be merged between io.js and joyent/node. New working group structure and relationship with “TSC”. People can engage @ <https://github.com/joyent/nodejs-advisory-board/> with active PRs @ <https://github.com/joyent/nodejs-advisory-board/pull/30> & <https://github.com/joyent/nodejs-advisory-board/pull/33>
 * Bert: discussed why this is good for io.js:
   - io.js still has a very low profile, merging would be good for everyone
   - budget from corporate backers, including the ability to travel

--- a/meetings/io.js/2015-04-08.md
+++ b/meetings/io.js/2015-04-08.md
@@ -2,18 +2,18 @@
 
 ## Links
 
-* **Public YouTube feed**: http://www.youtube.com/watch?v=OjlK8k10oyo
-* **Google Plus Event page**: https://plus.google.com/events/c1c3234uog6svplgrapqucb557k
-* **GitHub Issue**: https://github.com/nodejs/io.js/issues/1369
-* **Original Minutes Google Doc**: https://docs.google.com/document/d/1EsDjfRGpVKFABH4LcNXNxsAsBTnHsU-i5cehmAcp1A8
+* **Public YouTube feed**: <http://www.youtube.com/watch?v=OjlK8k10oyo>
+* **Google Plus Event page**: <https://plus.google.com/events/c1c3234uog6svplgrapqucb557k>
+* **GitHub Issue**: <https://github.com/nodejs/io.js/issues/1369>
+* **Original Minutes Google Doc**: <https://docs.google.com/document/d/1EsDjfRGpVKFABH4LcNXNxsAsBTnHsU-i5cehmAcp1A8>
 
 ## Agenda
 
-Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeting.
 
 * [#1101](https://github.com/nodejs/io.js/pull/1101) http: allow HTTP to return an HTTPS server / @silverwind / the use of a `tls` option to trigger `https` module functionality
 * [#1301](https://github.com/nodejs/io.js/pull/1301) Util(.is*) Deprecations / @Fishrock123 & @brendanashworth / [this comment](https://github.com/nodejs/io.js/pull/1301#issuecomment-90829575) asking for an opinion from the TC on how to move forward
-* Discuss https://github.com/jasnell/dev-policy [[comment by @mikeal]](https://github.com/nodejs/io.js/issues/1369#issuecomment-90955688)
+* Discuss <https://github.com/jasnell/dev-policy> [[comment by @mikeal]](https://github.com/nodejs/io.js/issues/1369#issuecomment-90955688)
 * Discuss / Review the `require(‘.’)` situation [[comments by @silverwind and @Fishrock123]](https://github.com/nodejs/io.js/issues/1369#issuecomment-90933134)
 
 ### Present

--- a/meetings/io.js/2015-04-15.md
+++ b/meetings/io.js/2015-04-15.md
@@ -2,14 +2,14 @@
 
 ## Links
 
-* **Public YouTube feed**: http://www.youtube.com/watch?v=lsRu_of0Xp8
-* **Google Plus Event page**: https://plus.google.com/events/cdinisa9mlisv81um91h71g3css
-* **GitHub Issue**: https://github.com/nodejs/io.js/issues/1431
-* **Original Minutes Google Doc**: https://docs.google.com/document/d/1zlYeYS0LCyIjN4KsjXh9d46hNjp302M6L1K_-_OckzQ
+* **Public YouTube feed**: <http://www.youtube.com/watch?v=lsRu_of0Xp8>
+* **Google Plus Event page**: <https://plus.google.com/events/cdinisa9mlisv81um91h71g3css>
+* **GitHub Issue**: <https://github.com/nodejs/io.js/issues/1431>
+* **Original Minutes Google Doc**: <https://docs.google.com/document/d/1zlYeYS0LCyIjN4KsjXh9d46hNjp302M6L1K_-_OckzQ>
 
 ## Agenda
 
-Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeting.
 
 * [#1393](https://github.com/nodejs/io.js/issues/1393) Ready to upgrade to V8 4.2?
 * [#1413](https://github.com/nodejs/io.js/issues/1413) combining TC and Node core call
@@ -54,7 +54,7 @@ Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting
   - Mikeal: there was a meeting where it was generally agreed that an ABI change would warrant a version bump
   - Rod & Isaac suggested that ABI changes shouldn’t bump major
   - Discussion came around to most members agreeing that ABI change _should_ bump major. Rod voted 0 on this, everyone else apparently +1.
-  - Discussed semver-major changes including process.send() sync regressions, agreed that https://github.com/nodejs/io.js/milestones/2.0.0 represents the best info on what’s mergable
+  - Discussed semver-major changes including process.send() sync regressions, agreed that <https://github.com/nodejs/io.js/milestones/2.0.0> represents the best info on what’s mergable
 * Discussed git, agreed that we should move back to master, Chris to handle git changes
 * Discussed RC build, could use nightly or next-nightly but officially link it off the website and maybe label it differently. Rod to figure this out.
 

--- a/meetings/io.js/2015-04-22.md
+++ b/meetings/io.js/2015-04-22.md
@@ -2,14 +2,14 @@
 
 ## Links
 
-* **Public YouTube feed**: http://www.youtube.com/watch?v=s7LIMsTFaps
-* **Google Plus Event page**: https://plus.google.com/events/co7i7pv2a51270jat7jvkfcue64
-* **GitHub Issue**: https://github.com/nodejs/io.js/issues/1502
-* **Original Minutes Google Doc**: https://docs.google.com/document/d/1G4aJ2OwiW2WphW7Vz2OW56VRot8xRBFitluKsuYPxk0
+* **Public YouTube feed**: <http://www.youtube.com/watch?v=s7LIMsTFaps>
+* **Google Plus Event page**: <https://plus.google.com/events/co7i7pv2a51270jat7jvkfcue64>
+* **GitHub Issue**: <https://github.com/nodejs/io.js/issues/1502>
+* **Original Minutes Google Doc**: <https://docs.google.com/document/d/1G4aJ2OwiW2WphW7Vz2OW56VRot8xRBFitluKsuYPxk0>
 
 ## Agenda
 
-Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeting.
 
 * [#1130](https://github.com/nodejs/io.js/issues/1130) Nominating Jeremiah Senkpiel @Fishrock123 to the TC
 * [#1481](https://github.com/nodejs/io.js/issues/1481) Nominating @mikeal to the TC
@@ -100,7 +100,7 @@ Rod: any other breaking changes worth discussing?
 
 Ben: process.send() ready but not merged, any objections? - no objections.
 
-Chris: https://github.com/nodejs/io.js/milestones/2.0.0 new label “land-on-master” to indicate PRs that are still targeting the v1.x branch.
+Chris: <https://github.com/nodejs/io.js/milestones/2.0.0> new label “land-on-master” to indicate PRs that are still targeting the v1.x branch.
 
 Ben & Bert discussed Ben’s possible timers rewrite - Ben implemented a heap and red-black tree in JS, turned out to be a bit faster but not complete yet and Ben has been distracted on other projects. **
 

--- a/meetings/io.js/2015-04-29.md
+++ b/meetings/io.js/2015-04-29.md
@@ -2,18 +2,18 @@
 
 ## Links
 
-* **Public YouTube feed**: http://www.youtube.com/watch?v=-e675TT4WEA
-* **Google Plus Event page**: https://plus.google.com/events/cei87pqnichrtt4qggbbo656bpk
-* **GitHub Issue**: https://github.com/nodejs/io.js/issues/1557
-* **Original Minutes Google Doc**: https://docs.google.com/document/d/1C9nfm_5EhNz1jifITbtQcnGBX4R9vktoZ9KsFiCU7sQ
+* **Public YouTube feed**: <http://www.youtube.com/watch?v=-e675TT4WEA>
+* **Google Plus Event page**: <https://plus.google.com/events/cei87pqnichrtt4qggbbo656bpk>
+* **GitHub Issue**: <https://github.com/nodejs/io.js/issues/1557>
+* **Original Minutes Google Doc**: <https://docs.google.com/document/d/1C9nfm_5EhNz1jifITbtQcnGBX4R9vktoZ9KsFiCU7sQ>
 
 ## Agenda
 
-Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting.
+Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeting.
 
 * Release Proposal: v2.0.0 [#1532](https://github.com/nodejs/io.js/pull/1532)
 * Forward-port from v1.x [#1559](https://github.com/nodejs/io.js/pull/1559)
-* Convergence plan (https://github.com/jasnell/dev-policy/pull/66)
+* Convergence plan (<https://github.com/jasnell/dev-policy/pull/66>)
 * Combined node.js/io.js TC/core call about convergence doc [#1413](https://github.com/nodejs/io.js/issues/1413)
 
 ### Present
@@ -75,7 +75,7 @@ Extracted from https://github.com/nodejs/io.js/labels/tc-agenda prior to meeting
 Chris, Trevor: discussion about how the `master` and `next` branches are used.
 
 * process.send changes will slip for v2.0
-* waiting for Petka’s comment and review on url changes (https://github.com/nodejs/io.js/pull/1561)
+* waiting for Petka’s comment and review on url changes (<https://github.com/nodejs/io.js/pull/1561>)
 * release 2.x asap (friday)
 
 After the release:
@@ -90,7 +90,7 @@ Discussed current plan for backporting patches to maintenance patches.
 
 * Consensus that we should give the “land in master and backport” plan a go and see how it works out.
 
-### Convergence plan (https://github.com/jasnell/dev-policy/pull/66)
+### Convergence plan (<https://github.com/jasnell/dev-policy/pull/66>)
 
 ### Combined node.js/io.js TC/core call [#1413](https://github.com/nodejs/io.js/issues/1413)
 

--- a/meetings/io.js/2015-05-13.md
+++ b/meetings/io.js/2015-05-13.md
@@ -2,14 +2,14 @@
 
 ## Links
 
-* **Public YouTube feed**: http://www.youtube.com/watch?v=UbYiFLf7MpU
-* **Google Plus Event page**: https://plus.google.com/events/cu606mlllfehl11u8kcj7q2407k
-* **GitHub Issue**: https://github.com/iojs/io.js/issues/1689
-* **Original Minutes Google Doc**: https://docs.google.com/document/d/15Y_kJlYm-8cIf-alniaqUWMM-TjGISCqLf40G3pv4sM
+* **Public YouTube feed**: <http://www.youtube.com/watch?v=UbYiFLf7MpU>
+* **Google Plus Event page**: <https://plus.google.com/events/cu606mlllfehl11u8kcj7q2407k>
+* **GitHub Issue**: <https://github.com/iojs/io.js/issues/1689>
+* **Original Minutes Google Doc**: <https://docs.google.com/document/d/15Y_kJlYm-8cIf-alniaqUWMM-TjGISCqLf40G3pv4sM>
 
 ## Agenda
 
-Extracted from https://github.com/iojs/io.js/labels/tc-agenda prior to meeting.
+Extracted from <https://github.com/iojs/io.js/labels/tc-agenda> prior to meeting.
 
 * V8 4.4 to remove indexed properties via external data [#1451](https://github.com/iojs/io.js/issues/1451)
 * NODE_PATH deprecation [#1627](https://github.com/iojs/io.js/issues/1627)
@@ -40,7 +40,7 @@ Extracted from https://github.com/iojs/io.js/labels/tc-agenda prior to meeting.
 * Bert: Played Keen, not much io.js stuff; last Monday met with James, Mikeal about convergence
 * Brian: looking over potential optimizations in the JS codebase, started working on a DNS resolver as a potential replacement for cares
 * Chris: fixing race conditions in the REPL, poking at adding Ctrl-R history searching to readline
-* Domenic: working with V8 team in Munich, working on v8-extras feature, putting large portions of things into snapshot to speed up startup and other things: https://groups.google.com/forum/#!topic/v8-users/D6FmTwlvCgk
+* Domenic: working with V8 team in Munich, working on v8-extras feature, putting large portions of things into snapshot to speed up startup and other things: <https://groups.google.com/forum/#!topic/v8-users/D6FmTwlvCgk>
 * Jeremiah: issue management, working on tooling for automatic dependency upgrades, see [#1688](https://github.com/iojs/io.js/pull/1688)
 * Mikeal: Foundation stuff, getting ducks in a row
 * Shigeki: holiday in JP, fix TLS bug involving edge-case, needs review
@@ -51,7 +51,7 @@ Extracted from https://github.com/iojs/io.js/labels/tc-agenda prior to meeting.
 
 * Release Proposal: v2.0.0 [#1532](https://github.com/iojs/io.js/pull/1532)
 * Forward-port from v1.x [#1559](https://github.com/iojs/io.js/pull/1559)
-* Convergence plan (https://github.com/jasnell/dev-policy/pull/66)
+* Convergence plan (<https://github.com/jasnell/dev-policy/pull/66>)
 * Combined node.js/io.js TC/core call [#1413](https://github.com/iojs/io.js/issues/1413)
 
 ## Minutes
@@ -71,7 +71,7 @@ Extracted from https://github.com/iojs/io.js/labels/tc-agenda prior to meeting.
 * Jeremiah: there was a suggestion to deprecate NODE_PATH entirely, debate is over deprecation or not, lots of people appear to be finding novel uses of it.
 * Domenic: maybe we should document it
 * Chris: it is documented, Googling shows that it’s been ingrained into the Node background, there’s lots of info out there about how it’s used
-* Domenic: https://iojs.org/api/modules.html#modules_loading_from_the_global_folders
+* Domenic: <https://iojs.org/api/modules.html#modules_loading_from_the_global_folders>
 * Mikeal: maybe write docs about how it exists but you shouldn’t use it
 
 **Action: Mikeal to open an issue to change the docs to talk about how you probably shouldn’t use them** (note: it might be as simple as styling!)
@@ -79,7 +79,7 @@ Extracted from https://github.com/iojs/io.js/labels/tc-agenda prior to meeting.
 ### Join the Node Foundation? [#1664](https://github.com/iojs/io.js/issues/1664)
 
 * Mikeal: Mostly a consensus in the issue about joining
-* Mikeal: Next step is to move the “iojs” org to “nodejs”, then move the convergence repo in to be “node” to be the new tip: https://github.com/jasnell/node.js-convergence
+* Mikeal: Next step is to move the “iojs” org to “nodejs”, then move the convergence repo in to be “node” to be the new tip: <https://github.com/jasnell/node.js-convergence>
 
 Lots of discussions about process and what needs to happen & when, Mikeal pushing for a vote to get the org moved.
 

--- a/meetings/node.js/2014-12-10.md
+++ b/meetings/node.js/2014-12-10.md
@@ -11,7 +11,7 @@ promoted from apprentice to core team members.
 
 The next stable release, 0.10.34, is imminent and should be available in the
 next few days. The only issue remaining is that recently libuv added an entry
-to the public API (see https://github.com/libuv/libuv/commit/9da5fd443ebc2c56a
+to the public API (see <https://github.com/libuv/libuv/commit/9da5fd443ebc2c56a>
 7f5946f0a1e04801b370a33). Node will need to find a way to not cause any
 problems for users who link node with a dynamic shared libuv.
 

--- a/meetings/node.js/2014-12-16.md
+++ b/meetings/node.js/2014-12-16.md
@@ -138,6 +138,6 @@ approximation/mistake and add any relevant info?).
 
 ### Planning of next core team meetings
 
-Every Tuesday, Chris Dickinson will send and e-mail to team@nodejs.org to ask
+Every Tuesday, Chris Dickinson will send and e-mail to <mailto:team@nodejs.org> to ask
 for things people want to discuss on the next core team meeting happening
 every Thursday.

--- a/meetings/node.js/2014-12-18.md
+++ b/meetings/node.js/2014-12-18.md
@@ -71,4 +71,4 @@ additional features like:
 ### nodebug.me command line version
 
 Chris Dickinson recently released a command line interface to its great
-http://nodebug.me/ issues/PRs triaging tool.
+<http://nodebug.me/> issues/PRs triaging tool.

--- a/meetings/node.js/2015-01-22.md
+++ b/meetings/node.js/2015-01-22.md
@@ -23,7 +23,7 @@ refactored to:
 - Update the .mailmap file with authors' email addresses.
 
 Julien has been assigned to this and work is in progress at
-https://github.com/joyent/node/pull/9088.
+<https://github.com/joyent/node/pull/9088>.
 
 Participants agreed that eventually the project should have more tooling to
 land changes from contributors and that these tools would also take care of

--- a/meetings/node.js/2015-01-29.md
+++ b/meetings/node.js/2015-01-29.md
@@ -22,7 +22,7 @@ than using SNI.
 
 Colin: has two bug fixes not API breaking that could go in for 0.11.16.
 
-TJ: Would like to put https://github.com/joyent/node/pull/8966 in v0.10. Colin
+TJ: Would like to put <https://github.com/joyent/node/pull/8966> in v0.10. Colin
 hasn't tried to rebase it on v0.10, but will do today.
 
 ## Building dependencies

--- a/meetings/node.js/2015-02-05.md
+++ b/meetings/node.js/2015-02-05.md
@@ -32,11 +32,11 @@ Wyatt: security page published.
 ### Post 0.12.0
 
 TJ: From now on, it would be nice if core team members would use
-https://github.com/joyent/git-apply-pr to land PRs/contributions. It's a work
+<https://github.com/joyent/git-apply-pr> to land PRs/contributions. It's a work
 in progress, bug fixes/improvements are more than welcome!
 
 TJ: We may discuss what to integrate from the core team working group of the
-Node.js Advisory Board (https://github.com/joyent/nodejs-advisory-board)
+Node.js Advisory Board (<https://github.com/joyent/nodejs-advisory-board>)
 during the next core team call.
 
 ### Testing downstream modules and applications

--- a/meetings/node.js/2015-02-19.md
+++ b/meetings/node.js/2015-02-19.md
@@ -22,17 +22,16 @@
 
 * Robert Kowalski
   * Progress:
-    * I fixed the bad merge for https://github.com/joyent/node-documentation-
+    * I fixed the bad merge for <https://github.com/joyent/node-documentation>-
     generator and will continue to work on it, next items are .markdown
     support and sending a PR to node and node-website to make use of the
     module.
 
-    * It is [not possible any more to accidentally deploy an outdated version of
-    the website](https://github.com/joyent/node-website/commit/dc1ab6f2037a9005d7fc44e73001bf9067e25d5b).
+    * It is [not possible any more to accidentally deploy an outdated version of the website](https://github.com/joyent/node-website/commit/dc1ab6f2037a9005d7fc44e73001bf9067e25d5b).
 
   * Blocked by:
-    * I'm still waiting for a fixed SSl Cert for https://blog.nodejs.org/ to
-    continue with https://github.com/joyent/node-website/issues/68.
+    * I'm still waiting for a fixed SSl Cert for <https://blog.nodejs.org/> to
+    continue with <https://github.com/joyent/node-website/issues/68>.
 
 ## Current state of v0.12.0
 
@@ -45,16 +44,16 @@ Trevor: Yes, I'm currently investigating.
 
 #### V8 max_old_space issue
 
-See https://github.com/joyent/node/pull/9200#issuecomment-75001656.
+See <https://github.com/joyent/node/pull/9200#issuecomment-75001656>.
 
 TJ: We'll float the patch as it's pretty uncontroversial.
 
 #### VM module
 
-See https://github.com/joyent/node/issues/9084.
+See <https://github.com/joyent/node/issues/9084>.
 
 TJ: would like to reboot the VM module. Will do a writeup in
-https://github.com/joyent/node/issues/9084. Who would like to work on
+<https://github.com/joyent/node/issues/9084>. Who would like to work on
 implementing the proposed enhancements?
 
 Colin: I would like to work on this.
@@ -63,14 +62,14 @@ TJ: alright!
 
 #### let issue
 
-See https://github.com/joyent/node/issues/9113.
+See <https://github.com/joyent/node/issues/9113>.
 
 TJ: This one should be able to be debugged with only d8 to identify if and
 what version of V8 introduced the bug.
 
 ### node::Makecallback issue
 
-See https://github.com/joyent/node/issues/9245.
+See <https://github.com/joyent/node/issues/9245>.
 
 Trevor: there's a case with some developers add-on where calling
 `MakeCallback` processes next tick callbacks. I'm working on a fix that would
@@ -78,7 +77,7 @@ make calling MakeCallback safe in every case.
 
 ### Security issue with shared OpenSSL
 
-See https://github.com/nodejs/node/pull/800.
+See <https://github.com/nodejs/node/pull/800>.
 
 ### --abort-on-uncaught-exception and domains
 
@@ -86,24 +85,24 @@ Colin: abort on uncaught exception fix hasn't been forward ported to 0.12.0,
 so that prevents us from upgrading to 0.12.0.
 
 Julien: There's an issue in the 0.12.1 milestone that tracks this. See
-https://github.com/joyent/node/issues/8877.
+<https://github.com/joyent/node/issues/8877>.
 
 ### Installer on Windows not updating PATH
 
-See https://github.com/joyent/node/issues/4356.
+See <https://github.com/joyent/node/issues/4356>.
 
 Alexis: issue with installer on Windows. Julien: fixed in io.js. Alexis: I
 will take care of this.
 
 ### TCP_NODELAY issue
 
-See https://github.com/joyent/node/issues/9235.
+See <https://github.com/joyent/node/issues/9235>.
 
 Michael Dawson: I have a candidate for a patch, would like to get feedback on that.
 
 ### test-http-destroyed-socket-write2.js failing on AIX
 
-See https://github.com/joyent/node/issues/9234.
+See <https://github.com/joyent/node/issues/9234>.
 
 Michael Dawson: I also have a patch for that, feedback wanted.
 
@@ -124,7 +123,7 @@ Bradley Meck, TJ and Steven Loomis will discuss bundles and resources today.
 ## Issues triaging and general workflow
 
 Julien: I submitted a proposal to improve our workflow here:
-https://gist.github.com/misterdjules/50d78ed4b0c5a156edd1.
+<https://gist.github.com/misterdjules/50d78ed4b0c5a156edd1>.
 
 Steven: It would be nice to know what's the focus on a release, so that we
 know what issues to put in the next milestones.
@@ -141,7 +140,7 @@ TJ: call tomorrow to discuss the proposal sent by Julien.
 
 ## libuv upgrade
 
-See https://github.com/joyent/node/pull/9179.
+See <https://github.com/joyent/node/pull/9179>.
 
 TJ: Caveats in the GitHub issue are the only concerns that I have. enum/int
 ABI issue, not sure if it's an actual issue or not. Would like to get more

--- a/meetings/node.js/2015-02-26.md
+++ b/meetings/node.js/2015-02-26.md
@@ -25,7 +25,7 @@ going to set this up.
 
 Steven Loomis mentioned there was a suggestion to delivery to an npm.
 Attendees seemed to like this idea and discussion will be carried forward in
-https://github.com/joyent/node/pull/9091.
+<https://github.com/joyent/node/pull/9091>.
 
 ### Website updates
 

--- a/meetings/node.js/2015-03-12.md
+++ b/meetings/node.js/2015-03-12.md
@@ -16,7 +16,7 @@
 #### v0.10.37
 
 Julien: All binaries, files and tarballs are available at
-https://nodejs.org/dist/v0.10.37. I'm currently coordinating with people from
+<https://nodejs.org/dist/v0.10.37>. I'm currently coordinating with people from
 Heroku and New Relic to have it tested. Once I hear back from them, we can
 make the announcement.
 
@@ -41,7 +41,7 @@ Julien: Discussion around floating patches on top of 1.4.0 or waiting for
 TJ,Trevor: Upgrade to the latest 1.4.x, float patches and rerun the tests.
 
 Trevor: We should probably make sure to integrate
-https://github.com/joyent/node/issues/9342.
+<https://github.com/joyent/node/issues/9342>.
 
 ##### V8 "lateral" upgrade
 
@@ -64,10 +64,10 @@ TJ will provision a FreeBSD server for Trevor to take a look at this issue.
 
 ##### Other issues
 
-Michael: https://github.com/joyent/node/issues/9317, I will create a PR for
+Michael: <https://github.com/joyent/node/issues/9317>, I will create a PR for
 that.
 
-Michael: https://github.com/joyent/node/issues/9334, I'll take a look at the
+Michael: <https://github.com/joyent/node/issues/9334>, I'll take a look at the
 comments.
 
 ##### VM module
@@ -83,7 +83,7 @@ Michael: We are well into our testing cycle for v0.12.0 on power.
 Michael: How open are we to floating patches on V8? For instance, issue
 with profiler performance.
 
-Steven: Also https://code.google.com/p/v8/issues/detail?id=3348.
+Steven: Also <https://code.google.com/p/v8/issues/detail?id=3348>.
 
 TJ: We're going to have more scenarios where we need to float patches. We need
 a way to manage a queue of patches (e.g quilt). Long term solution: have a
@@ -97,7 +97,7 @@ TJ: Problem with having our own forks is not every dependency uses Git.
 ### Leap second
 
 Steven: started an FAQ on leap seconds:
-https://gist.github.com/srl295/e74710ae42e8d13b96e7.
+<https://gist.github.com/srl295/e74710ae42e8d13b96e7>.
 
 TJ: Does faketime have a way to "simulate leap seconds"?
 

--- a/meetings/node.js/2015-03-26.md
+++ b/meetings/node.js/2015-03-26.md
@@ -26,8 +26,8 @@ would work well to help the work done by the foundation.
 Michael: We'd like to have tools to make sure there's no performance
 regression between releases.
 
-Michael: We could use https://github.com/acmeair/acmeair, and there's a
-Node.js version: https://github.com/acmeair/acmeair-nodejs.
+Michael: We could use <https://github.com/acmeair/acmeair>, and there's a
+Node.js version: <https://github.com/acmeair/acmeair-nodejs>.
 
 Michael: Have talked to maintainer of acme-air and they are willing to
 collaborate, we could also get them to give us an intro to the benchmark if
@@ -101,17 +101,17 @@ patches.
 ### v0.12.2
 
 Julien: New P-1 issue added: debugger is very slow, takes 1 or 2 minutes to do
-basic operations, see https://github.com/joyent/node/issues/9125 for more
+basic operations, see <https://github.com/joyent/node/issues/9125> for more
 information.
 
 Trevor: There's a major issue with buffer
-(https://github.com/joyent/node/issues/9180) that causes asserts for a lot of
+(<https://github.com/joyent/node/issues/9180>) that causes asserts for a lot of
 users, can we get a v0.12.2 release asap with the current state of v0.12, and
 move everything else from the 0.12.2 milestone to 0.12.3?
 
 Julien: We may also want to add an upgrade to npm 2.7.3 for this release.
 
-Trevor: See also https://github.com/joyent/node/issues/14165.
+Trevor: See also <https://github.com/joyent/node/issues/14165>.
 
 No objection from anyone.
 
@@ -141,8 +141,8 @@ James: Can start the conversation with a proposal of improvements.
 
 TJ: We'll have a new single certificate with support for subdomains.
 
-Robert: Need some feedback on https://github.com/joyent/node-
+Robert: Need some feedback on <https://github.com/joyent/node>-
 website/issues/81.
 
-Robert: Made changes to the license here: https://github.com/joyent/node-
+Robert: Made changes to the license here: <https://github.com/joyent/node>-
 website/pull/93.

--- a/meetings/node.js/2015-04-24.md
+++ b/meetings/node.js/2015-04-24.md
@@ -16,7 +16,7 @@
 
 Discussion around removal of RC4 to address Bar Mitzva attack.  Progress
 being made, need to update to clarify precedence of command line
-options (https://github.com/joyent/node/pull/19148), update code/tests to
+options (<https://github.com/joyent/node/pull/19148>), update code/tests to
 match this description (James), finalize release notes (Julien with input from all)
 and then do one final review before release (all).   Important that we add
 tests to make sure merge with 0.12.X can be easily validated.

--- a/meetings/node.js/2015-04-30.md
+++ b/meetings/node.js/2015-04-30.md
@@ -24,13 +24,13 @@ Julien: Will review as soon as possible.
 
 ##### TLS default ciphers not used if ciphers null or undefined
 
-Julien: See https://github.com/joyent/node/pull/23947. This must probably be
+Julien: See <https://github.com/joyent/node/pull/23947>. This must probably be
 considered before releasing the other changes to the default ciphers lists
 that have already landed in v0.10.
 
 ##### Timer fixes
 
-Julien: Current PR here: https://github.com/joyent/node/pull/17203.
+Julien: Current PR here: <https://github.com/joyent/node/pull/17203>.
 
 Julien: Need more feedback on whether to land this in v0.10.39. Recent changes
 to the timers module broke a lot of users in the past few v0.10.x releases, so
@@ -41,9 +41,9 @@ though.
 
 ##### V8 lateral upgrade and other V8 fixes
 
-Julien: https://github.com/joyent/node/pull/18206 landed, as well as the
+Julien: <https://github.com/joyent/node/pull/18206> landed, as well as the
 floating patch to fix let bindings in for loops
-(https://github.com/joyent/node/pull/23948).
+(<https://github.com/joyent/node/pull/23948>).
 
 ##### Upgrade npm to 2.8.4
 
@@ -58,7 +58,7 @@ Michael: We could probably create a Jenkins job to run the test-npm make target.
 
 Colin: This issue was reported a while ago, and we probably need to make a
 decision about it sooner than later:
-https://github.com/joyent/node/issues/9195.
+<https://github.com/joyent/node/issues/9195>.
 
 James: I would suggest updating the docs in 0.12, and wait to have more input
 to maybe make a change in behavior on master.
@@ -67,7 +67,7 @@ Colin and ALL: agreed.
 
 ### Convergence plan
 
-James: Initial convergance plan: https://github.com/jasnell/dev-policy/pull/66.
+James: Initial convergance plan: <https://github.com/jasnell/dev-policy/pull/66>.
 
 James: nothing set in stone. Current plan:
 

--- a/meetings/node.js/2015-05-07.md
+++ b/meetings/node.js/2015-05-07.md
@@ -45,11 +45,11 @@ the API/ABI, to determine if we want this in the next release.
 
 Julien: Identified 5 different PRs that we could land before the release.
 Most of them already reviewed, we can land them pretty soon.
-https://github.com/joyent/node/pull/8875
-https://github.com/joyent/node/pull/9448
-https://github.com/joyent/node/issues/25137
-https://github.com/joyent/node/pull/25100
-https://github.com/joyent/node/pull/14193
+<https://github.com/joyent/node/pull/8875>
+<https://github.com/joyent/node/pull/9448>
+<https://github.com/joyent/node/issues/25137>
+<https://github.com/joyent/node/pull/25100>
+<https://github.com/joyent/node/pull/14193>
 
 Another issue was with inconsistency of styles of invocations of makeCallback.
 Trevor working on it. Might not make it for the next 0.12 release.
@@ -70,12 +70,12 @@ Alexis: motivation for urgency?
 
 Julien:
 - v8 lateral upgrade. A lot of impact on users.
-  https://github.com/joyent/node/pull/18206
+  <https://github.com/joyent/node/pull/18206>
 - Fixes on freeBSD
-  https://github.com/joyent/node/pull/14819
-  https://github.com/joyent/node/issues/8540
+  <https://github.com/joyent/node/pull/14819>
+  <https://github.com/joyent/node/issues/8540>
 
-Colin: can we land this too? https://github.com/joyent/node/pull/9159
+Colin: can we land this too? <https://github.com/joyent/node/pull/9159>
 
 Michael: Christian is away for a couple weeks. I will need to take over one of
 the PRs on the list.
@@ -89,18 +89,18 @@ James: once RC4 issues are fixed in 0.12, we should be able to land them in
 Julien: start in 0.10.39, then port to 0.12.
 
 Julien: Alexis, your PR should be added to to the 0.10.39 milestone.
-https://github.com/joyent/node/pull/25100
+<https://github.com/joyent/node/pull/25100>
 
 Julien:
 For 10.39, there's also a fix for timers:
-https://github.com/joyent/node/pull/17203
+<https://github.com/joyent/node/pull/17203>
 First fix was already reviewed. Then I submitted a simpler fix. Looking for a
 second review.
 It shouldn't hold up the release, but it should be pretty safe and it fixes
 some annoying issues.
 
 ### Flaky tests support
-Alexis: io.js removed support for flaky tests. https://github.com/nodejs/node/pull/812
+Alexis: io.js removed support for flaky tests. <https://github.com/nodejs/node/pull/812>
 It looks like this issue might be slightly controversial.
 I am guessing they thought it was a mechanism for ignoring test failures in
 general, while it is only meant to support the automatic merge in

--- a/meetings/node.js/2015-05-21.md
+++ b/meetings/node.js/2015-05-21.md
@@ -12,7 +12,7 @@
 #### v0.12.4
 Looking to do a 0.12.4 release soon, end of this week or early next week to address:
 
-* breaking v8 change https://github.com/joyent/node/issues/25324 - have PR ready
+* breaking v8 change <https://github.com/joyent/node/issues/25324> - have PR ready
 * Windows XP issues, have pull request from io.js, ready to pull over
 
 James also has RC4/Bar Mitzvah fix ready to go back in as well
@@ -22,7 +22,7 @@ If time permits Alexis will do more investigation to identify what caused the XP
 ### npm testing
 
 Michael: update to npm 2.8.4 broke our test-npm target.  PR to fix is here:
-https://github.com/joyent/node/issues/25290.  Previously you could run tests without
+<https://github.com/joyent/node/issues/25290>.  Previously you could run tests without
 install but now install is required or tests don't run.
 
 Julien: we shoul talk with npm team on how to make sure the best way to run the tests
@@ -56,7 +56,7 @@ complex issue so Alexis will open an issue on github (in the LTS repo) to discus
 
 ### Logjam
 
-https://weakdh.org/
+<https://weakdh.org/>
 
 James/Julien had run tools provided in report against Node 0.10.X and 0.12.X and they don't report an
 issue so its only the second part which applies.  This is related to allowing short key lengths.


### PR DESCRIPTION
- Angle bracket explicit urls
- Add mailto to email links in addition to angle brackets