### PR TITLE
chore: format all markdown docs

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -9,14 +9,14 @@ invalid and are superseded by the TSC Charter.
 ## Onboarding
 
 * Confirm that the new member has read, understands, and agrees to uphold the
-  [Code of Conduct](https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md).
+  [Code of Conduct](https://github.com/nodejs/admin/blob/master/CODE\_OF\_CONDUCT.md).
 * Add the new member to the `@nodejs/tsc` and `@nodejs/security-tsc` teams.
 * Change the new member's role in the GitHub `nodejs` organization to `Owner`.
 * Add them to the `@nodejs-private` org and with an `Owner` role.
 * Add them to the `@nodejs-private/security-tsc` team.
 * Add them to the `@pkgjs` org and with an `Owner` role.
 * Add them to the `@pkgjs/node-tsc` team.
-* Invite them to the HackerOne [Node.js team](https://hackerone.com/nodejs/team_members).
+* Invite them to the HackerOne [Node.js team](https://hackerone.com/nodejs/team\_members).
 * Add them to the `tsc` and `crypto-export` mailing lists.
 * Update the `@nodejs/node` repository README to reflect membership in the TSC.
 * Update <https://github.com/nodejs/create-node-meeting-artifacts/blob/master/templates/invited_tsc> and <https://github.com/nodejs/create-node-meeting-artifacts/blob/master/templates/observers_tsc> to reflect membership in the TSC.
@@ -24,7 +24,7 @@ invalid and are superseded by the TSC Charter.
 ## Offboarding
 
 * Remove the member from the `@nodejs/tsc` and `@nodejs/security-tsc` teams.
-* Remove them from the HackerOne [Node.js team](https://hackerone.com/nodejs/team_members).
+* Remove them from the HackerOne [Node.js team](https://hackerone.com/nodejs/team\_members).
 * Change the member's role in the GitHub `nodejs` organization to `Member`
   unless they have `Owner` role for a reason other than TSC membership.
 * Remove them from the `@nodejs-private/security-tsc` team.

--- a/OpenSSL-Strategy.md
+++ b/OpenSSL-Strategy.md
@@ -51,7 +51,7 @@ For Node.js >= 10.16.0:
 * OpenSSL version: 1.1.1
 * Allowed shared OpenSSL version: 1.1.0 or 1.1.1
 * Default minimum TLS version is TLSv1, default maximum is TLSv1.2. It is
-  expected that TLS1.3 support will be backported to 10.x, but it will *not* be
+  expected that TLS1.3 support will be backported to 10.x, but it will _not_ be
   supported by default, only by explicit run-time configuration.
 * FIPS: not supported
 
@@ -102,7 +102,7 @@ For Node.js >= 11.9.0:
 * OpenSSL version: 1.1.0
 * Allowed shared OpenSSL version: 1.1.0 or 1.1.1
 * Default minimum TLS version is TLSv1, default maximum is TLSv1.2. It is
-  expected that TLS1.3 support will be backported to 11.x, but it will *not* be
+  expected that TLS1.3 support will be backported to 11.x, but it will _not_ be
   supported by default, only by explicit run-time configuration.
 * FIPS: not supported
 
@@ -111,7 +111,7 @@ For Node.js >= 11.9.0:
 * OpenSSL version: 1.1.1
 * Allowed shared OpenSSL version: 1.1.1
 * Default minimum TLS version is TLSv1.2, default maximum is TLSv1.3. TLSv1
-  and TLSv1.1 are *not* supported by default, only by explicit run-time
+  and TLSv1.1 are _not_ supported by default, only by explicit run-time
   configuration.
 * FIPS: not supported
 
@@ -124,13 +124,13 @@ Node.js EOL dates:
 ## Node.js version 15.x (est. Oct 2020) (EOL Jun 2021)
 
 * quictls/OpenSSL version: 1.1.1+quic
-Node.js currently uses a temporary OpenSSL fork, which closely tracks the main
-openssl/openssl releases with the addition of APIs to support the QUIC protocol.
-Details on the fork, as well as the latest sources, can be found at
-<https://github.com/quictls/openssl>.
+  Node.js currently uses a temporary OpenSSL fork, which closely tracks the main
+  openssl/openssl releases with the addition of APIs to support the QUIC protocol.
+  Details on the fork, as well as the latest sources, can be found at
+  <https://github.com/quictls/openssl>.
 * Allowed shared OpenSSL version: 1.1.1
 * Default minimum TLS version is TLSv1.2, default maximum is TLSv1.3. TLSv1
-  and TLSv1.1 are *not* supported by default, only by explicit run-time
+  and TLSv1.1 are _not_ supported by default, only by explicit run-time
   configuration.
 * FIPS: not supported
 
@@ -142,14 +142,14 @@ of 15.x (which is only about 8 months), that experimental support for OpenSSL
 ## Node.js version 16.x (est Apr 2021) (EOL Apr 2024)
 
 * quictls/OpenSSL version: openssl-3.0.0+quic
-Node.js currently uses a temporary OpenSSL fork, which closely tracks the main
-openssl/openssl releases with the addition of APIs to support the QUIC protocol.
-This will be used until OpenSSL releases support for the QUIC protocol. Details
-on the fork, as well as the latest sources, can be found at
-<https://github.com/quictls/openssl>.
+  Node.js currently uses a temporary OpenSSL fork, which closely tracks the main
+  openssl/openssl releases with the addition of APIs to support the QUIC protocol.
+  This will be used until OpenSSL releases support for the QUIC protocol. Details
+  on the fork, as well as the latest sources, can be found at
+  <https://github.com/quictls/openssl>.
 * Allowed shared OpenSSL version: 3.0.0, 3.0.0+quic, 1.1.1, 1.1.1+quic
 * Default minimum TLS version is TLSv1.2, default maximum is TLSv1.3. TLSv1
-  and TLSv1.1 are *not* supported by default, only by explicit run-time
+  and TLSv1.1 are _not_ supported by default, only by explicit run-time
   configuration.
 * FIPS: unpredictable, see below
 
@@ -166,19 +166,19 @@ building against OpenSSL 1.1.1 out-of-tree, even if OpenSSL 3.x was in-tree.
 The plan described above is to:
 
 * Once OpenSSL has been updated with support for the QUIC protocol replace the
-temporary quictls/openssl depencency with it.
+  temporary quictls/openssl depencency with it.
 
 Challenges are:
 
 1. OpenSSL 3.x moved many algorithms into a legacy library, that is only
-  accessible as a dynamically loaded provider, so cannot ship with Node.js
+   accessible as a dynamically loaded provider, so cannot ship with Node.js
 2. Node.js has a build system wrapped around OpenSSL 1.1.1, it is currently
-  incompatible with the OpenSSL 3.x build system (effort to fix this is
-  unknown).
+   incompatible with the OpenSSL 3.x build system (effort to fix this is
+   unknown).
 3. OpenSSL 3.x has compile-time warning-deprecated a number of OpenSSL 1.1.1
-  APIs, but the alternatives to those deprecated APIs do not exist in OpenSSL
-  1.1.1. So, Node.js 16.x either needs to ship calling deprecated APIs, or
-  break compatibility with OpenSSL 1.1.1 (so it will _only build with 3.x_).
+   APIs, but the alternatives to those deprecated APIs do not exist in OpenSSL
+   1.1.1. So, Node.js 16.x either needs to ship calling deprecated APIs, or
+   break compatibility with OpenSSL 1.1.1 (so it will _only build with 3.x_).
 
 Tracking issue: <https://github.com/nodejs/node/issues/29817>
 
@@ -197,7 +197,7 @@ for more information about OpenSSL-compatible libraries.
 
 Shared OpenSSL libraries will lack our floating patches, and may also not be the
 latest OpenSSL patch release. Node.js supports being configured to build against
-a shared OpenSSL library. Node.js does *not* support the resulting Node.js
+a shared OpenSSL library. Node.js does _not_ support the resulting Node.js
 binaries built with this non-default configuration, doing so is the
 responsibility of the distributor.
 
@@ -241,7 +241,7 @@ Currently, there are three supported versions of OpenSSL as per the
 * Version 1.1.0: supported until 2019-09-11, not a LTS release line
 * Version 1.1.1: supported until 2023-09-11, designated Long-term Support (LTS)
 * Version 3.0.0: first release: Q4 2020 (estimated), designation as LTS:
-  *unknown*
+  _unknown_
 
 ### OpenSSL 1.0.2 and FIPS
 
@@ -253,7 +253,7 @@ be the support timeframe for Node.js version 8 (2020-04), the version 8.x EOL
 date has been [contracted](https://github.com/nodejs/release#release-schedule)
 to coincide with the OpenSSL 1.0.2 EOL date at the end of 2019.
 
-[Federal Information Processing Standard](https://en.wikipedia.org/wiki/FIPS_140-2),
+[Federal Information Processing Standard](https://en.wikipedia.org/wiki/FIPS\_140-2),
 "FIPS", is managed by the NIST.  Publication 140-2 is a US government standard
 used to approve cryptographic software.
 
@@ -281,7 +281,7 @@ means that Node.js 6.x and 8.x are the only versions of Node.js that currently
 support FIPS.
 
 In particular, note  that Node.js 10.x, the most recent Node.js LTS release
-line, does not and *will not* support FIPS.
+line, does not and _will not_ support FIPS.
 
 Aside from some manual configuration that is
 required in order to support GYP builds (instead of the Perl-based Configure
@@ -338,7 +338,7 @@ support TLS 1.3, however Node.js' TLS1.3 support requires at least OpenSSL
 
 The next release of OpenSSL will be 3.0.0. It is skipping 2.0 because that
 version has been used for OpenSSL FIPS. It is a major re-architecting, and while
-it is expected to be API compatible with OpenSSL 1.1.1, it is *not* expected to
+it is expected to be API compatible with OpenSSL 1.1.1, it is _not_ expected to
 be ABI compatible, re-compilation will be necessary to upgrade from OpenSSL
 1.1.1 to 3.0.0.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ responsibilities as defined below.
 
 ### Node.js Core
 
-*Node.js Core* is defined as the contents of the repository located at
+_Node.js Core_ is defined as the contents of the repository located at
 <https://github.com/nodejs/node> from which the `node` executable and associated
 packages are built, excluding the vendored projects included in the codebase
 located in the [deps][] and [tools][] directories that are copied in from
@@ -150,7 +150,7 @@ To request access, [open an issue](https://github.com/nodejs/TSC/issues/new).
 
 ## Working Groups
 
-* [Working Groups](WORKING_GROUPS.md)
+* [Working Groups](WORKING\_GROUPS.md)
 
 ## Policy change proposal process
 

--- a/Security-Team.md
+++ b/Security-Team.md
@@ -15,13 +15,13 @@ that aren't appropriate for public availability.
 The policy for inclusion is as follows:
 
 1. All members of @nodejs/TSC have access to private security reports and
-  private patches.
+   private patches.
 2. Members of the @nodejs/releasers team
-  have access to private security patches in order to produce releases.
+   have access to private security patches in order to produce releases.
 3. On a case-by-case basis, individuals outside the Technical Steering
-  Committee are invited by the TSC to have access to private security reports
-  or private patches so that their expertise can be applied to an issue or
-  patch. This access may be temporary or permanent, as decided by the TSC.
+   Committee are invited by the TSC to have access to private security reports
+   or private patches so that their expertise can be applied to an issue or
+   patch. This access may be temporary or permanent, as decided by the TSC.
 
 Membership on the security teams can be requested via an issue in the TSC repo.
 
@@ -62,7 +62,7 @@ These non-TSC and TSC Emeriti also have access:
 * [vdeturckheim](https://github.com/vdeturckheim) - **Vladimir de Turckheim**
 * [@watson](https://github.com/watson) - **Thomas Watson**
 
-List is from the [member page](https://hackerone.com/nodejs/team_members) for
+List is from the [member page](https://hackerone.com/nodejs/team\_members) for
 the Node.js program on HackerOne.
 
 ## Team with access to private security patches to Node.js
@@ -114,52 +114,52 @@ Report states are described in HackerOne [docs](https://docs.hackerone.com/progr
 The expected workflow for issues reported to Node.js is:
 
 1. `NEW`: issue reported (initial state).  Issues in this state are in the
-    process of being analyzed with the intention to move them into either
-    `TRIAGED`, `NEEDS-MORE-INFO`, or one of the "Closed" states
-    (`NOT-APPLICABLE`, `INFORMATIVE`, etc.). Has several sub-states:
-    1. `H1 Triage`: Issues start off assigned to the `H1 Triage` team. That team
+   process of being analyzed with the intention to move them into either
+   `TRIAGED`, `NEEDS-MORE-INFO`, or one of the "Closed" states
+   (`NOT-APPLICABLE`, `INFORMATIVE`, etc.). Has several sub-states:
+   1. `H1 Triage`: Issues start off assigned to the `H1 Triage` team. That team
       does initial triage. They ask for a runnable reproduction, they run it,
       and they verify whether it does in fact appear to demonstrate a
       vulnerability that has not already been reported. Once this is done, they
       assign the issue to the `Node.js Team`.
-    2. `Node.js Team`: Issues assigned by `H1 Triage`, or issues that Node.js
+   2. `Node.js Team`: Issues assigned by `H1 Triage`, or issues that Node.js
       assigns to itself for triage preemptively (perhaps because of priority, or
       because its disposition is obvious, or any other reason we decide to
       skip the `H1 Team`'s reproduction).
-    3. `NEEDS-MORE-INFO`: In the state of back-and-forth with reporter.
+   3. `NEEDS-MORE-INFO`: In the state of back-and-forth with reporter.
       When further progress on the issue is blocked on response from the reporter,
       this is the state.
 2. `TRIAGED`: State for an issue when it is a non-duplicate and resolvable.
-    Issues in this state are waiting for the Node.js team to take some action to
-    resolve them. Typically, this would be publishing a Node.js release that
-    resolves the issue, but it could also be publishing documentation, or making
-    a configuration change to our infrastructure for a <https://nodejs.org>
-    problem. The expected resolution should be described in a comment on the
-    issue when it is moved to `TRIAGED`.
-    * ...: There are no explicit states for an issue as it is in process of
-    getting resolved. Comments on the issue when someone is working on it are
-    useful, as is assignment of the issue to a person who agrees to be
-    responsible for following it through to resolution and disclosure.
-    * Once a fix is ready for release, the issue should be assigned to the
-    `Ready for release` team, and a comment added indicating the relevant PRs that
-    need to be merged during the release process.
+   Issues in this state are waiting for the Node.js team to take some action to
+   resolve them. Typically, this would be publishing a Node.js release that
+   resolves the issue, but it could also be publishing documentation, or making
+   a configuration change to our infrastructure for a <https://nodejs.org>
+   problem. The expected resolution should be described in a comment on the
+   issue when it is moved to `TRIAGED`.
+   * ...: There are no explicit states for an issue as it is in process of
+     getting resolved. Comments on the issue when someone is working on it are
+     useful, as is assignment of the issue to a person who agrees to be
+     responsible for following it through to resolution and disclosure.
+   * Once a fix is ready for release, the issue should be assigned to the
+     `Ready for release` team, and a comment added indicating the relevant PRs that
+     need to be merged during the release process.
 3. `RESOLVED`: State for an issue that has had a fix published. Issues in this
-    state should be disclosed.
+   state should be disclosed.
 4. ...: Final states for issues that we will not fix:
-    * `NOT-APPLICABLE`: We do not agree this a vulnerability. We can request
-    that the reporter close it to preserve their H1 "reputation points".  If
-    it is an issue, though not a vulnerability, we can suggest that it be
-    reported to the Node.js issue tracker.
-    * `INFORMATIVE`: This means we agree that the report contains useful
-    information, but we don't intend to publish a fix. This might be because
-    it isn't possible, or because its in an unsupported API or version. We
-    can consider disclosing it if we  think the information should be
-    publicized.
-    * `DUPLICATE`: The report is a duplicate of an already reported issue. It
-    should not need disclosure, because the original issue will be disclosed
-    after it is resolved.
-    * `SPAM`: Self-explanatory (and rare).
+   * `NOT-APPLICABLE`: We do not agree this a vulnerability. We can request
+     that the reporter close it to preserve their H1 "reputation points".  If
+     it is an issue, though not a vulnerability, we can suggest that it be
+     reported to the Node.js issue tracker.
+   * `INFORMATIVE`: This means we agree that the report contains useful
+     information, but we don't intend to publish a fix. This might be because
+     it isn't possible, or because its in an unsupported API or version. We
+     can consider disclosing it if we  think the information should be
+     publicized.
+   * `DUPLICATE`: The report is a duplicate of an already reported issue. It
+     should not need disclosure, because the original issue will be disclosed
+     after it is resolved.
+   * `SPAM`: Self-explanatory (and rare).
 5. Disclosure: This not a HackerOne report state, but it is the final state
-    from our perspective. Disclosure should be considered once an issue is
-    closed. See the
-    [disclosure docs](https://docs.hackerone.com/programs/disclosure.html).
+   from our perspective. Disclosure should be considered once an issue is
+   closed. See the
+   [disclosure docs](https://docs.hackerone.com/programs/disclosure.html).

--- a/Streaming/Streaming-To-Youtube.md
+++ b/Streaming/Streaming-To-Youtube.md
@@ -9,7 +9,7 @@ The Zoom user ID is `nodejs-meetings@linuxfoundation.org`, the password needs
 to be communicated privately, ask the TSC Chair.
 
 Your YouTube Account must be a manager of the
-[Node.js YouTube account](https://www.youtube.com/channel/UCQPYJluYC_sn_Qz_XE-YbTQ).
+[Node.js YouTube account](https://www.youtube.com/channel/UCQPYJluYC\_sn\_Qz\_XE-YbTQ).
 Ask the TSC Chair or foundation managers (Amanda Ennis, Brian Warner, Rachel
 Romoff) to make your account a manager. To add managers or verify an account
 is a manager:
@@ -18,7 +18,7 @@ is a manager:
 2. Click on the node.js icon on the right top.
 3. Select settings, select "Add or remove managers", select "Manage permissions"
 4. On that page you can use the +people at the top right of the popup to add
-  people. It also lists all current managers.
+   people. It also lists all current managers.
 
 ## Live streaming a meeting
 
@@ -29,19 +29,19 @@ is a manager:
 3. Press "Start", it should open the meeting in the Zoom application.
 4. Go to "Participants" panel, check Attendees, promote them to panelists.
 5. Go to "... More" in toolbar, choose "Live on YouTube", it will open in
-  browser.
+   browser.
 6. Choose to login to <https://youtube.com> with Node.js account, accept
-  Zoom usage agreement (on first use)
+   Zoom usage agreement (on first use)
 7. On the Streaming page, edit the webinar title to include the meeting date,
-  then press the red "Go Live!" button. Troubleshooting note: at least one
-  person has found that "Go Live!" errored with a message "Please grant
-  necessary privilege for live streaming". Copying the link from the default
-  browser to a different browser may work around this issue.
+   then press the red "Go Live!" button. Troubleshooting note: at least one
+   person has found that "Go Live!" errored with a message "Please grant
+   necessary privilege for live streaming". Copying the link from the default
+   browser to a different browser may work around this issue.
 
 Every participant can choose whether to participate with or without video.
 
 YouTube records the live stream. Recordings are made available on the
-[Node.js channel](https://www.youtube.com/channel/UCQPYJluYC_sn_Qz_XE-YbTQ/videos).
+[Node.js channel](https://www.youtube.com/channel/UCQPYJluYC\_sn\_Qz\_XE-YbTQ/videos).
 
 The stream title is set automatically from the information in Zoom. We usually
 set it to `Node.js Technical Steering Committee meeting` for TSC meetings,
@@ -86,5 +86,5 @@ Moderation follows the [Moderation Policy](../Moderation-Policy.md). Messages ca
 
 If you participate in the chat while logged in as Node.js, it's good practice to append your initials to your messages.
 
-During TSC meetings, there is a section of public Q&A at the end.
-It is important to solicit for questions **well in advance** of public Q&A sections so that people have time to think of and type questions.
+During TSC meetings, there is a section of public Q\&A at the end.
+It is important to solicit for questions **well in advance** of public Q\&A sections so that people have time to think of and type questions.

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -64,7 +64,7 @@ TSC members are expected to regularly participate in TSC activities.
 
 In the case where an individual TSC member -- within any three month period --
 attends fewer than 25% of the regularly scheduled meetings, does not
-participate in TSC discussions, *and* does not participate in TSC votes, the
+participate in TSC discussions, _and_ does not participate in TSC votes, the
 member shall be automatically removed from the TSC. The member may be invited
 to continue attending TSC meetings as an observer.
 
@@ -83,7 +83,7 @@ including:
 * Maintaining the list of additional Collaborators.
 * Development process and any coding standards.
 * Mediating technical conflicts between Collaborators or Foundation
-projects.
+  projects.
 
 The TSC will define Node.js project’s release vehicles.
 
@@ -171,14 +171,14 @@ looking to participate in the development effort.
 ## Section 9. Definitions
 
 * **Contributors**: contribute code or other artifacts, but do not have
-the right to commit to the code base. Contributors work with the
-project’s Collaborators to have code committed to the code base. A
-Contributor may be promoted to a Collaborator by the TSC. Contributors should
-rarely be encumbered by the TSC and never by the CPC or OpenJS Foundation Board.
+  the right to commit to the code base. Contributors work with the
+  project’s Collaborators to have code committed to the code base. A
+  Contributor may be promoted to a Collaborator by the TSC. Contributors should
+  rarely be encumbered by the TSC and never by the CPC or OpenJS Foundation Board.
 
 * **Project**: a technical collaboration effort, e.g. a subsystem, that
-is organized through the project creation process and approved by the
-TSC.
+  is organized through the project creation process and approved by the
+  TSC.
 
 [Condorcet]: https://en.wikipedia.org/wiki/Condorcet_method
 [Consensus Seeking]: https://en.wikipedia.org/wiki/Consensus-seeking_decision-making

--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -8,7 +8,7 @@ Once formed the work defined in the Working Group charter is the
 responsibility of the WG rather than the TSC.
 
 It is important that Working Groups are not formed pre-maturely. Working
-Groups are not formed to *begin* a set of tasks but instead are formed
+Groups are not formed to _begin_ a set of tasks but instead are formed
 once that work is already underway and the contributors
 think it would benefit from being done as an autonomous project.
 
@@ -27,8 +27,8 @@ the working group's repository.
 ## Starting A Core Working Group
 
 A Working Group is established by first defining a charter  that can be
-ratified by the TSC. A charter is a *statement of purpose*, a
-*list of responsibilities* and a *list of initial membership*.
+ratified by the TSC. A charter is a _statement of purpose_, a
+_list of responsibilities_ and a _list of initial membership_.
 
 A working group needs 3 initial members. These should be individuals
 already undertaking the work described in the charter.
@@ -439,7 +439,7 @@ Responsibilities include:
   GitHub organization including but not limited to:
   * Managing the list of organization owners which supplement the standard
     Node.js organization owners as outlined in:
-    [https://github.com/nodejs/admin/blob/master/GITHUB_ORG_MANAGEMENT_POLICY.md#owners](https://github.com/nodejs/admin/blob/master/GITHUB_ORG_MANAGEMENT_POLICY.md#owners)
+    <https://github.com/nodejs/admin/blob/master/GITHUB_ORG_MANAGEMENT_POLICY.md#owners>
   * Overseeing new repositories (creating, moving, removing)
   * Managing the maintainer teams for all of the repositories.
   * Contribution policy for repositories

--- a/meetings/2015-05-27.md
+++ b/meetings/2015-05-27.md
@@ -13,15 +13,15 @@ Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting
 
 ### nodejs/node-convergence-archive
 
-* \[Converge\] timers: Avoid linear scan in `_unrefActive`. [#23](https://github.com/nodejs/node-convergence-archive/issues/23)
-* \[Converge\] child_process argument type checking [#22](https://github.com/nodejs/node-convergence-archive/issues/22)
-* \[Converge\] SSLv2/3 disable/enable related commits [#20](https://github.com/nodejs/node-convergence-archive/issues/20)
+* \[Converge] timers: Avoid linear scan in `_unrefActive`. [#23](https://github.com/nodejs/node-convergence-archive/issues/23)
+* \[Converge] child\_process argument type checking [#22](https://github.com/nodejs/node-convergence-archive/issues/22)
+* \[Converge] SSLv2/3 disable/enable related commits [#20](https://github.com/nodejs/node-convergence-archive/issues/20)
 * doc: Add new working groups [#15](https://github.com/nodejs/node-convergence-archive/pull/15)
 
 ### nodejs/io.js
 
 * Buffer implemented using Uint8Array [#1810](https://github.com/nodejs/io.js/issues/1810)
-* \[Discussion\] FFI - Giving Buffer more low-level C functionality [#1750](https://github.com/nodejs/io.js/pull/1750)
+* \[Discussion] FFI - Giving Buffer more low-level C functionality [#1750](https://github.com/nodejs/io.js/pull/1750)
 * Chrome 43 released; time for V8 4.3! [#1735](https://github.com/nodejs/io.js/issues/1735)
 * Deprecation Policy [#1704](https://github.com/nodejs/io.js/issues/1704)
 * TSC needs to elect a board representative. [#1697](https://github.com/nodejs/io.js/issues/1697)
@@ -69,7 +69,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting
 
 ## Minutes
 
-### \[Converge\] timers: Avoid linear scan in `_unrefActive`. [#23](https://github.com/nodejs/node-convergence-archive/issues/23)
+### \[Converge] timers: Avoid linear scan in `_unrefActive`. [#23](https://github.com/nodejs/node-convergence-archive/issues/23)
 
 * James: conflicting approaches in both repos
 * Ben: both are terrible under different workloads - do away with the code and start again
@@ -77,13 +77,13 @@ Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting
 * Bert: some problems with http - discussion happened about the implementation
 * Chris: would be good to have Julien’s input since he was active on the joyent/node impl
 
-### \[Converge\] child_process argument type checking [#22](https://github.com/nodejs/node-convergence-archive/issues/22)
+### \[Converge] child\_process argument type checking [#22](https://github.com/nodejs/node-convergence-archive/issues/22)
 
 * James: arg checking merged in 0.10 after the fork
 * Discussion about why this wasn’t merged to io.js
 * Defer back to GitHub discussion after no reason for not merging could be found on the call
 
-### \[Converge\] SSLv2/3 disable/enable related commits [#20](https://github.com/nodejs/node-convergence-archive/issues/20)
+### \[Converge] SSLv2/3 disable/enable related commits [#20](https://github.com/nodejs/node-convergence-archive/issues/20)
 
 * James: SSLv2/3 removed in io.js, merging these commits would involve reverting
 * Jeremiah proposed 0.12 being the LTS for SSLv2/3 support
@@ -112,7 +112,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting
 * Fedor: how does it work with 32bit numbers?
 * Trevor: It acts the same as before
 
-### \[Discussion\] FFI - Giving Buffer more low-level C functionality [#1750](https://github.com/nodejs/io.js/pull/1750)
+### \[Discussion] FFI - Giving Buffer more low-level C functionality [#1750](https://github.com/nodejs/io.js/pull/1750)
 
 * Trevor: concerns about being able to write to buffers and execute arbitrary code
 * Rod: concerned about changing the nature of what Node _is_ and the safety it exposes

--- a/meetings/2015-06-03.md
+++ b/meetings/2015-06-03.md
@@ -41,7 +41,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting
 * Mikeal: getting foundation legalities and officialities in order
 * Shigeki: working on security issues, reviewing root cert update
 * Chris: working on getting npm static analysis working [estoc](https://github.com/chrisdickinson/estoc)
-* Colin: reviewing prs and issues, doing some libuv work (uv_os_homedir, which landed in libuv 1.6.0)
+* Colin: reviewing prs and issues, doing some libuv work (uv\_os\_homedir, which landed in libuv 1.6.0)
 * Julien: vacation, nodejs.org downtime postmortem
 * James: working on convergence, triaging joyent/node issues
 * Michael: triaging some joyent/node issues, working on powerpc build and npm testing
@@ -58,15 +58,15 @@ Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting
 
 ### nodejs/node
 
-* \[Converge\] timers: Avoid linear scan in `_unrefActive`. [#23](https://github.com/nodejs/node/issues/23)
-* \[Converge\] child_process argument type checking [#22](https://github.com/nodejs/node/issues/22)
-* \[Converge\] SSLv2/3 disable/enable related commits [#20](https://github.com/nodejs/node/issues/20)
+* \[Converge] timers: Avoid linear scan in `_unrefActive`. [#23](https://github.com/nodejs/node/issues/23)
+* \[Converge] child\_process argument type checking [#22](https://github.com/nodejs/node/issues/22)
+* \[Converge] SSLv2/3 disable/enable related commits [#20](https://github.com/nodejs/node/issues/20)
 * doc: Add new working groups [#15](https://github.com/nodejs/node/pull/15)
 
 ### nodejs/io.js
 
 * Buffer implemented using Uint8Array [#1810](https://github.com/nodejs/io.js/issues/1810)
-* \[Discussion\] FFI - Giving Buffer more low-level C functionality [#1750](https://github.com/nodejs/io.js/pull/1750)
+* \[Discussion] FFI - Giving Buffer more low-level C functionality [#1750](https://github.com/nodejs/io.js/pull/1750)
 * Chrome 43 released; time for V8 4.3! [#1735](https://github.com/nodejs/io.js/issues/1735)
 * Deprecation Policy [#1704](https://github.com/nodejs/io.js/issues/1704)
 * TSC needs to elect a board representative. [#1697](https://github.com/nodejs/io.js/issues/1697)
@@ -158,6 +158,6 @@ _Discussed the pros and cons and agreed to tentatively move forward with experim
 
 ### TSC needs to elect a board representative. [#1697](https://github.com/nodejs/io.js/issues/1697)
 
-***Call ended prematurely due to Uberconference difficulties***
+_**Call ended prematurely due to Uberconference difficulties**_
 
 ## Next meeting

--- a/meetings/2015-06-10.md
+++ b/meetings/2015-06-10.md
@@ -117,7 +117,7 @@ Decision was that it might be confusing at first, so onboarding of these collabo
 * **Trevor**: what if we added process.resetRlimits and when that process spawns it resets rlimits.
 * **Bradley**: need to pass that to child processes still.
 * **Trevor**: if using cluster, then that seems easy.
-* **Bert**: Don’t like having globals for that kind of stuff, related to multi isolates. Maybe add as an option to child_process.spawn?
+* **Bert**: Don’t like having globals for that kind of stuff, related to multi isolates. Maybe add as an option to child\_process.spawn?
 * **Trevor**: how would that help regarding multi isolates environments?
 * **Bert**: Yeah, not suggesting to be able to set different limits per isolate. Ben any opinion?
 * **Ben**: Resetting rlimits when we spawn new process would be fine. Don’t care about environment variable that would make node not touch rlimits.

--- a/meetings/2015-06-17.md
+++ b/meetings/2015-06-17.md
@@ -62,7 +62,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting
 ### Standup
 
 * Rod: build, productive work on improving the ci and build convergence, ci now does linting before running the tests, also improving the io.js make file so that less logic for releases is contained in jenkins
-* Colin: reviewing issues and pr’s, landed a cluster patch to not use --debug_port on cluster workers by default
+* Colin: reviewing issues and pr’s, landed a cluster patch to not use --debug\_port on cluster workers by default
 * Chris: NodeConf, got great feedback there. PR for code coverage incoming soon, spun up the docs WG.
   * <http://neversaw.us/scratch/node-coverage/> – code coverage
   * <https://github.com/nodejs/docs>
@@ -124,7 +124,7 @@ Called for a vote, got +1's for both candidates from each of: Chris, Rod, Bert, 
   we stick with semver
   (CD: Mikeal could you fill this out further?)
 * Domenic: We don’t need to move away from semver for the next branch
-Yearly releases pick a version that aligns
+  Yearly releases pick a version that aligns
 * Mikeal: don’t call it canary, get a codename – increment one, two, three or five over a year – when we merge into master we choose a new name
 * CD: Could not capture entirety of discussion – moved a bit fast for me.
 * Bert: there is no ideal answer here. Would like mikeal and domenic to continue discussion and come back with something to vote on.

--- a/meetings/2015-07-01.md
+++ b/meetings/2015-07-01.md
@@ -64,15 +64,23 @@ Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting
 ### Internationalization WG (Steven)
 
 * <https://github.com/nodejs/internationalization> (repo)
+
 * <https://github.com/nodejs/internationalization/issues/4> (README)
+
 * <https://github.com/nodejs/internationalization/issues/5> (CFP)
 
 * Steven introduced the work towards getting this set up
+
 * Steven clarified the scope of the work (this is done in the README), it’s different to outreach and user assistance (i.e. the i18n translation stuff that io.js already has).
+
 * Jeremiah suggested we name the group after `Intl` so it’s clearer what it’s about.
+
 * James: It’s about Intl stuff in the code, unicode, REPL dying because of bad unicode
+
 * Mikeal: We’ve talked about starting a formal translation/language group that unifies all of the independent translation efforts. That’s probably why people are showing up for this group thinking it’s the translation group that we’ve talked about setting up. We should set up that separate group and maybe use `Intl` as the name for this separate group.
+
 * Bikeshedded naming for a little while.
+
 * Conclusion: rename as the Intl WG or similar for clarity. (renamed to Intl)
 
 ### lts: strawman LTS cycle [lts#13](https://github.com/nodejs/LTS/pull/13) / Proposal: Release Process [#1997](https://github.com/nodejs/io.js/issues/1997)

--- a/meetings/2015-07-08.md
+++ b/meetings/2015-07-08.md
@@ -66,8 +66,8 @@ Extracted from **tsc-agenda** labelled issues and pull requests prior to meeting
 * Jeremiah Senkpiel: General triaging and reviewing, helped do the release last friday. `_unrefActive` with optimizations with heap timers. At CascadiaJS the next of the week to get people’s feedback.
 * Julien Gilli: Released 0.12.6 last week, working on setting up other people to do joyent/node releases, joyent/node issue triage
 * Chris Dickinson: Working on docs more, have a new tool for docs to make sure the links are correct in a tree of docs, started a collaborator check-in on the io.js issue tracker, hopefully will be weekly.
-Jeremiah: what is that doctool?
-Chris: “count-docula”, a MDAST-based tool to verify correctness of the docs.
+  Jeremiah: what is that doctool?
+  Chris: “count-docula”, a MDAST-based tool to verify correctness of the docs.
 * Shigeki Ohtsu: Not much on io.js, preparing to update OpenSSL tonight to get the OpenSSL security fix out.
 * Trevor Norris: Investigating the UTF8 decoder security issue and working on the fix. Reviewing PRs and being involved in the W3C Web Assembly working group.
 * Domenic Denicola: Not much on io.js, travelling, stress testing the vm module.

--- a/meetings/2015-07-22.md
+++ b/meetings/2015-07-22.md
@@ -105,19 +105,31 @@ Voting on approving the process stated above:
 Specific proposal for August
 
 * 15K max budget (we had previously talked about 10K but I don't think that is enough)
+
 * Approve a $900 max spend per person on accommodations.
+
 * Approve a $500 max spend on domestic travel
+
 * Approve a $1500 max spend on international travel (if someone has to go over it just requires additional TSC approval)
 
 * Rod: +1
+
 * James: +1
+
 * Fedor: +1
+
 * Michael: +1
+
 * Steven: +1
+
 * Jeremiah: +1
+
 * Brian: +1
+
 * Ben: +1
+
 * Trevor: +1
+
 * Chris: +1
 
 Approval for extra expenditure for @joaocgreis (from Portugal): $1,742.66

--- a/meetings/2015-08-19.md
+++ b/meetings/2015-08-19.md
@@ -104,13 +104,17 @@ No objections to combining the a whole "release team" to handle all release bran
 ### node-gyp is now in our org [#2379](https://github.com/nodejs/node/issues/2379)
 
 * Rod: node-gyp has a busy issue tracker and has no tests, needs more eyes
+
 * Ben: Zero tests?
+
 * Rod: Correct.
-* Domenic: on Windows Chromium’s depot_tools will automatically download VS community edition and put it in the right place. Someone with copious free time could have node-gyp do similar things.
+
+* Domenic: on Windows Chromium’s depot\_tools will automatically download VS community edition and put it in the right place. Someone with copious free time could have node-gyp do similar things.
 
 * Discussed maybe looking at `gn` (the eventual replacement for `gyp`)
 
 * Domenic: even v8 still uses gyp, don’t worry about it for a good while until noise about it being deprecated gets louder
+
 * Rod: issue [#151](https://github.com/nodejs/build/issues/151) in build has a discussion about precompiled native addons. Chime in!
 
 ## Next Meeting

--- a/meetings/2015-08-26.md
+++ b/meetings/2015-08-26.md
@@ -66,7 +66,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests in the nodejs or
 ### Update README to reflect move to nodejs/node [#25897](https://github.com/joyent/node/pull/25897)
 
 * Alexis: made changes in CI to prepare for this, we’ll keep PRs in original repo, node-accept-pull-request will land changes in new repo as well, mirroring changes in 0.10 and 0.12 across both old and new repos. Still using the old Jenkins for releases for 0.10 and 0.12 right now and that doesn’t depend on repo name & location.
-Target ETA for transition: Monday.
+  Target ETA for transition: Monday.
 
 ### doc: merge CHANGELOG.md with joyent/node ChangeLog [#2536](https://github.com/nodejs/node/pull/2536)
 
@@ -91,7 +91,7 @@ Target ETA for transition: Monday.
   * backup release date of Monday, 7th of September if absolutely necessary to punt
 * Discussed the outstanding items in the 4.0.0 milestone: <https://github.com/nodejs/node/milestones/4.0.0>, some concerning items:
   * mdb support is late and may not get done, might have to be a semver-minor prior to LTS
-  * vcbuilt.bat needs to use the new build_release target and we have to verify that all builds have Intl enabled - Steven to work with Rod on this
+  * vcbuilt.bat needs to use the new build\_release target and we have to verify that all builds have Intl enabled - Steven to work with Rod on this
   * `process.send()` async/sync, Ben said that this is async on all platforms now (was just Windows previously but now it’s cross-platform) but it’s missing a callback so there’s no way of doing back-pressure. No time to add this prior to v4 but could be done as semiver-minor later. Ben agreed to document current behaviour properly in the docs.
   * `_unrefActive` is in Jeremiah’s hands, he will land the 0.12 changes as the io.js version is terrible. Discussed further perf improvements but agreed to leave those changes till later, ideally till v5 because of the potential for subtle edge-case bugs being introduced.
 

--- a/meetings/2015-09-02.md
+++ b/meetings/2015-09-02.md
@@ -16,7 +16,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests in the nodejs or
 * deps: update v8 to 4.5.103.30 [#2632](https://github.com/nodejs/node/pull/2632)
 * Inspecting Node.js with Chrome DevTools [#2546](https://github.com/nodejs/node/issues/2546)
 * Node.js v4 Release Timeline [#2522](https://github.com/nodejs/node/issues/2522)
-* doc: update COLLABORATOR_GUIDE.md [#2638](https://github.com/nodejs/node/pull/2638)
+* doc: update COLLABORATOR\_GUIDE.md [#2638](https://github.com/nodejs/node/pull/2638)
 
 ### nodejs/build
 
@@ -148,7 +148,7 @@ Rod: they are getting quicker, adding raspberrypis to the cluster. good incentiv
 
 Rod: let’s move on
 
-### doc: update COLLABORATOR_GUIDE [#2638](https://github.com/nodejs/node/pull/2638)
+### doc: update COLLABORATOR\_GUIDE [#2638](https://github.com/nodejs/node/pull/2638)
 
 Jeremiah: Alexis wanted to put the pr tool into the collaborator guide should punt on this right now notifying collaborators on issues is more effective messaging than the docs
 
@@ -160,7 +160,7 @@ Rod: looking at the possibility of jumping to 4.5 for the v4 release it’s read
 
 Bert: what breaks? what are the cons?
 
-Domenic: looking at v8 by code inspection, there are no breakages, just new deprecations — should *in theory* work — I don’t think anyone’s been testing it though
+Domenic: looking at v8 by code inspection, there are no breakages, just new deprecations — should _in theory_ work — I don’t think anyone’s been testing it though
 
 Bert: can this v8 release be supported for LTS? we don’t know if this is better or worse than 4.4? maybe ask goog eng
 
@@ -222,7 +222,7 @@ Rod: longer we have to support our own V8, the harder it is, and another 6 weeks
 
 James: I’m -0
 
-Rod: spending some time today testing some existing addons taht have upgraded to nan@2. if there’s breakage, that tells me nan’s not ready, and that should be taken into account
+Rod: spending some time today testing some existing addons taht have upgraded to nan\@2. if there’s breakage, that tells me nan’s not ready, and that should be taken into account
 
 Domenic: if nan’s not ready, we don’t upgrade
 
@@ -335,7 +335,7 @@ OTW wire is generic, consumable by anyone, chrome dev tools is a key consumer, b
 cons:
 
 APIs going to need to be tightly integrated — needs to know about all async events
-  add conditionals to e.g. nextTick + timers
+add conditionals to e.g. nextTick + timers
 
 Domenic: add something to MakeCallback?
 

--- a/meetings/2015-09-16.md
+++ b/meetings/2015-09-16.md
@@ -62,7 +62,7 @@ Due to IBM’s acquisition of StrongLoop, IBM is over the TSC 25% company limit 
 ### Previous meeting’s agenda
 
 * Jenkins merge jobs always overwrites PR-URL and Reviewed-By [#179](https://github.com/nodejs/build/issues/179)
-* doc: update COLLABORATOR_GUIDE [#2638](https://github.com/nodejs/node/pull/2638)
+* doc: update COLLABORATOR\_GUIDE [#2638](https://github.com/nodejs/node/pull/2638)
 * deps: update v8 to 4.5.103.30 [#2632](https://github.com/nodejs/node/pull/2632)
 * Node.js v4 Release Timeline [#2522](https://github.com/nodejs/node/issues/2522)
 * Inspecting Node.js with Chrome DevTools [#2546](https://github.com/nodejs/node/issues/2546)

--- a/meetings/2015-10-07.md
+++ b/meetings/2015-10-07.md
@@ -27,7 +27,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests in the nodejs or
 ### nodejs/node
 
 * WG: Considering a new HTTP WG [#3214](https://github.com/nodejs/node/issues/3214)
-* lib,test: deprecate _linklist [#3078](https://github.com/nodejs/node/pull/3078)
+* lib,test: deprecate \_linklist [#3078](https://github.com/nodejs/node/pull/3078)
 * Discussion: LTS & v5 release planning [#3000](https://github.com/nodejs/node/issues/3000)
 * Compiling node v4.0.0 with OpenSSL 1.0.1 fails [#2783](https://github.com/nodejs/node/issues/2783)
 * Inspecting Node.js with Chrome DevTools [#2546](https://github.com/nodejs/node/issues/2546)
@@ -43,7 +43,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests in the nodejs or
 * Rod Vagg: 4.1.2 release, security procedures surrounding that
 * Brian White: Working on javascript dns resolver, regular PR + Issue work.
 * Steven Loomis: Working on ICU 56 Release. TC 39 & emca spec work for Intl WG. Working on Intl build issues.
-* Trevor Norris: Focused on fixing async_wrap, writing tests and preparing for it to become more official
+* Trevor Norris: Focused on fixing async\_wrap, writing tests and preparing for it to become more official
 * Shigeki Ohtsu: No works for node project, I spent all time to my internal works.
 * Ben Noordhuis: Nothing to report—the usual
 * Mikeal Rogers: Looking into stalled Wgs and seeing how to help out. Working on the umbrella program. Lots of conference things.
@@ -63,7 +63,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests in the nodejs or
 * Discussed the HTTP WG based on James’ comments @ <https://github.com/nodejs/node/issues/3234#issuecomment-146293038>
 * Generally positive, only concerns are regarding decision making power—TSC may not want to hand that off as this is not quite like Streams (in that few people grok the code!) and there are philosophical questions to be resolved about HTTP that the TSC should be involved in.
 
-### lib,test: deprecate _linklist [#3078](https://github.com/nodejs/node/pull/3078)
+### lib,test: deprecate \_linklist [#3078](https://github.com/nodejs/node/pull/3078)
 
 * Userland modules exist that could be used instead
 * Ben suggested straight removal, Jeramiah raised the matter of process that we have committed to adding a warning before removal, so we could remove in v6 but probably shouldn’t in v5

--- a/meetings/2015-10-14.md
+++ b/meetings/2015-10-14.md
@@ -56,7 +56,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests in the nodejs or
 ### Review of previous meeting
 
 * WG: Considering a new HTTP WG [#3214](https://github.com/nodejs/node/issues/3214)
-* lib,test: deprecate _linklist [#3078](https://github.com/nodejs/node/pull/3078)
+* lib,test: deprecate \_linklist [#3078](https://github.com/nodejs/node/pull/3078)
 * Discussion: LTS & v5 release planning [#3000](https://github.com/nodejs/node/issues/3000)
 * Compiling node v4.0.0 with OpenSSL 1.0.1 fails [#2783](https://github.com/nodejs/node/issues/2783)
 * Inspecting Node.js with Chrome DevTools [#2546](https://github.com/nodejs/node/issues/2546)

--- a/meetings/2015-10-21.md
+++ b/meetings/2015-10-21.md
@@ -49,20 +49,34 @@ Extracted from **tsc-agenda** labelled issues and pull requests in the nodejs or
 
 ### Standup
 
-* Rod Vagg: index.tab and index.json updates (nodejs.org/dist/index.*) including an “lts” field, also made consistent directories for ancient Node tarballs with shasums files so nvm and other tools can simplify their access. v5 and other build yak shaving.
+* Rod Vagg: index.tab and index.json updates (nodejs.org/dist/index.\*) including an “lts” field, also made consistent directories for ancient Node tarballs with shasums files so nvm and other tools can simplify their access. v5 and other build yak shaving.
+
 * Brian White: usual triaging and PR and Issues commenting, not much else
-* Steven R. Loomis: Intl meeting, "full-icu" npm module \[will be away until Nov 11 meeting, Unicode conf/Unicode-TC\]
+
+* Steven R. Loomis: Intl meeting, "full-icu" npm module \[will be away until Nov 11 meeting, Unicode conf/Unicode-TC]
+
 * James Snell: Working on localization for the node runtime [#3413](https://github.com/nodejs/node/pull/3413)
+
 * Michael Dawson: Working through PPC and AIX PRs and issues, LTS WG discussions, Benchmarking WG, working with Stefan on agenda items for API WG meeting.
+
 * Chris Dickinson: was busy with vacation and conferences, but looking into the WhatWG Streams spec, next up is static analysis server
+
 * Ben Noordhuis: The usual. Looking into make the debugger better. The test suite is in bad shape
-* Jeremiah Senkpiel: issue and PR work — going back through the backlog now, helping with v5 release + npm@3
+
+* Jeremiah Senkpiel: issue and PR work — going back through the backlog now, helping with v5 release + npm\@3
+
 * Trevor Norris: flurry of AsyncWrap PRs, trying to get it to a point where people could more reliably use it, it can’t be hidden forever.
+
 * Alexis Campailla: Sick, traveling; CI progress on flakiness, some progress on native module build service
+
 * Mikeal Rogers: Foundation resources for v5 release: PR folks wrote a blog post, expectation setting, make sure enterprises are still using LTS, if you’re a dev here’s what to be excited about, etc.
+
 * Shigeki Ohtsu: Worked semver-major fix to limit DH key size [#1831](https://github.com/nodejs/node/pull/1831) and some works for root certs.
+
 * Seth Thompson: Security mailing list stuff went through this week, working on v8 side of things to create a new version of the octane benchmark, excited about the benchmarking WG
+
 * Bert Belder: nothing
+
 * Fedor Indutny: reviewing PRs, helped fix a beforeExit bug, fixing yet another V8’s ArrayBuffer issue
   * Discussed the ArrayBuffer issue in detail
 
@@ -80,11 +94,11 @@ Stems from conversation from the 0.X days about whether Node should ship other l
 
 This is a module published on npm as an alternative to shipping with Node proper.
 
-Whether node can detect a full-icu install in a special place (node_modules/full-icu, global/node_modules/full-icu)
+Whether node can detect a full-icu install in a special place (node\_modules/full-icu, global/node\_modules/full-icu)
 
 Nathan7 commented with a concern about coupling npm to node
 
-Currently have to start node with ICU_DATA_PATH=some/path/to/file
+Currently have to start node with ICU\_DATA\_PATH=some/path/to/file
 
 Rod: Couple it to `execPath`
 
@@ -98,9 +112,9 @@ James: Happens right after parsing args
 
 Rod: Could use HOME?
 
-Stephen: Could use NODE_PATH?
+Stephen: Could use NODE\_PATH?
 
-Rod: Trying to move away from NODE_PATH
+Rod: Trying to move away from NODE\_PATH
 
 Ben: Might just bite the bullet and include ICU?
 
@@ -118,7 +132,7 @@ Bert: I would not be in favor of that. We end up with “oh my module doesn’t 
 
 Jeremiah: It’s going to make it confusing no matter what
 
-... \[I missed this\]
+... \[I missed this]
 
 Chris: could we offer better error messages?
 
@@ -140,7 +154,7 @@ Ben: should we add it to the repo?
 
 Alexis: I think so, it’s causing problems
 
-\[???\]: It’s about 80mb
+\[???]: It’s about 80mb
 
 Rod: How big is it?
 
@@ -179,7 +193,7 @@ Stephen: I’m not sure — it looks pretty deeply enmeshed into V8
 Seth: I don’t have answers off the top of my head on that one, I responded on the thread; we don’t currently have a priority to mess
 around with localization. If there’s a design doc that proposes cleaning things up we’d be interested
 
-James: Resource bundle mechanism — \[Note: didn’t get all of this\] “using the same startup sequence as Intl.. so needs to be configured at start time” (<https://github.com/nodejs/node/pull/3413> uses ICU’s resource bundle mechanism, which uses the same init path as the core data. ICU does not allow multiple initializations.
+James: Resource bundle mechanism — \[Note: didn’t get all of this] “using the same startup sequence as Intl.. so needs to be configured at start time” (<https://github.com/nodejs/node/pull/3413> uses ICU’s resource bundle mechanism, which uses the same init path as the core data. ICU does not allow multiple initializations.
 
 Alexis: If the only reason we’re trying to package it is to use npm to install it, maybe we’re complicating this unnecessarily
 
@@ -191,7 +205,7 @@ Chris: JS proxies
 
 Steven: Possible, but _very_ tricky
 
-\[Moving conversation to GH\]
+\[Moving conversation to GH]
 
 ### WG: Considering a new HTTP WG [#3214](https://github.com/nodejs/node/issues/3214)
 

--- a/meetings/2016-01-28.md
+++ b/meetings/2016-01-28.md
@@ -5,7 +5,7 @@
 * **Video Recording**: Not available
 * **GitHub Issue**: <https://github.com/nodejs/TSC/issues/38>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1WliRr9DCue8MjRMsPrg33eOvOvfbelHKwbwD36N4_Qk>
-* **Previous Minutes Google Doc**: nil_
+* **Previous Minutes Google Doc**: nil\_
 
 ## Present
 

--- a/meetings/2016-02-04.md
+++ b/meetings/2016-02-04.md
@@ -5,7 +5,7 @@
 * **Video Recording**: Not available
 * **GitHub Issue**: <https://github.com/nodejs/TSC/issues/41>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1wJ0fuc1BcPn1armdR3D5NF6lTGyA3SiBCDktc2p5Voo>
-* **Previous Minutes Google Doc**: nil_
+* **Previous Minutes Google Doc**: nil\_
 
 ## Present
 
@@ -33,7 +33,7 @@ nothing officially covered
 
 ### Express PR <https://github.com/nodejs/TSC/pull/39>
 
-James: moved quickly since last week, Doug has decided to contribute a large portion of his modules to the submission. Updated PR today, basic idea is to have a rough TC containing current owners of express, pillarjs, jshtttp org owners \[RV: not sure I have that list correct\]. There are a large number of modules that are included. Lots to be done on the PR still.
+James: moved quickly since last week, Doug has decided to contribute a large portion of his modules to the submission. Updated PR today, basic idea is to have a rough TC containing current owners of express, pillarjs, jshtttp org owners \[RV: not sure I have that list correct]. There are a large number of modules that are included. Lots to be done on the PR still.
 
 Mikeal: multiple-org thing is reshaping our assumptions about what the incubator would look like and what the process looks like. Makes sense to assign 2 mentors to express and 2 to libuv. Tell other projects that we are taking a month-long hiatus to figure this stuff out and build up base-level documentation.
 

--- a/meetings/2016-02-11.md
+++ b/meetings/2016-02-11.md
@@ -5,7 +5,7 @@
 * **Video Recording**: Not available
 * **GitHub Issue**: <https://github.com/nodejs/TSC/issues/49>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1wJ0fuc1BcPn1armdR3D5NF6lTGyA3SiBCDktc2p5Voo>
-* **Previous Minutes Google Doc**: nil_
+* **Previous Minutes Google Doc**: nil\_
 
 ## Present
 

--- a/meetings/2016-06-16.md
+++ b/meetings/2016-06-16.md
@@ -74,9 +74,13 @@ would include: (not exclusive):
 Projects:
 
 * citgm
+
 * node-gyp
+
 * nan
+
 * libuv
+
 * nodejs-github-bot
 
 * CTC: big-picture things, releases, important decisions made

--- a/meetings/2016-06-30.md
+++ b/meetings/2016-06-30.md
@@ -5,7 +5,7 @@
 * **Video Recording**: <https://youtu.be/NSiOB1XcUDU>
 * **GitHub Issue**: <https://github.com/nodejs/TSC/issues/115>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1eUpQNVdupAlsyvVVEnu8za6d8aBhOv9bEZK9FVWm8ds>
-* _Previous Minutes Google Doc: <https://docs.google.com/document/d/1WMrf2OmU11zqlu9SAHeKq8dwH1CSnW-eavLZ8kPCAJo>
+* \_Previous Minutes Google Doc: <https://docs.google.com/document/d/1WMrf2OmU11zqlu9SAHeKq8dwH1CSnW-eavLZ8kPCAJo>
 
 ## Present
 

--- a/meetings/2016-07-14.md
+++ b/meetings/2016-07-14.md
@@ -5,7 +5,7 @@
 * **Video Recording**: <https://www.youtube.com/watch?v=UXlzfJ9zPIY>
 * **GitHub Issue**: <https://github.com/nodejs/TSC/issues/118>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1M29qRvgLU5LedQZ9kpZfWzzlDbNvWB9RolWBcD5ZBco>
-* _Previous Minutes Google Doc: <https://docs.google.com/document/d/1eUpQNVdupAlsyvVVEnu8za6d8aBhOv9bEZK9FVWm8ds>
+* \_Previous Minutes Google Doc: <https://docs.google.com/document/d/1eUpQNVdupAlsyvVVEnu8za6d8aBhOv9bEZK9FVWm8ds>
 
 ## Present
 

--- a/meetings/2016-08-04.md
+++ b/meetings/2016-08-04.md
@@ -5,7 +5,7 @@
 * **Audio Recording**: <https://www.youtube.com/watch?v=deTR-XFnKGQ>
 * **GitHub Issue**: <https://github.com/nodejs/TSC/issues/124>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1ja56BVVPy946OZlDv1EQBy4TC5he6IQkQtxhE-20X4E>
-* _Previous Minutes Google Doc: <https://docs.google.com/document/d/1M29qRvgLU5LedQZ9kpZfWzzlDbNvWB9RolWBcD5ZBco>
+* \_Previous Minutes Google Doc: <https://docs.google.com/document/d/1M29qRvgLU5LedQZ9kpZfWzzlDbNvWB9RolWBcD5ZBco>
 
 ## Present
 
@@ -29,7 +29,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests from the **nodej
 ### nodejs/TSC
 
 * doc: cover moderation of IRC, mail, and slack channels [#122](https://github.com/nodejs/TSC/pull/122)
-* #node-dev IRC is not currently under TSC supervision [#121](https://github.com/nodejs/TSC/issues/121)
+* \#node-dev IRC is not currently under TSC supervision [#121](https://github.com/nodejs/TSC/issues/121)
 * Define "Node.js core" [#113](https://github.com/nodejs/TSC/issues/113) / [#84](https://github.com/nodejs/TSC/issues/84)
 * Regular roll-up reporting for active working groups [#109](https://github.com/nodejs/TSC/issues/109)
 

--- a/meetings/2016-08-11.md
+++ b/meetings/2016-08-11.md
@@ -31,7 +31,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests from the **nodej
 ### nodejs/TSC
 
 * doc: cover moderation of IRC, mail, and slack channels [#122](https://github.com/nodejs/TSC/pull/122)
-* #node-dev IRC is not currently under TSC supervision [#121](https://github.com/nodejs/TSC/issues/121)
+* \#node-dev IRC is not currently under TSC supervision [#121](https://github.com/nodejs/TSC/issues/121)
 * Define "Node.js core" [#113](https://github.com/nodejs/TSC/issues/113) / [#84](https://github.com/nodejs/TSC/issues/84)
 * Regular roll-up reporting for active working groups [#109](https://github.com/nodejs/TSC/issues/109)
 
@@ -70,7 +70,9 @@ Extracted from **tsc-agenda** labelled issues and pull requests from the **nodej
 * Did this last week.. untagging
 
 * Michael: Status update
+
 * Bryan: Phillip also moved the github bot this week
+
 * Jeremiah: Some problems with nodejs-github-bot and travis
 
 ### TSC Board Director Elections [#126](https://github.com/nodejs/TSC/issues/126)

--- a/meetings/2016-08-25.md
+++ b/meetings/2016-08-25.md
@@ -5,7 +5,7 @@
 * **Audio Recording**: <https://www.youtube.com/watch?v=IDz3i6bmxhA>
 * **GitHub Issue**: <https://github.com/nodejs/TSC/issues/134>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1ZMYiM236GgE9MXaqecOCrUWHhXe94dxTbXHutkp3nnA>
-* _Previous Minutes Google Doc: <https://docs.google.com/document/d/1Sp78uVB_1NBv9AZk1pXKj-YWmwqtCA6ZqxAE_lsjuk0>
+* \_Previous Minutes Google Doc: <https://docs.google.com/document/d/1Sp78uVB_1NBv9AZk1pXKj-YWmwqtCA6ZqxAE_lsjuk0>
 
 ## Present
 
@@ -36,7 +36,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests from the **nodej
 
 * Repositories to contribute collaboratively [#30](https://github.com/nodejs/post-mortem/issues/30)
 * doc: cover moderation of IRC, mail, and slack channels [#122](https://github.com/nodejs/TSC/pull/122)
-* #node-dev IRC is not currently under TSC supervision [#121](https://github.com/nodejs/TSC/issues/121)
+* \#node-dev IRC is not currently under TSC supervision [#121](https://github.com/nodejs/TSC/issues/121)
 * Define "Node.js core" [#113](https://github.com/nodejs/TSC/issues/113) / [#84](https://github.com/nodejs/TSC/issues/84)
 * Regular roll-up reporting for active working groups [#109](https://github.com/nodejs/TSC/issues/109)
 
@@ -65,7 +65,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests from the **nodej
 
 ### Define "Node.js core" - Mark II [#113](https://github.com/nodejs/TSC/issues/113)
 
-* No activity for ~ a month so won’t cover it here
+* No activity for \~ a month so won’t cover it here
 
 ### Regular roll-up reporting for active working groups [#109](https://github.com/nodejs/TSC/issues/109)
 

--- a/meetings/2016-09-08.md
+++ b/meetings/2016-09-08.md
@@ -5,7 +5,7 @@
 * **Audio Recording**: <https://www.youtube.com/watch?v=mtCTkakK7RA>
 * **GitHub Issue**: <https://github.com/nodejs/TSC/issues/135>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1ku52mOlqBxyGGMFY9phBwcB9bNMOyjwK3F1qVpNWryE>
-* _Previous Minutes Google Doc: <https://docs.google.com/document/d/1ZMYiM236GgE9MXaqecOCrUWHhXe94dxTbXHutkp3nnA>
+* \_Previous Minutes Google Doc: <https://docs.google.com/document/d/1ZMYiM236GgE9MXaqecOCrUWHhXe94dxTbXHutkp3nnA>
 
 ## Present
 

--- a/meetings/2016-09-22.md
+++ b/meetings/2016-09-22.md
@@ -5,7 +5,7 @@
 * **Audio Recording**: <https://www.youtube.com/watch?v=Y2zBT9t42Fg>
 * **GitHub Issue**: <https://github.com/nodejs/TSC/issues/143>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1YOe-9yjpVbsPURcWI2yoJenFQSaMEbMaeurkIRMM938>
-* _Previous Minutes Google Doc: <https://docs.google.com/document/d/1ku52mOlqBxyGGMFY9phBwcB9bNMOyjwK3F1qVpNWryE>
+* \_Previous Minutes Google Doc: <https://docs.google.com/document/d/1ku52mOlqBxyGGMFY9phBwcB9bNMOyjwK3F1qVpNWryE>
 
 ## Present
 
@@ -61,9 +61,11 @@ Extracted from **tsc-agenda** labelled issues and pull requests from the **nodej
 ### Request for Foundation funds to get @Fishrock123 to SF for ES Modules meetings [#141](https://github.com/nodejs/TSC/issues/141)
 
 * Need More financial information from the foundation in general
+
 * Vote passed among present TSC members
 
 * Collab Summit was under-attended
+
 * Code & Learn needs to be distinct from Collab Summit, NIEU experience wasn’t great there due to the lack of separate meeting places and having them on the same day
 
 ### Switching the default license from MIT to Apache v2 [#139](https://github.com/nodejs/TSC/issues/139)

--- a/meetings/2016-10-06.md
+++ b/meetings/2016-10-06.md
@@ -5,7 +5,7 @@
 * **Audio Recording**: <https://www.youtube.com/watch?v=Tyf6KKdn98Y>
 * **GitHub Issue**: [TSC#152](https://github.com/nodejs/TSC/issues/152)
 * **Minutes Google Doc**: <https://docs.google.com/document/d/16-3u9OV7t4E0kVZsZxRtrhTJimZUwzOCbHoCLjsYYas>
-* _Previous Minutes Google Doc: <https://docs.google.com/document/d/1YOe-9yjpVbsPURcWI2yoJenFQSaMEbMaeurkIRMM938>
+* \_Previous Minutes Google Doc: <https://docs.google.com/document/d/1YOe-9yjpVbsPURcWI2yoJenFQSaMEbMaeurkIRMM938>
 
 ## Present
 

--- a/meetings/2016-10-20.md
+++ b/meetings/2016-10-20.md
@@ -50,9 +50,9 @@ Extracted from **tsc-agenda** labelled issues and pull requests from the **nodej
 * Jeremiah is main strong objection to merging the two bodies.
 * Bryan reported that one of Jeremiah’s objections is that we haven’t defined the problem first and have jumped to a solution, perhaps there’s other ways of dealing with the problem if we define it clearly.
 * So what are the problems?
-    1. Fundamental problem: CTC reports to TSC, will their interests always be in alignment?
-    2. Need concrete minimum qualifications for TSC membership.
-    3. Difficulty in explaining technical governance structure to outsiders.
+  1. Fundamental problem: CTC reports to TSC, will their interests always be in alignment?
+  2. Need concrete minimum qualifications for TSC membership.
+  3. Difficulty in explaining technical governance structure to outsiders.
 
 ### Investigate moving `nvm` into the foundation [#96](https://github.com/nodejs/TSC/issues/96)
 

--- a/meetings/2016-11-03.md
+++ b/meetings/2016-11-03.md
@@ -80,7 +80,7 @@ will that solve this issue?
 Josh: Perhaps still a question of redundancy between CTC and TSC.
 
 Rod: Emphasize the Board supports the TSC, TSC supports the CTC. Their role is
-to *serve* the sub-bodies.
+to _serve_ the sub-bodies.
 
 Mikeal: Perhaps outline the areas which the TSC holds sole responsibility for.
 
@@ -103,14 +103,14 @@ The same applies to TSC and CTC.
 
 * Rod to discuss with CTC and better understand their concerns.
 
----
+***
 
 ### charter: revised membership rules [#142](https://github.com/nodejs/TSC/pull/142)
 
 William: We should change bylaws accordingly once we make changes locally (in
 GitHub).
 
----
+***
 
 ### Investigate moving `nvm` into the foundation [#96](https://github.com/nodejs/TSC/issues/96)
 
@@ -127,7 +127,7 @@ or otherwise. We want recommendations and plan from the group.
   collaborate and make a roadmap/recommendation to TSC and CTC.
 * Revisit in next meeting (11/17).
 
----
+***
 
 ### Other
 
@@ -135,13 +135,13 @@ William: Live TSC or CTC meetings at Node.js Interactive?
 
 Rod: If William can handle logistics.
 
----
+***
 
 ## Q/A
 
 None.
 
----
+***
 
 ## Next Meeting
 

--- a/meetings/2016-11-17.md
+++ b/meetings/2016-11-17.md
@@ -66,7 +66,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests from the
 
 * @rvagg: Yes, but we need to know that a group is addressing strategic
   questions and there are sufficient people and effort in it. Then we can
-consider bringing in specific projects like nvm.
+  consider bringing in specific projects like nvm.
 
 * @mikeal: Main concern for TSC is to ensure a stable contributing group.
 
@@ -87,7 +87,7 @@ Next steps:
 * @williamkapke will update #96 accordingly.
 * version-management discussion group to continue defining strategy.
 
----
+***
 
 ### Utilize travel fund for all CTC / TSC members who want to come to Node Interactive [#147](https://github.com/nodejs/TSC/issues/147)
 
@@ -107,7 +107,7 @@ Next steps:
 
 ### charter: revised membership rules [#142](https://github.com/nodejs/TSC/pull/142)
 
----
+***
 
 ## Q/A
 

--- a/meetings/2016-12-15.md
+++ b/meetings/2016-12-15.md
@@ -57,8 +57,10 @@ Extracted from **tsc-agenda** labelled issues and pull requests from the
 
 * Utilize travel fund for all CTC / TSC members who want to come to Node
   Interactive [#147](https://github.com/nodejs/TSC/issues/147)
+
 * Add scope of responsibility for TSC ("Define Node Core" cont.)
   [#144](https://github.com/nodejs/TSC/pull/144)
+
 * charter: revised membership rules
   [#142](https://github.com/nodejs/TSC/pull/142)
 
@@ -81,7 +83,7 @@ Anna is comfortable with the politics involved.
 
 @rvagg: TSC members please respond in issue.
 
----
+***
 
 ### Formation of a Security Working Group [#175](https://github.com/nodejs/TSC/issues/175)
 
@@ -99,7 +101,7 @@ Security WG may be orthogonal to NSP integration.
 of new Security WG, and ensure focus of WG.
 
 @mikeal: Foundation is now taking responsibility for managing vulnerabilities
-and disclosures for core *and* module ecosystem.
+and disclosures for core _and_ module ecosystem.
 
 All seem to agree that there should be a separate group for vulnerabilities in
 core. The Security WG would be a broader group to manage vulnerabilities in the
@@ -118,7 +120,7 @@ project. But we’ll look to the advice of this advisory group.
 
 @sam-github to connect with @rvagg and @mikeal as needed.
 
----
+***
 
 ### Updating the Copyright [#174](https://github.com/nodejs/TSC/issues/174)
 
@@ -144,9 +146,9 @@ There will then be 2 PRs:
 
 1. Restore headers to original text mentioning Joyent etc.
 2. Update and reduce headers to something more desirable, such as SPDX, URL to
-license, etc.
+   license, etc.
 
----
+***
 
 ### Utilize travel fund for all CTC / TSC members who want to come to Node Interactive [#147](https://github.com/nodejs/TSC/issues/147)
 
@@ -177,7 +179,7 @@ Initial allocation for 2017 was reduced because we didn’t need/use that much i
 * Update guidance document.
 * Set up request system via GitHub doc and PRs.
 
----
+***
 
 ### Add scope of responsibility for TSC ("Define Node Core" cont.)
 
@@ -186,7 +188,7 @@ Initial allocation for 2017 was reduced because we didn’t need/use that much i
 @rvagg: Reviewed with Board. Only feedback was no mention of projects brought in
 by Board, which Rod will add.
 
----
+***
 
 ### charter: revised membership rules
 
@@ -194,7 +196,7 @@ by Board, which Rod will add.
 
 Revisit in new year.
 
----
+***
 
 ### Investigate moving `nvm` into the foundation
 
@@ -213,13 +215,13 @@ Latest meeting (see last section):
 
 See also: <https://github.com/nodejs/version-management/issues/10>
 
----
+***
 
 ## Q/A
 
 None.
 
----
+***
 
 ## Next Meeting
 

--- a/meetings/2017-01-12.md
+++ b/meetings/2017-01-12.md
@@ -97,13 +97,13 @@ Extracted from **tsc-agenda** labelled issues and pull requests from the
 * Voted to bring this into the nodejs GitHub org _pending_ a vote on the CTC
   that this is what they want to do.
 
----
+***
 
 ## Q/A
 
 None.
 
----
+***
 
 ## Next Meeting
 

--- a/meetings/2017-01-26.md
+++ b/meetings/2017-01-26.md
@@ -61,7 +61,7 @@
 * nvm and version-management
 * node-inspect
 
----
+***
 
 ## Minutes
 
@@ -73,7 +73,7 @@
 Waiting on transfer of data from nsp. Bill of sale is on board agenda for
 Jan-30. Hopefully will be able to transfer some time next week.
 
----
+***
 
 ### version-management & nvm
 
@@ -97,7 +97,7 @@ repo and Discussion Group active.
 
 * Update #96 and remove from tsc-agenda, but leave repo active.
 
----
+***
 
 ### Copyright
 
@@ -128,7 +128,7 @@ previously included it can’t be removed.
 
 * PR to add list of requirements for new projects to TSC repo.
 
----
+***
 
 ### Governance & TSC
 
@@ -137,7 +137,7 @@ previously included it can’t be removed.
 
 Ping @jasnell for update.
 
----
+***
 
 * General update to the Member travel fund doc
   [TSC#181](https://github.com/nodejs/TSC/pull/181)
@@ -157,7 +157,7 @@ Should also add to document how much money has been allocated and spent.
 
 @Fishrock123 will continue discussion and help merge.
 
----
+***
 
 * Rotating meeting times
   [TSC#198](https://github.com/nodejs/TSC/issues/198)
@@ -178,23 +178,23 @@ Can we find a time which works for Ben, Rod, and American folks?
 
 * Continue discussion in GitHub.
 
----
+***
 
 ### Community Committee
 
 * ...migrate Inclusivity Working Group...
-    [TSC#179](https://github.com/nodejs/TSC/issues/179)
+  [TSC#179](https://github.com/nodejs/TSC/issues/179)
 * <https://github.com/nodejs/community-committee>
 
 No updates.
 
----
+***
 
 ## Q/A
 
 None.
 
----
+***
 
 ## Next Meeting
 

--- a/meetings/2017-02-09.md
+++ b/meetings/2017-02-09.md
@@ -64,7 +64,7 @@
 * ...migrate Inclusivity Working Group...
   [TSC#179](https://github.com/nodejs/TSC/issues/179)
 
----
+***
 
 ## Minutes
 
@@ -89,7 +89,7 @@ Next steps:
 
 * Vote in issue or privately, James will report results.
 
----
+***
 
 ### Copyright Date [TSC#195](https://github.com/nodejs/TSC/issues/195)
 
@@ -110,7 +110,7 @@ Next steps:
 
 * Refer question to Board.
 
----
+***
 
 ### Formation of a Security Working Group [TSC#175](https://github.com/nodejs/TSC/issues/175)
 
@@ -124,7 +124,7 @@ Next steps:
 * @mikeal to contact Adam Baldwin.
 * Remove from tsc-agenda.
 
----
+***
 
 ### Updating the Copyright [TSC#174](https://github.com/nodejs/TSC/issues/174)
 
@@ -133,7 +133,7 @@ Once Board approves first PR it will land.
 Second PR (updated copyright header) needs review by Board and copyright holders
 before it can land. Initial review next week, final approval later.
 
-James added linting, docs in COLLABORATOR_GUIDE.md. It’s ready to go, waiting on
+James added linting, docs in COLLABORATOR\_GUIDE.md. It’s ready to go, waiting on
 Board.
 Do we need to backport to LTS lines? @mikeal: No, we have approval to update
 master alone.
@@ -142,13 +142,13 @@ Next steps:
 
 * Await Board and Legal Committee direction.
 
----
+***
 
 ### Utilize travel fund for all CTC / TSC members who want to come to Node Interactive [TSC#147](https://github.com/nodejs/TSC/issues/147)
 
 This should be closed and removed from agenda.
 
----
+***
 
 ### charter: revised membership rules [node#142](https://github.com/nodejs/TSC/pull/142)
 
@@ -167,7 +167,7 @@ Next steps:
 * Votes from TSC.
 * Add to Board agenda.
 
----
+***
 
 ### Rotating meeting times [TSC#198](https://github.com/nodejs/TSC/issues/198)
 
@@ -178,17 +178,17 @@ Next steps:
 
 * Review the doc and propose some times.
 
----
+***
 
 ## Q/A
 
 Q: Should we support a Collaboration Summit around JSConf EU in May (see
 [summit#39](https://github.com/nodejs/summit/issues/39)?
 
-A: Sure, we just need people to drive it. There’s a Code&Learn being planned by
+A: Sure, we just need people to drive it. There’s a Code\&Learn being planned by
 Rich and Anna around that conference too.
 
----
+***
 
 ## Next Meeting
 

--- a/meetings/2017-02-23.md
+++ b/meetings/2017-02-23.md
@@ -84,7 +84,7 @@ fund requests we can ask people to open issues in nodejs/TSC.
 * Seek a volunteer, possibly @addaleax or @eljefedelrodeodeljefe to lead and
   make concrete proposal.
 
----
+***
 
 ### nominating @joshgav to the TSC [#205](https://github.com/nodejs/TSC/issues/205)
 
@@ -93,14 +93,14 @@ fund requests we can ask people to open issues in nodejs/TSC.
 What about @mhdawson and @addaleax? Would be helpful for attaining quorum. Also
 good to officially include those who are contributing. No objections.
 
----
+***
 
 ### Copyright Date [#195](https://github.com/nodejs/TSC/issues/195)
 
 Was discussed at Board meeting, when @mikeal reviews Board notes he’ll update
 issue.
 
----
+***
 
 ### Updating the Copyright [#174](https://github.com/nodejs/TSC/issues/174)
 
@@ -110,13 +110,13 @@ Board ratified first PR
 Second PR ([node#10599](https://github.com/nodejs/node/pull/10599)) still under
 discussion with Legal Committee and Board. No timeline for answer.
 
----
+***
 
 ### charter: revised membership rules [#142](https://github.com/nodejs/TSC/pull/142)
 
 Vote was called for, still awaiting quorum.
 
----
+***
 
 ### npm package managed for node.js foundation modules [TSC#211](https://github.com/nodejs/TSC/issues/211)
 
@@ -134,13 +134,13 @@ compatibility, so best not to use.
 
 * Continue discussion on GH.
 
----
+***
 
 ## Q/A
 
 None.
 
----
+***
 
 ## Next Meeting
 

--- a/meetings/2017-03-09.md
+++ b/meetings/2017-03-09.md
@@ -46,12 +46,12 @@
 ### Next Collaboration Summit [#39](https://github.com/nodejs/summit/issues/39)
 
 * Settling on May 4-5th, and for doing it.  Anna will send out
-    email now to see how many people may will attend, or open an
-    issue to just ask the question.
+  email now to see how many people may will attend, or open an
+  issue to just ask the question.
 * Tracy, if we need funds/allocation we just need the date and
-    Details and then she can help on that side.
+  Details and then she can help on that side.
 * Agreed on May 4-5, Anna to send out email to collaborators to get
-    numbers.
+  numbers.
 
 ### nominating @joshgav to the TSC [#205](https://github.com/nodejs/TSC/issues/205)
 
@@ -62,15 +62,15 @@
 ### Copyright Date [#195](https://github.com/nodejs/TSC/issues/195)
 
 * Rod.  What should we be doing here ?   No answer on the legal
-    front so far.  James posted good summary last week, let.s push
-    to board.  Rod will forward questions to board to see if they
-    want to answer or forward to legal committee.
+  front so far.  James posted good summary last week, let.s push
+  to board.  Rod will forward questions to board to see if they
+  want to answer or forward to legal committee.
 
 ### Updating the Copyright [#174](https://github.com/nodejs/TSC/issues/174)
 
 * PR 1 ready to go, likely to land this week.
 * Still need feedback from legal committee on PR 2 -
-    <https://github.com/nodejs/TSC/pull/174>.
+  <https://github.com/nodejs/TSC/pull/174>.
 
 ### charter: revised membership rules [#142](https://github.com/nodejs/TSC/pull/142)
 
@@ -78,30 +78,30 @@
 * now 6 out of 12 votes so far.
 * Need 2/3 so we need to get to 8 votes.
 * Bert has now raised some concerns on issue.  Instead of
-    attendance rule, have to vote as opposed to attending
-    Meetings.
+  attendance rule, have to vote as opposed to attending
+  Meetings.
 * James, don.t want to drag on too much longer, lets
-    Bring back for vote next week. Between now and then
-    continue discussion in github.
+  Bring back for vote next week. Between now and then
+  continue discussion in github.
 * James will cast as .participation. as opposed to attending
-    Meetings, and define participation which may include commenting
-    on issues, voting, being involved in meeting etc.
+  Meetings, and define participation which may include commenting
+  on issues, voting, being involved in meeting etc.
 
 ### 1 Code of Conduct for everything? [#7](https://github.com/nodejs/community-committee/issues/7)
 
 * discussion around moving CoC into own repo and then
-    link to it from everywhere else.
+  link to it from everywhere else.
 * Would allow it to be modified across the board more
-    easily.
+  easily.
 * Currently in working group template, often just copied
-    in to WG repos, now not all of them are in sync.
+  in to WG repos, now not all of them are in sync.
 * Does not change the rules that allow WGs to set their
-    own so WG does not have to use common version, but we expect
-    that most will.
+  own so WG does not have to use common version, but we expect
+  that most will.
 * overall agreement that this is a good idea and we.ll take it
-    back into github.
+  back into github.
 
----
+***
 
 ## Q/A
 
@@ -118,7 +118,7 @@
     not necessarily fit with use case, but would need more detail
     to answer properly.
 
----
+***
 
 ## Next Meeting
 

--- a/meetings/2017-03-23.md
+++ b/meetings/2017-03-23.md
@@ -47,7 +47,7 @@ Are non-collaborators invited? Yes.
 
 * Continue discussion in GH.
 
----
+***
 
 ### Copyright
 
@@ -56,7 +56,7 @@ Are non-collaborators invited? Yes.
 
 To be discussed at upcoming Board meeting.
 
----
+***
 
 ### 1 Code of Conduct for everything? [community-committee#7](https://github.com/nodejs/community-committee/issues/7)
 
@@ -80,7 +80,7 @@ Propose to keep stub for a year, then remove.
 
 * @jasnell to open PR to move code of conduct to TSC repo and replace in other repos with stubs.
 
----
+***
 
 ### charter: revised membership rules [TSC#142](https://github.com/nodejs/TSC/pull/142)
 
@@ -118,13 +118,13 @@ Conclusion: Go with simple majority/>50% for everything to minimize friction. As
 * @jasnell to update PR and request feedback from TSC.
 * @mikeal to consider for presentation at next board meeting.
 
----
+***
 
 ## Q/A
 
 Unusual posts and snippets coming from <https://medium.com/@nodejs> RSS feed. @joshgav to investigate and file issue if needed.
 
----
+***
 
 ## Next Meeting
 

--- a/meetings/2017-04-06.md
+++ b/meetings/2017-04-06.md
@@ -80,6 +80,7 @@
   guaranteed to continue. If not TSC or CTC who?
 
 * @mhdawson: Could be opt-in for those members.
+
 * @nebrius: Greater access also increases risk from greater surface area.
 
 * Next steps:
@@ -88,20 +89,20 @@
 
 Michael to open the 2 issues.
 
----
+***
 
 ## Q/A
 
 * Has node ever applied for Google Summer of Code/Google Code-In?
   * as a foundation no
   * but sort of as part of outreachy as it came out of google summer
-  of code to get more diversity in the candidates
+    of code to get more diversity in the candidates
   * Tracy is working on future internship programs.
 
 * Question -> Effective memory management in Node.js
   * will direct to github repo
 
----
+***
 
 ## Next Meeting
 

--- a/meetings/2017-06-01.md
+++ b/meetings/2017-06-01.md
@@ -26,7 +26,7 @@ from the **nodejs org** prior to the meeting.
 
 ### nodejs/readable-stream
 
-* Bring string_decoder into the foundation
+* Bring string\_decoder into the foundation
   [#272](https://github.com/nodejs/readable-stream/issues/272)
 
 ### nodejs/TSC
@@ -52,10 +52,10 @@ from the **nodejs org** prior to the meeting.
 * For now we'll switch over to hangouts for the next
   meeting until Myles reports.
 
-### Bring string_decoder into the foundation [#272](https://github.com/nodejs/readable-stream/issues/272)
+### Bring string\_decoder into the foundation [#272](https://github.com/nodejs/readable-stream/issues/272)
 
 * There are no objections from the CTC.  Added comment to TSC issue
-  [#260}(<https://github.com/nodejs/TSC/issues/260>) to say will
+  \[#260}(<https://github.com/nodejs/TSC/issues/260>) to say will
   Be considered to be approved unless there are objections by Monday June 5.
 
 ### Request to move moderation responsibilities to CommComm[#270](https://github.com/nodejs/TSC/issues/270)

--- a/meetings/2017-09-13.md
+++ b/meetings/2017-09-13.md
@@ -66,7 +66,7 @@ We skipped this as we had a packed agenda.
 
 * TSC Meeting Schedule [#336](https://github.com/nodejs/TSC/issues/336)
   * We should revisit quarterly, ideally aligned with
-  daylight savings times changes.
+    daylight savings times changes.
   * Agreed we should move forward with the proposed times.
 
 * 2FA for the entire org [#301](https://github.com/nodejs/TSC/issues/301)
@@ -98,12 +98,12 @@ We skipped this as we had a packed agenda.
   * prefer not to tack on properties to people’s object
   * having bundled into separate objects is better
   * anna, Brian are you ok with current state ?
-  * Brian, _ not ideal but if we can’t agree on any alternatives yes
+  * Brian, \_ not ideal but if we can’t agree on any alternatives yes
   * Can’t explain how it works without including discussions of
     internal state machine.
   * If we have separate object that refers to existing one, but
     Matteo believes this may be an issue due to additional allocation
-  * Jeremiah just consider _XX for writable and readable part of
+  * Jeremiah just consider \_XX for writable and readable part of
     public API and doc.  Brian does not prefer this but if not other
     good solutions then keep as is.
   * Matteo, fine to close all issues, but has been requested in
@@ -117,13 +117,13 @@ We skipped this as we had a packed agenda.
 
 * Land 6.1 into 8 LTS
 * V8 team has worked on abi compatible patches (unclear if this
-    is complete yet)
+  is complete yet)
 * V8 reports that 6.1 has a larger number of fixes that would help
-    ongoing maintenance
+  ongoing maintenance
 * Rod, originally we said 2 months at one point
 * We would need to set end Oct as LTS release date
 * Research this week on risk/reward and push decision to LTS/Release
-    working group for informed decision on upcoming Monday LTS/Release meeting
+  working group for informed decision on upcoming Monday LTS/Release meeting
 
 ### nodejs/security-wg
 
@@ -139,7 +139,7 @@ We skipped this as we had a packed agenda.
   * Ongoing discussion over last week
   * Most appropriate to discuss next steps in private section of meeting
 
-## Q&A, Other
+## Q\&A, Other
 
 * not seen simple user access control with react ?
   * we are not sure what the questions is.

--- a/meetings/2017-09-20.md
+++ b/meetings/2017-09-20.md
@@ -71,7 +71,7 @@
   * Consensus was to move forward unless someone objects in the issue
     in the next week.
 
-## Q&A, Other
+## Q\&A, Other
 
 * Planning for collaborator summit is ongoing
   * Plan for every working group to plan something.

--- a/meetings/2017-09-27.md
+++ b/meetings/2017-09-27.md
@@ -33,7 +33,7 @@ the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
-* path: deprecate internal _makeLong, replace [#14956](https://github.com/nodejs/node/pull/14956)
+* path: deprecate internal \_makeLong, replace [#14956](https://github.com/nodejs/node/pull/14956)
 
 ### nodejs/TSC
 
@@ -64,19 +64,23 @@ No announcements this week
 
 ### nodejs/node
 
-* path: deprecate internal _makeLong, replace [#14956](https://github.com/nodejs/node/pull/14956)
+* path: deprecate internal \_makeLong, replace [#14956](https://github.com/nodejs/node/pull/14956)
   * Matteo, new module work to enable ES7 there are certain
     Functions from core that are pre-fixed that are required
     Proposes to remove underscore so that it is part of the
     public API.  Likely to be used by lodash so would be heavy
     Usage.
+
   * Anna what need to see if anybody objects to it happening ?
+
   * Put into 9 and revert if pushback ?
+
   * Rich: Seems like no main objections in the issue so it could land ?
+
   * Ben has asked that we answer these 2 questions:
     * Are we comfortable promoting this to officially supported API?
       That effectively freezes it for all eternity, or as good as.
-      path._makeLong() has been tweaked over the years. A likely outcome
+      path.\_makeLong() has been tweaked over the years. A likely outcome
       is that we end up with a tweaked internal copy sooner or later and then we
       are back to square one.
     * Is it so widely useful that it should be part of core?1 Why can't
@@ -149,7 +153,7 @@ No announcements this week
 * kick off discussion.
 * Ran out of time roll over to next meeting
 
-## Q&A, Other
+## Q\&A, Other
 
 * bitbang, would be confusing to have 2 LTS version of 8
 

--- a/meetings/2017-10-11.md
+++ b/meetings/2017-10-11.md
@@ -10,12 +10,19 @@
 ## Present
 
 * Franziska Hinkelmann @fhinkel (TSC)
+
 * Joyee Cheung @joyeecheung (TSC)
+
 * Matteo Collina @mcollina (TSC)
+
 * Michael Dawson @mhdawson (TSC)
+
 * Myles Borins @MylesBorins (TSC)
+
 * Rod Vagg @rvagg (TSC)
+
 * Rich Trott @Trott (TSC)
+
 * Trevor Norris @trevnorris (TSC)
 
 * Gibson Fahnestock @gibfahn (Release WG delegate for update/observer)
@@ -76,7 +83,7 @@ Extracted from **tsc-agenda** labelled issues and pull requests from the **nodej
 
 There were rolled over to the next meeting:
 
-* async_hooks: skip sanity checks when disabled [#15454](https://github.com/nodejs/node/pull/15454)
+* async\_hooks: skip sanity checks when disabled [#15454](https://github.com/nodejs/node/pull/15454)
 * buffer: runtime-deprecate Buffer ctor by default [#15346](https://github.com/nodejs/node/pull/15346)
 * http: send 400 bad request on parse error [#15324](https://github.com/nodejs/node/pull/15324)
 * stream: move prefixed files into internal/streams. [#11957](https://github.com/nodejs/node/pull/11957)
@@ -110,7 +117,7 @@ These were rolled over to the next meeting:
   * Generally no objection to landing before values discussion closes
     but we need input from CommComm as well.
 
-## Q&A, Other
+## Q\&A, Other
 
 * No questions this week.
 

--- a/meetings/2017-10-18.md
+++ b/meetings/2017-10-18.md
@@ -36,7 +36,7 @@ No announcements this week.
 
 #### Benchmarking Work Group
 
-*Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/build
 
@@ -68,7 +68,7 @@ No announcements this week.
   * Nikita: +1 to deprecating FIPS.
   * ACTION ITEM: Myles, James, Michael, hopefully Fedor and Shigeki, maybe others, will talk about this and bring back a proposal.
 
-* async_hooks: skip sanity checks when disabled [#15454](https://github.com/nodejs/node/pull/15454)
+* async\_hooks: skip sanity checks when disabled [#15454](https://github.com/nodejs/node/pull/15454)
   * Matteo: some asserts in place, they were causing failures
     in tests even without async hooks being enabled (needed to
     rush release to fix hapi).  Question is about making the
@@ -88,7 +88,7 @@ No announcements this week.
   * Evan: So the bugs we have left are fixable?
   * James: Yes.
 
-* http2: expose http2 by default, add NODE_NO_HTTP2  [#15685](https://github.com/nodejs/node/pull/15685)
+* http2: expose http2 by default, add NODE\_NO\_HTTP2  [#15685](https://github.com/nodejs/node/pull/15685)
   * change has happened in master
   * time sensitive is discussion about getting it into 8.x
   * existing http2 modules in userland.  This would
@@ -102,6 +102,7 @@ No announcements this week.
     deprecated
   * Rich, has action to feel out people as to where we stand
     collectively.
+
 * http: send 400 bad request on parse error [#15324](https://github.com/nodejs/node/pull/15324)
   * discussed, additional votes will be added by Rich/Ali, hope is that this pushes it over the 50% level.
 
@@ -137,7 +138,7 @@ No announcements this week.
 * doc: doc expectations on TSC and CommComm members [#12](https://github.com/nodejs/admin/pull/12)
   * roll over as we are out of time
 
-## Q&A, Other
+## Q\&A, Other
 
 * why report the DOS vulnerabilty ?
   * to give people time to prepare to be able to apply quickly once

--- a/meetings/2017-10-25.md
+++ b/meetings/2017-10-25.md
@@ -36,21 +36,29 @@
 
 * 10 members, so far have had to be intervene in 0 issues, though there were 2 requests
   for guidance
+
 * team not working group
+
 * scope set as enforcing policies, not setting them.
+
 * With thefourtheye joining the team now has global timezone coverage
   (this has been challenge due to being a small team)
+
 * Work coordinated through a slack workspace
+
 * Tracy looking at training for moderation team members
+
 * Team will suggest moderation changes, iteration based on experience gained
   through events.  These will come to TSC or other areas for TSC/CommComm to review.
+
 * Myles, one thing for moderation team to think about is moderation requests
   about leadership.  This is something Myles would be interested to see suggestion
   as to process for this (since they need to implement it).
+
 * Forrest, as long as policy is clear enough, it should be able to be applied to
   leaders and members alike.
 
-*Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -76,6 +84,7 @@
     criteria.
 
 * stream: move prefixed files into internal/streams. [#11957](https://github.com/nodejs/node/pull/11957)
+
 * Enable explicit `.m.js` intent for ESM [#16170](https://github.com/nodejs/node/pull/16170)
   * remove from agenda at this.
 
@@ -102,7 +111,7 @@
   * William mentioned current version has removed some references to values and
     believes we should not block either.
 
-## Q&A, Other
+## Q\&A, Other
 
 * From irc, Bryan English, number of uncharted WG's not an issue to have groups to
   work on things which are uncharted.  Michael maybe we can ask the

--- a/meetings/2017-11-01.md
+++ b/meetings/2017-11-01.md
@@ -22,7 +22,7 @@
 
 ## Announcements
 
-*Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -38,9 +38,9 @@
   * Myles, running update at start, comparison to standup, part of reason they stopped
     making sense was due to numbers.
   * Myles, initially thought it would be something that puts the project at risk if not done
-  if we don't align on it
+    if we don't align on it
   * Take back to github for now.  All on TSC please review/comment as to scope of what should
-  be on the list.
+    be on the list.
   * Lets work on a stronger definition as well.
 
 * Proposal to form a Governance Working Group [#383](https://github.com/nodejs/TSC/issues/383)
@@ -56,7 +56,7 @@
   * Defer until we have a meeting with James and until then take discussion back to
     github.
 
-## Q&A, Other
+## Q\&A, Other
 
 No questions today.
 

--- a/meetings/2017-11-08.md
+++ b/meetings/2017-11-08.md
@@ -9,18 +9,31 @@
 ## Present
 
 * Сковорода Никита Андреевич @ChALkeR
+
 * Colin Ihrig @cjihrig
+
 * Evan Lucas @evanlucas
+
 * Franziska Hinkelmann @fhinkel
+
 * Jeremiah Senkpiel @Fishrock123
+
 * James M Snell @jasnell
+
 * Matteo Collina @mcollina
+
 * Michael Dawson @mhdawson
+
 * Myles Borins @mylesborins
+
 * Ali Ijaz Sheikh @ofrobots
+
 * Michaël Zasso @targos
+
 * Sakthipriyan Vairamani @thefourtheye
+
 * Rich Trott @Trott
+
 * Trevor Norris @trevnorris
 
 * William Kapke (observer)  @williamkapke
@@ -65,9 +78,9 @@ Myles: I’ll add some language to make things clear.
 ### nodejs/summit
 
 * Node.js collaborator summit in Berlin before or after JSConfEU?
-JSConfEU is on June 2nd & 3rd 2018 (Saturday & Sunday). CSSConf is on June 1st 2018 (Friday). See <https://github.com/nodejs/summit/issues/56>
+  JSConfEU is on June 2nd & 3rd 2018 (Saturday & Sunday). CSSConf is on June 1st 2018 (Friday). See <https://github.com/nodejs/summit/issues/56>
 
-## Q&A, Other
+## Q\&A, Other
 
 No questions.
 

--- a/meetings/2017-11-15.md
+++ b/meetings/2017-11-15.md
@@ -66,15 +66,15 @@ Standards track requires a standards body to write an RFC for the MIME type. It�
 
 Q: Can the Foundation be used as the contact?
 
-Jasnell: tl/dr; version: Mime types can be registered Standards track or Vendor track as described here: <https://tools.ietf.org/html/rfc4288#section-3.1>. Vendor track is for commercial products, Standards track is for stuff that is of “general" interest. The IESG/IETF may be viewing this in the latter case -- in general, they prefer things *not* to be Vendor track as much as possible. The concern is that Standards track takes longer and requires an RFC to be published, which any one of us could write up. It doesn’t require Board action to push through, so we should get Bradley’s reasoning for why he’d like to see that. Also, fwiw, I’ve written many RFC’s to this point and I’m quite familiar with the process so can help push this forward.
+Jasnell: tl/dr; version: Mime types can be registered Standards track or Vendor track as described here: <https://tools.ietf.org/html/rfc4288#section-3.1>. Vendor track is for commercial products, Standards track is for stuff that is of “general" interest. The IESG/IETF may be viewing this in the latter case -- in general, they prefer things _not_ to be Vendor track as much as possible. The concern is that Standards track takes longer and requires an RFC to be published, which any one of us could write up. It doesn’t require Board action to push through, so we should get Bradley’s reasoning for why he’d like to see that. Also, fwiw, I’ve written many RFC’s to this point and I’m quite familiar with the process so can help push this forward.
 
 Myles, James, and Bradley will figure this out in email and either get it done or else bring it back to the TSC next week.
 
-## Q&A, Other
+## Q\&A, Other
 
 “Should ES6 import/export work under .mjs without harmony flags? Only from 9 version of Node.js?”
 
---experimental-modules flag in version 9
+\--experimental-modules flag in version 9
 
 ## Upcoming Meetings
 

--- a/meetings/2017-11-22.md
+++ b/meetings/2017-11-22.md
@@ -24,7 +24,7 @@
 
 * no announcements.
 
-*Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -54,7 +54,7 @@
       * Myles added to agenda
       * Added comment to issue to ask that more context as to what the question is for the TSC.
 
-## Q&A, Other
+## Q\&A, Other
 
 No questions this week.
 

--- a/meetings/2017-11-29.md
+++ b/meetings/2017-11-29.md
@@ -24,7 +24,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -68,7 +68,7 @@
 * Foundation Medium blog post on modules
   * we brought this up and no objections using the Foundation Medium blog
 
-## Q&A, Other
+## Q\&A, Other
 
 No questions this week.
 

--- a/meetings/2017-12-06.md
+++ b/meetings/2017-12-06.md
@@ -28,7 +28,7 @@
 
 * No announcements this week.
 
-*Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -151,7 +151,7 @@
         may be one of the modules we can get real-life usage. Push on testing and documentation
         continues.
 
-## Q&A, Other
+## Q\&A, Other
 
 No questsions this week.
 

--- a/meetings/2017-12-13.md
+++ b/meetings/2017-12-13.md
@@ -21,7 +21,7 @@
 
 * Collab summit Berlin, most likely on May 31 - Friday, June 1, 2018. The 2 days prior to JSConf.eu [#56](https://github.com/nodejs/summit/issues/56).
 
-*Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -29,7 +29,7 @@
 
 Rich: GitHub conversation did not get “unstuck”. Move to vote.
 
-* DO NOT MERGE: \[module\] Revert checking for package.json before extensions [#15015](https://github.com/nodejs/node/pull/15015)
+* DO NOT MERGE: \[module] Revert checking for package.json before extensions [#15015](https://github.com/nodejs/node/pull/15015)
 
 Michaël: Need an update from Bradley
 
@@ -64,7 +64,7 @@ Rich: Probably. Let’s gather what votes we can though.
 
 “Yes” votes from this meeting’s attendes and email: Rich, Franzi, Michaël Zasso, Trevor, Nikita, Anna, James, Michael Dawson, Colin, Evan, Matteo
 
-\[Post-meeting note from Rich: That’s enough votes to declare it official. Will move forward with it on GitHub.\]
+\[Post-meeting note from Rich: That’s enough votes to declare it official. Will move forward with it on GitHub.]
 
 * Document guidelines for accountability expectations for all members of the TSC and CommComm [#311](https://github.com/nodejs/TSC/issues/311)
 
@@ -76,7 +76,7 @@ Franzi: Myles put it on the agenda and wanted to know if we should work on it or
 
 Rich: +1
 
-## Q&A, Other
+## Q\&A, Other
 
 ## Upcoming Meetings
 

--- a/meetings/2017-12-20.md
+++ b/meetings/2017-12-20.md
@@ -65,7 +65,7 @@ Yes: Michaël, Myles, Franzi, Ali, Jeremiah, Rich, Trevor, Nikita
 Abstain: Matteo, Sakthi, Colin
 
 * Mentorship initiative ramping up. [#443](https://github.com/nodejs/TSC/issues/443)
-@mhdawson
+  @mhdawson
 
 Rich: This is Michael Dawson’s issue. He opened it and he put it on the agenda. He’s not here today, so I propose that we table it until he gets back (which is expected to be the second meeting in January). It seems like he may have only put it on the agenda for awareness anyway, so maybe go check out the issue and repo that is linked there?
 
@@ -99,7 +99,7 @@ Rich: Love it.
 
 Myles: I’m a fan.
 
-## Q&A, Other
+## Q\&A, Other
 
 ## Upcoming Meetings
 

--- a/meetings/2018-01-10.md
+++ b/meetings/2018-01-10.md
@@ -34,12 +34,13 @@
   10.x branch then.
 * Release group is discussing creating a more concrete schedule for releases
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/TSC
 
 * Mentorship initiative ramping up. [#443](https://github.com/nodejs/TSC/issues/443)
   * Just wanted to make sure everybody is aware
+
 * Enterprise Advisory Group [#431](https://github.com/nodejs/TSC/issues/431)
   * James: Heads up at this point. Goal is to look at things happening core and provide
     feedback. TSC members to be invited as observers as opposed to members.
@@ -110,7 +111,7 @@
 * GitHub Owner permissions [#33](https://github.com/nodejs/admin/issues/33)
   * Will be pushing to get consensus on this within 1 week or less.
 
-## Q&A, Other
+## Q\&A, Other
 
 * Some questions on feedback group, addressed earlier on
 * Some positive kudos on keeping up the good work
@@ -120,4 +121,4 @@
 ## Upcoming Meetings
 
 * **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
-Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
+  Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-01-17.md
+++ b/meetings/2018-01-17.md
@@ -27,18 +27,18 @@
 ### nodejs/TSC
 
 * Moderation access [#469](https://github.com/nodejs/TSC/pull/469)
-Michael: Bot for the future is OK, but we shouldn’t stand in the way any longer of the Moderation Team being able to do their job now.
-Rod: I’ve said my piece. I don’t like it. But I’m not going to hold it up.
-Jeremiah & James discussed possibilities of org being deleted the way NodeSchool was.
-Michael: We should continue to work on ways to limit the total number of people with privileges.
-Rod: I will say that so far I’m impressed with the professionalism of the Moderation Team. My concern about the individuals is minimal. It’s an organizational precedent-setting concern.
-Jeremiah: I agree with Anna in the chat that it’s not easy to delete the org accidentally nowadays.
-Michael: We tried to set the expectation in the PR to limit Moderation Team
-activity to just what they need to do to moderate.
-Jeremiah: I might contact GitHub just to see whats changed.
-Rich will take the action item of making sure that 2FA is enabled on all Moderation Team members, and that this is communicated to Moderation Team. PR is good to land.
+  Michael: Bot for the future is OK, but we shouldn’t stand in the way any longer of the Moderation Team being able to do their job now.
+  Rod: I’ve said my piece. I don’t like it. But I’m not going to hold it up.
+  Jeremiah & James discussed possibilities of org being deleted the way NodeSchool was.
+  Michael: We should continue to work on ways to limit the total number of people with privileges.
+  Rod: I will say that so far I’m impressed with the professionalism of the Moderation Team. My concern about the individuals is minimal. It’s an organizational precedent-setting concern.
+  Jeremiah: I agree with Anna in the chat that it’s not easy to delete the org accidentally nowadays.
+  Michael: We tried to set the expectation in the PR to limit Moderation Team
+  activity to just what they need to do to moderate.
+  Jeremiah: I might contact GitHub just to see whats changed.
+  Rich will take the action item of making sure that 2FA is enabled on all Moderation Team members, and that this is communicated to Moderation Team. PR is good to land.
 * Enterprise Advisory Group [#431](https://github.com/nodejs/TSC/issues/431)
-Michael and James: This can be removed from the agenda.
+  Michael and James: This can be removed from the agenda.
 * Strategic Initiatives - Tracking Issue [#423](https://github.com/nodejs/TSC/issues/423)
   * N-API - no update since last week.
   * Moderation Team: No significant moderation activity this is week, which is as it should be. There was some conversation about how to make decisions quickly on temp ban vs. indefinite ban. Mostly internal Moderation Team stuff.
@@ -65,16 +65,16 @@ Michael and James: This can be removed from the agenda.
 * Q: Who is responsible for onboarding?
   * A: Joyee, Rich, Anna (if she wants), and any other interested parties will discuss in a separate venue (email, hangout). Rod/Michael ask that if we need more people to onboard, to ask the TSC because the onboarding doc is straightforward.
 * esm: provide named exports for all builtin libraries [#18131](https://github.com/nodejs/node/pull/18131)
-James: Deprecation issue is particularly important. TSC needs to pay attention to this because it’s going to come back to us.
+  James: Deprecation issue is particularly important. TSC needs to pay attention to this because it’s going to come back to us.
 
 ### nodejs/admin
 
 * GitHub Owner permissions [#33](https://github.com/nodejs/admin/issues/33)
-Rich/Michael: Already covered. Rich will remove label and possibly close issue.
+  Rich/Michael: Already covered. Rich will remove label and possibly close issue.
 
-## Q&A, Other
+## Q\&A, Other
 
 ## Upcoming Meetings
 
 * **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
-Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
+  Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2018-01-31-V8.md
+++ b/meetings/2018-01-31-V8.md
@@ -35,7 +35,7 @@
 
 ## Summary
 
-### Performance of async hooks performance ([0:10](http://www.youtube.com/watch?v=a6YtLIaqMqs&t=0m10s))
+### Performance of async hooks performance ([0:10](http://www.youtube.com/watch?v=a6YtLIaqMqs\&t=0m10s))
 
 * Facing up to 30% performance regression (on hapi17) when enabling async hooks.
 * Koa is not as bad.
@@ -54,12 +54,12 @@
 * Async hooks performance will become worse as developers adopt async/await. We need to find a solution.
 * Only part of the problem is the boundary crossing between JS and C++. Other part is weak handle on the promise and the destroy hook.
 * We landed a CL in V8 to reduce Promise size, fewer GCs, better performance. Large allocation in addition to holding onto Promises works against the generational hypothesis for the GC. Having objects survive into old space makes GC more expensive.
-* Are other async hooks aside from Promise bottlenecks? No specific numbers, but experience are ~10%. Mostly from calling nextTicks. 10% might be acceptable for production.
+* Are other async hooks aside from Promise bottlenecks? No specific numbers, but experience are \~10%. Mostly from calling nextTicks. 10% might be acceptable for production.
 * 10% should be the target for Promise and async/await hooks too, to become competitive.
 * Existing APM solutions do not work with async/await.
 * Matteo will create a write-up.
 
-### Update on GYP/GN ([19:50](http://www.youtube.com/watch?v=a6YtLIaqMqs&t=19m50s))
+### Update on GYP/GN ([19:50](http://www.youtube.com/watch?v=a6YtLIaqMqs\&t=19m50s))
 
 * We will remove gyp files from V8 in 6.6.
 * Node will need to inherit them.
@@ -75,18 +75,18 @@
 * For day-to-day test with Canary we could either automate updating file lists or use `--build-v8-with-gn`. In case of the latter we will lose nightly builds for some platforms.
 * GN bridge does not yet work for Windows, but V8 wants to work on this. Also not going to work for AIX or FreeBSD.
 
-### General perception of Promise performance ([27:10](http://www.youtube.com/watch?v=a6YtLIaqMqs&t=27m10s))
+### General perception of Promise performance ([27:10](http://www.youtube.com/watch?v=a6YtLIaqMqs\&t=27m10s))
 
 * What are general issues with Promises?
 * Allocation causing bad GC performance as mentioned previously. Work being done here.
 * Default Promise constructor runs synchronously. FS Promises need to propagate exceptions asynchronously. So the Promise is actually created in a Promise resolver, making this two Promises. Maybe a way to make this faster?
 
-### Status of workers ([29:00](http://www.youtube.com/watch?v=a6YtLIaqMqs&t=29m00s))
+### Status of workers ([29:00](http://www.youtube.com/watch?v=a6YtLIaqMqs\&t=29m00s))
 
 * Anna Henningsen would know best. Sync with her directly makes most sense.
 * SharedArrayBuffers are going to be disabled in the short-term future. The current goal is to re-enable them "at some point".
 
-### V8 extras in Node.js ([31:00](http://www.youtube.com/watch?v=a6YtLIaqMqs&t=31m00s))
+### V8 extras in Node.js ([31:00](http://www.youtube.com/watch?v=a6YtLIaqMqs\&t=31m00s))
 
 * Originally designed to expose V8 internal features to JavaScript so that Chrome can use them to implement web platform features, such as streams.
 * Test coverage is not as good as it could be.
@@ -101,7 +101,7 @@
 * Natives syntax will be phased out, since V8 is moving builtins away from JavaScript implementation. Will still have it for testing purposes.
 * Conclusion: do not use.
 
-### Memory tooling ([37:00](http://www.youtube.com/watch?v=a6YtLIaqMqs&t=37m00s))
+### Memory tooling ([37:00](http://www.youtube.com/watch?v=a6YtLIaqMqs\&t=37m00s))
 
 * Trying to improve memory tooling to debug memory leaks.
 * Heap snapshot is not very usable.
@@ -114,7 +114,7 @@
 * Async patterns could cause issues for the GC by doing too much work for marking.
 * Repro case would be great to work with the GC team. Maybe there are tools that the GC team already uses. Matteo to provide some data.
 
-### GCC/MSVC support in V8 ([47:00](http://www.youtube.com/watch?v=a6YtLIaqMqs&t=47m00s))
+### GCC/MSVC support in V8 ([47:00](http://www.youtube.com/watch?v=a6YtLIaqMqs\&t=47m00s))
 
 * [Presentation](https://docs.google.com/presentation/d/1amWFe4-SHLAeG0jfKJCJIS2JBtN1gljgB0T3sAOqEuQ/edit) on V8 and Clang by Michael Lippautz.
 * V8 currently supports GCC, Clang, and MSVC.
@@ -133,7 +133,7 @@
 * Clang also seems to produce better code than GCC.
 * When is Clang requirement going to happen? No roadmap yet. Currently very early phase. Experiments to implement Clang plugin for verifying handles would be the first step.
 
-### Snapshot support in Node.js ([59:10](http://www.youtube.com/watch?v=a6YtLIaqMqs&t=59m10s))
+### Snapshot support in Node.js ([59:10](http://www.youtube.com/watch?v=a6YtLIaqMqs\&t=59m10s))
 
 * [Node issue](https://github.com/nodejs/node/issues/17058#issuecomment-345231793) to implement custom startup snapshot for Node.js. Estimated speed up for startup is 4x.
 * Alibaba picked this up. Experiment confirms 4x.
@@ -146,7 +146,7 @@
 * Worth doing due to huge performance win. Alibaba might be interested in this because they may be planning to use Node.js as application runtime on mobile.
 * Once this works, we can extend this to user code. Several projects including webpack are very interested in this. This needs a container format to support native modules.
 
-### Spectre and Meltdown ([1:06:10](http://www.youtube.com/watch?v=a6YtLIaqMqs&t=66m10s))
+### Spectre and Meltdown ([1:06:10](http://www.youtube.com/watch?v=a6YtLIaqMqs\&t=66m10s))
 
 * Node.js not directly affected, but OS need to be patched.
 * [V8 announcement](https://groups.google.com/forum/#!topic/v8-users/RAAPBN6um1U). Runtime flag to disable mitigations (`--no-untrusted-code-mitigations`) in favor of performance.
@@ -155,7 +155,7 @@
 * Chrome is not going to provide test coverage in the wild for `--no-untrusted-code-mitigations`.
 * Performance penalty probably upwards of 10%.
 
-### Trace events ([1:09:00](http://www.youtube.com/watch?v=a6YtLIaqMqs&t=69m00s))
+### Trace events ([1:09:00](http://www.youtube.com/watch?v=a6YtLIaqMqs\&t=69m00s))
 
 * Make trace events available for JS with low overhead?
 * Definitely interest, but not super critical.
@@ -163,7 +163,7 @@
 * V8 could provide a JS API to trigger trace events that can be inlined into optimized code.
 * Need some more thought here both in V8 and Node.js.
 
-### REPL mode for V8 parser ([1:12:30](http://www.youtube.com/watch?v=a6YtLIaqMqs&t=72m30s))
+### REPL mode for V8 parser ([1:12:30](http://www.youtube.com/watch?v=a6YtLIaqMqs\&t=72m30s))
 
 * DevTools console and Node.js REPL execute code a bit differently than regular JavaScript.
 * Expectations are not entirely clear.

--- a/meetings/2018-01-31.md
+++ b/meetings/2018-01-31.md
@@ -26,7 +26,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 Moderation team update:
 
@@ -53,7 +53,7 @@ Moderation team update:
   * Matteo, important issue. Schedule modules call to discuss will help move it forward.
   * Matteo will coordinate with Myles meeting to discussion.
 
-* configure: fix type of arm_version [#14595](https://github.com/nodejs/node/pull/14595)
+* configure: fix type of arm\_version [#14595](https://github.com/nodejs/node/pull/14595)
   * Breaking change, so it needs another TSC approval but nobody seems to be comfortable approving.
   * added comment to issue, pushed back to GitHub discussion.
 
@@ -65,7 +65,7 @@ Moderation team update:
   * there is an alternative PR from Bradley, main difference is whether the cache
     is updated or not.
   * Rich will try to work out solution or define option to vote on, issue being fixed was open
-  since 2016 so don't think it is urgent.  Rich will try to get to it this week or next.
+    since 2016 so don't think it is urgent.  Rich will try to get to it this week or next.
 
 ### nodejs/benchmarking
 
@@ -86,14 +86,17 @@ Moderation team update:
     * dynamic import on by default for esm
       * currently you need to use two flags to get dynamic import
       * nodejs/node#18387
+
   * import.meta implementation
     * finding consensus around initial api
     * nodejs/node#18368
+
   * named exports for core modules
     * Important feature we need to release without a flag
     * Debate over if the exported modules should be filtered
     * current implementation may create hazard for apms (@mcollina can speak to this)
     * nodejs/node#18131
+
   * esm mode flag
     * introduces semantic that could allow esm modules with the .js extension
     * per package flags for loading mode
@@ -110,14 +113,14 @@ Moderation team update:
   * in last security-wg meeting, talking about using HackerOne for using modules, which is
     working well. Not much input from core team yet.  More responses since then
   * Vladimir requested and if he joined the core security triage team, it will make it easier
-  to do knowledge transfer
+    to do knowledge transfer
   * Colin asked if there were any objections from those on the call to using HackerOne, none
-  voiced.
+    voiced.
 
-## Q&A, Other
+## Q\&A, Other
 
 * JDD: comments that HackerOne has a few bugs, some concern over how secure it is.
-Suggestion is that he opens specific issues in the security-wg repo to raise the concerns.
+  Suggestion is that he opens specific issues in the security-wg repo to raise the concerns.
 * Guy: asking if <https://github.com/nodejs/node/issues/18233> would address apm concerns.
 * JDD: any plans to use N-API for ESM implementation.  Answer, long term thoughts to use
   N-API for internal implementations but not there yet.

--- a/meetings/2018-02-07.md
+++ b/meetings/2018-02-07.md
@@ -27,11 +27,11 @@
 
 There was no significant Moderation Team activity this week.
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
-* document asserts Weak(Map|Set) behavior #18248**
+* document asserts Weak(Map|Set) behavior #18248\*\*
   * Discuss is taking place in <https://github.com/nodejs/node/issues/18227>
   * good to have summary of discussion from PR in that issue.
   * Ruben to add summary and do mini-poll to gauge general TSC direction on this.
@@ -53,9 +53,11 @@ There was no significant Moderation Team activity this week.
 [#18131](https://github.com/nodejs/node/pull/18131)
 
 * James added to agenda due to being controversial
+
 * Comes down to figuring out how we handle a few things, how to handle deprecation
   of named exports.  In ESM, things which are getters all end up getting used when
   module is built even if caller does not use them, or it not available at all.
+
 * Need more discussion, remove tag from agenda until these issues are figured out.
 
 * Fix typos in the 9.2.0 changelog. [#17062](https://github.com/nodejs/node/pull/17062)
@@ -88,7 +90,7 @@ There was no significant Moderation Team activity this week.
   * LTS team is having a hard time to keep up (larger issue)
   * Matteo, minor, then do another minor.
 
-## Q&A, Other
+## Q\&A, Other
 
 No questions for this week.
 

--- a/meetings/2018-02-21.md
+++ b/meetings/2018-02-21.md
@@ -26,7 +26,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -47,7 +47,7 @@
     * V8 Currency
     * Workers
 
-## Q&A, Other
+## Q\&A, Other
 
 No questions this week.
 

--- a/meetings/2018-02-28.md
+++ b/meetings/2018-02-28.md
@@ -30,7 +30,7 @@
 
 No announcements.
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -99,7 +99,7 @@ No announcements.
   * New stream APIs: minor progress on C++ prototyping
   * Async hooks: Not since last week.
 
-## Q&A, Other
+## Q\&A, Other
 
 No questions this week.
 

--- a/meetings/2018-03-07.md
+++ b/meetings/2018-03-07.md
@@ -22,7 +22,7 @@
 
 Collaboration summit [#56](https://github.com/nodejs/summit/issues/56) happening right before JSConfEU. We hope to see many of you at the summit.
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -44,7 +44,7 @@ Collaboration summit [#56](https://github.com/nodejs/summit/issues/56) happening
       * doc for node-addon-api
       * ecosystem adoption
 
-## Q&A, Other
+## Q\&A, Other
 
 ## Upcoming Meetings
 

--- a/meetings/2018-03-14.md
+++ b/meetings/2018-03-14.md
@@ -25,7 +25,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -58,7 +58,7 @@
     * PR wip for V8 6.6 update. This will probably be the version that we ship in Node 10.
     * Will open an issue to discuss whether we want to prepare a forward ABI/API compatibility patch for V8 6.7 or even V8 6.8 to make it easier to upgrade during Node 10's lifecycle.
 
-## Q&A, Other
+## Q\&A, Other
 
 ## Upcoming Meetings
 

--- a/meetings/2018-03-21.md
+++ b/meetings/2018-03-21.md
@@ -8,18 +8,31 @@
 ## Present
 
 * Anna Henningsen @addaleax (TSC)
+
 * Сковорода Никита Андреевич @ChALkeR (TSC)
+
 * Colin Ihrig @cjihrig (TSC)
+
 * Daniel Bevenius @danbev (TSC)
+
 * Evan Lucas @evanlucas (TSC)
+
 * Jeremiah Senkpiel @Fishrock123 (TSC)
+
 * Gibson Fahnestock @gibfahn (TSC)
+
 * James M Snell @jasnell (TSC)
+
 * Matteo Collina @mcollina (TSC)
+
 * Michael Dawson @mhdawson (TSC)
+
 * Ali Ijaz Sheikh @ofrobots (TSC)
+
 * Rod Vagg @rvagg (TSC)
+
 * Trevor Norris @trevnorris (TSC)
+
 * Rich Trott @Trott (TSC)
 
 * Mathias Buus Madsen @mafintosh (observer)
@@ -30,7 +43,7 @@
 
 * If you are a member of the Node.js GitHub org and are interested in participating in on-call rotation for the Moderation Team, please indicate so in issue 183 in the moderation repo.
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -84,7 +97,7 @@
   * Anna, more comfortable not doing in 10 since we’ve never done something like
     that, but will not block.
   * Anna, willing to open the PR today.
-  * Any objections to landing runtime deprecation that only prints for code outside node_modules
+  * Any objections to landing runtime deprecation that only prints for code outside node\_modules
     in 10.
 * Rich will update issue with decision made and cc TSC so those not here are aware.
 

--- a/meetings/2018-03-28.md
+++ b/meetings/2018-03-28.md
@@ -19,7 +19,7 @@
 
 ## Agenda
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.*
+_Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting._
 
 ### nodejs/node
 
@@ -44,7 +44,7 @@
 
 Hello Timothy!
 
-## Q&A, Other
+## Q\&A, Other
 
 Q: What is the main objective of Node.js?
 A: Fishrock: Allow people to write JavaScript outside of web browsers (server, desktop, IoT, terminal, space…)

--- a/meetings/2018-04-04.md
+++ b/meetings/2018-04-04.md
@@ -30,18 +30,19 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 #### nodejs/node
 
 * Tracking Issue for Runtime Deprecation of Buffer constructor #19079
-* buffer: do deprecation warning outside node_modules #19524
+
+* buffer: do deprecation warning outside node\_modules #19524
   * 1 approver short of enough TSC approvals to land, as there is one objection.
   * no objections? -
   * any abstentions?
   * TSC vote in the meeting today:
     * YES (10): @addaleax @Trott @targos @cjihrig @evanlucas @MylesBorins @mcollina
-        @gibfahn @thefourtheye @ofrobots
+      @gibfahn @thefourtheye @ofrobots
     * NO (0)
     * ABSTAIN (0)
     * 10 is enough to approve (19 members, so that's 50% + 1), so this can land.
@@ -74,19 +75,27 @@
     * Backports for 8.X and 6.X in progress.
     * Plan to ramp up effort on documentation for node-addon-api.
     * Nicola helping with a number of module backports.
+
   * http2
     * ongoing work on making sure its solid
+
   * modules
     * yesterday 8 hour online summit with presentations/discussion
     * 15-17 members
     * Videos available: <https://www.youtube.com/watch?v=IbPxOaGveXA&list=PLfMzBWSH11xb9LoHLO0q3Yo7HXjMOm11N>
 
   * Error messages
+
   * V8 Currency
+
   * Workers
+
   * Core promise APIs
+
   * TSC Governance
+
   * New stream APIs
+
   * More progress on C++ api prototype examples
 
 #### nodejs/modules
@@ -117,23 +126,23 @@
       * with promises we already have post mortem issues from domains, people
         Just making so errors get swallowed.
     * concerns over performance
-      * Jeremiah, different perf concerns from async_hooks.  For async_hooks only
+      * Jeremiah, different perf concerns from async\_hooks.  For async\_hooks only
         have overhead when turned on, whereas zones would always have the overhead.
       * Bradley, not sure if you would have overhead unless you are using zones
       * Ali, history was that at some point those pushing it lost motivation due to objections
         from people in the Node community.
-      * Ali, same interception points as async_hooks.
+      * Ali, same interception points as async\_hooks.
       * Matteo, today don’t have to turn on promise hooks, strong need for async tracking
         system and good amount of ecosystem does this. Main concern is error handling
         and second is performance (ie not enabled/perf hit all the time)
       * Ali without language level construct, we have real issues.  The perf concerns are valid
         but there is the need to be write/reason about their code.  V8 team is working on lowering
-    cost of promise hooks.
+        cost of promise hooks.
     * We are not blocking, but not committed to it.
     * James, we can probably not refine our opinion on this until there is an update on the Zones
       side from the champions.  Maybe organize a call with them to start dialog.
 
-## Q&A, Other
+## Q\&A, Other
 
 * why does Michael have node.js background? Michael -> covering up junky background in office for fun.
 

--- a/meetings/2018-04-11.md
+++ b/meetings/2018-04-11.md
@@ -18,7 +18,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * Michael -> May is election month for TSC Chair and TSC Director. Proposed schedule:
   * open nominations the week of April 16th
@@ -46,10 +46,11 @@
   * N-API - backports in progress for 8.x and 6.x.  6.x to start out as experimental.
 
   * V8 currency - V8 6.6 landed today on master. Waiting for a patch from the V8 team to make it compatible with upcoming V8 6.7.
+
   * OpenSSL - Has not had time to update doc on current status yet.
     * 1.1.0 now in master, and in latest 10.X test release
     * Does not have 1.0.2 compatibility but we can add that later if people complain and
-        people show up to do the work
+      people show up to do the work
     * Current plan, go out only with 1.1.0
     * ASM support is awkward due to new toolchain reqs, particularly on windows to
     * get assembly but at compile time. Proposed to have flag in vcbuild and configure,
@@ -57,7 +58,7 @@
       version without knowing about it.
     * Since bundlers don’t ship new versions, less important for the 1.0.2 support.
 
-## Q&A, Other
+## Q\&A, Other
 
 * No questions this week
 

--- a/meetings/2018-04-18.md
+++ b/meetings/2018-04-18.md
@@ -104,7 +104,7 @@ No objections
 11 +1’s
 Welcome!
 
-## Q&A, Other
+## Q\&A, Other
 
 No questions this week.
 

--- a/meetings/2018-04-25.md
+++ b/meetings/2018-04-25.md
@@ -37,13 +37,14 @@
   * [#257](https://github.com/nodejs/TSC/issues/257)
   * [#492](https://github.com/nodejs/TSC/issues/492)
   * [#490](https://github.com/nodejs/TSC/issues/490)
+
 * Jeremiah - created trial discord to see how that works for communication. Issue: <https://github.com/nodejs/admin/issues/53>, Discord link: <https://discordapp.com/invite/eF23Jpc>
 
 * Michael - reminder about TSC Chair and Director nominations.
 
 * Anna - announcing Node.js 10.x went out.
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -53,11 +54,14 @@
 ### nodejs/TSC
 
 * Coordination on npm releases  [#528](https://github.com/nodejs/TSC/issues/528)
+
 * Wiki Management [#525](https://github.com/nodejs/TSC/issues/525)
+
 * Tracking issue for updating TSC on Board Meetings [#476](https://github.com/nodejs/TSC/issues/476)
   * Board meeting coming up on Monday
   * Call for any issues to be brought to the board?
   * Now request from those on the call
+
 * Strategic Initiatives - Tracking Issue [#423](https://github.com/nodejs/TSC/issues/423)
   * N-API - still working on 8.x backport and regular issue
   * Modules - in “yes and” and building list of modules, meeting later today
@@ -74,14 +78,14 @@
 * WHATWG Participation Policy [#532](https://github.com/nodejs/TSC/issues/532)
   * Myles - open group, no meeting, all on GitHub.  Nothing stopping us from participating.
     You can just show up and participate. Bias towards serving browser vendors as that is
-  part of their charter, we could try to change that.
+    part of their charter, we could try to change that.
   * If we want to be on the same page we might spin up an open standards strategic initiative
   * If you want to get involved don’t wait on the project, if you want to represent Node.js project
     would be good to coordinate internally.
   * Next step would be to see if people are interested in participating in a standards initiative.
   * Myles volunteered to see if there is interest in forming a group.
 
-## Q&A, Other
+## Q\&A, Other
 
 No questions this week.
 

--- a/meetings/2018-05-02.md
+++ b/meetings/2018-05-02.md
@@ -46,7 +46,7 @@ Myles is not here so no updates.
   * TSC governance: Myles is not here.
   * Streams: Jeremiah is not here.
   * V8 Currency: Michaël is not here but everything is on track as far as we know.
-  * Async hooks: Ali reports that they are trying to figure out how to get async_hooks out of
+  * Async hooks: Ali reports that they are trying to figure out how to get async\_hooks out of
     experimental and that they are focusing on performance. There is a new
     [proposal](https://github.com/nodejs/diagnostics/issues/188) by the V8
     team to change promise hooks that would improve performance. PTAL and leave comments.
@@ -83,8 +83,8 @@ Franzi: Was that this issue or a different one? (It was this issue)
 
 Joyee: If we don’t have a policy around this, we should make the decision that experimental modules could have their module IDs changed. Maybe in the future we can make them more consistent, but right now, there’s work to do to make the namespace happen. That could take awhile. But until then, we should make clear that it could change.
 
-Rich: We probably need to discuss on this in the tracker. I’ll summarize and hopefully we can get more input. Also, let’s leave it on the agenda for next week in case it *doesn’t* move forward.
+Rich: We probably need to discuss on this in the tracker. I’ll summarize and hopefully we can get more input. Also, let’s leave it on the agenda for next week in case it _doesn’t_ move forward.
 
-## Q&A, Other
+## Q\&A, Other
 
 No questions this week.

--- a/meetings/2018-05-09.md
+++ b/meetings/2018-05-09.md
@@ -27,7 +27,7 @@
 * TSC Chair - Vote ongoing, closes Monday May 14.
 * James - Good conversation with Microsoft team, need for work on installers and on libuv.
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -84,7 +84,7 @@
   * We have moved the promises API back to fs so not as critical, but still needs to be
     revisited.
 
-## Q&A, Other
+## Q\&A, Other
 
 * No questions this week.
 

--- a/meetings/2018-05-16.md
+++ b/meetings/2018-05-16.md
@@ -44,7 +44,7 @@
     but first cut for people to look at.  v10.0.2 proposal covered, would be good to get
     real-world usage. Anna to ping Myles.
 
-## Q&A, Other
+## Q\&A, Other
 
 * Question about moderation.  Clarified that its a joint initiative but CommComm
   as the lead and it will be covered in their updates.

--- a/meetings/2018-05-23.md
+++ b/meetings/2018-05-23.md
@@ -20,7 +20,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.*
+_Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting._
 
 ### nodejs/node
 
@@ -94,7 +94,7 @@
     Hooks with async/await, manual backport of V8 fix to 6.7, struggled with 6.6 backport, better
     to update to 6.7 <https://github.com/nodejs/node/pull/19989/commits/2473cab8e2047fe08745d5ae8eed20a4f81a11dc>, see <https://github.com/nodejs/node/issues/20516>.
 
-## Q&A, Other
+## Q\&A, Other
 
 * Question from Ryzokuken in YouTube regarding cloaking in the Freenode IRC channel.
   agreed that this is a CommComm issue, punting to them.

--- a/meetings/2018-06-06.md
+++ b/meetings/2018-06-06.md
@@ -8,23 +8,39 @@
 ## Present
 
 * Anna Henningsen @addaleax (TSC)
+
 * Сковорода Никита Андреевич @ChALkeR (TSC)
+
 * Colin Ihrig @cjihrig (TSC)
+
 * Daniel Bevenius @danbev (TSC)
+
 * Franziska Hinkelmann @fhinkel (TSC)
+
 * Jeremiah Senkpiel @Fishrock123 (TSC)
+
 * James Snell @jasnell (TSC)
+
 * Joyee Cheung @joyeecheung (TSC)
+
 * Matteo Collina @mcollina (TSC)
+
 * Michael Dawson @mhdawson (TSC)
+
 * Ali Sheikh @ofrobots (TSC)
+
 * Rod Vagg @rvagg (TSC)
+
 * Michaël Zasso @targos (TSC)
+
 * Sakthipriyan Vairamani @thefourtheye (TSC)
+
 * Rich Trott @Trott (TSC)
 
 * Bradley Farias @bmeck (GoDaddy, guest)
+
 * Ruben Bridgewater @BridgeAR (nearForm, gueset)
+
 * Jordan Harband @ljharb (Airbnb, guest)
 
 ## Agenda
@@ -81,10 +97,11 @@
 
 * Tracking issue for updating TSC on Board Meetings [#476](https://github.com/nodejs/TSC/issues/476)
   * Skipped as we did not have enough time
+
 * Strategic Initiatives - Tracking Issue [#423](https://github.com/nodejs/TSC/issues/423)
   * Skipped as we did not have enough time
 
-## Q&A, Other
+## Q\&A, Other
 
 * No questions this week.
 

--- a/meetings/2018-06-13.md
+++ b/meetings/2018-06-13.md
@@ -19,7 +19,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -98,7 +98,7 @@
   * Myles, we instead more likely need discussions on what is appropriate to discuss in the
     repo where it is not public as we want as much to be public as possible.
 
-## Q&A, Other
+## Q\&A, Other
 
 * All questions comment in thread, nothing to add.
 

--- a/meetings/2018-06-20.md
+++ b/meetings/2018-06-20.md
@@ -22,7 +22,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * No announcements this week.
 
@@ -91,7 +91,7 @@
 * Proposal: add all new core modules under a scope? (too late for http2) [#389](https://github.com/nodejs/TSC/issues/389)
   * no updates on issue since last week.  Posted reminder to TSC members to review/comment.
 
-## Q&A, Other
+## Q\&A, Other
 
 * No questions this week.
 

--- a/meetings/2018-06-27.md
+++ b/meetings/2018-06-27.md
@@ -40,6 +40,7 @@ Rod, Jon, Refael, and Joyee will set up a meeting to work through this issue.
   * Myles: Some -1’s coming in. I’d like to see a strong case that there are important security concerns
     and not security edge cases. Basically: What are we breaking in the ecosystem vs. what are the risks of
     leaving things as they are.
+
   * Nikita: I have data on that but it is probably premature to discuss it at this point.
 
   * Michael: Is deferring to August OK, Myles?
@@ -74,7 +75,7 @@ Rod, Jon, Refael, and Joyee will set up a meeting to work through this issue.
 
   * Michael: Discussion is ongoing. Let’s leave it on the agenda but let the discussion unfold and see where it goes.
 
-## Q&A, Other
+## Q\&A, Other
 
 * No questions on youtube
 

--- a/meetings/2018-07-12.md
+++ b/meetings/2018-07-12.md
@@ -21,7 +21,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/build
 
@@ -62,7 +62,7 @@
 * open web standards - TC39 meeting coming up but Myles won’t make it.  Gus and Jordan,
   Timothy will be there.
 
-## Q&A, Other
+## Q\&A, Other
 
 * No questions this week.
 

--- a/meetings/2018-07-18.md
+++ b/meetings/2018-07-18.md
@@ -22,7 +22,7 @@
 
 * Michael Zasso, 10.7 will be out today.
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/build
 
@@ -31,7 +31,7 @@
 
 ### nodejs/node
 
-* \[v10.x\] Revert "http: always emit close on req and res" [#21809](https://github.com/nodejs/node/pull/21809)
+* \[v10.x] Revert "http: always emit close on req and res" [#21809](https://github.com/nodejs/node/pull/21809)
   * Matteo, it's a SemVer Major that slipped through.  3 commits total
   * Michael Z - this broke end of stream but that was fixed with a later PR.
     <https://github.com/nodejs/node/pull/20941>
@@ -59,6 +59,7 @@
 ### nodejs/TSC
 
 * Tracking issue for updating TSC on Board Meetings [#476](https://github.com/nodejs/TSC/issues/476)
+
 * Strategic Initiatives - Tracking Issue [#423](https://github.com/nodejs/TSC/issues/423)
 
 * Proposal: add all new core modules under a scope? (too late for http2) [#389](https://github.com/nodejs/TSC/issues/389)
@@ -85,7 +86,7 @@
 * 2018-07-16 Public User Feedback Meeting - General User Feedback [#74](https://github.com/nodejs/user-feedback/issues/74)
   * meeting already happened, nothing to discuss.
 
-## Q&A, Other
+## Q\&A, Other
 
 No questions today.
 

--- a/meetings/2018-08-01.md
+++ b/meetings/2018-08-01.md
@@ -24,9 +24,9 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
-* readable-stream@3 is coming out soon, check it out with `npm i readable-stream@next` and provide feedback opening issues at <https://github.com/nodejs/readable-stream>
+* readable-stream\@3 is coming out soon, check it out with `npm i readable-stream@next` and provide feedback opening issues at <https://github.com/nodejs/readable-stream>
 
 ### nodejs/build
 
@@ -41,7 +41,7 @@
 * Password Hashing API [#21766](https://github.com/nodejs/node/issues/21766)
   * TSC  members to review proposal and if no objections by tonight, @Chalker will submit PR
 
-* tty: make _read throw ERR_TTY_WRITABLE_NOT_READABLE [#21654](https://github.com/nodejs/node/pull/21654)
+* tty: make \_read throw ERR\_TTY\_WRITABLE\_NOT\_READABLE [#21654](https://github.com/nodejs/node/pull/21654)
   * Rod - Can we defer to libuv and streams? Let’s
   * Anna we need libuv team to comment on whether they are going to fix the issue as that
     will affect what node needs to do.
@@ -49,7 +49,7 @@
 * doc: remove 2 unused error codes from errors.md [#21491](https://github.com/nodejs/node/pull/21491)
   * discussed, now ready to land.
 
-* \[v10.x\] Revert "http: always emit close on req and res" [#21809](https://github.com/nodejs/node/pull/21809)
+* \[v10.x] Revert "http: always emit close on req and res" [#21809](https://github.com/nodejs/node/pull/21809)
   * Discuss, consensus was it should land, more TSC members approved.
 
 ### nodejs/docker-node
@@ -103,7 +103,7 @@
     * Open issue about TC39 and ECMA and getting involved.  Myles is having some discussions
       To see if we can figure out political side of things.
 
-## Q&A, Other
+## Q\&A, Other
 
 * No questions this week.
 

--- a/meetings/2018-08-08.md
+++ b/meetings/2018-08-08.md
@@ -22,9 +22,9 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
-* readable-stream@3 is coming out this week, check it out with `npm i readable-stream@next` and provide feedback opening issues at <https://github.com/nodejs/readable-stream>
+* readable-stream\@3 is coming out this week, check it out with `npm i readable-stream@next` and provide feedback opening issues at <https://github.com/nodejs/readable-stream>
 
 ### nodejs/build
 
@@ -46,7 +46,7 @@
 * Password Hashing API [#21766](https://github.com/nodejs/node/issues/21766)
   * Chalker suggested that we defer until next week to discuss.
 
-* tty: make _read throw ERR_TTY_WRITABLE_NOT_READABLE [#21654](https://github.com/nodejs/node/pull/21654)
+* tty: make \_read throw ERR\_TTY\_WRITABLE\_NOT\_READABLE [#21654](https://github.com/nodejs/node/pull/21654)
   * Could tag stream as readable or writable but was not previously enforced. In a
     recent version it started enforcing it.
   * In Node 10, there was a regression, error is not readable, PR was to fix
@@ -86,7 +86,7 @@
 
 * Strategic Initiatives - Tracking Issue [#423](https://github.com/nodejs/TSC/issues/423)
 
-## Q&A, Other
+## Q\&A, Other
 
 * No questions for today.
 

--- a/meetings/2018-08-22.md
+++ b/meetings/2018-08-22.md
@@ -21,14 +21,14 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
 * stream-whatwg: add whatwg streams [#22352](https://github.com/nodejs/node/pull/22352)
   * Jeremiah proposed to defer to next meeting so he has time to comment in the issue.
 
-* \[WIP\] fs: feature detection for recursive mkdir\[Sync\] [#22302](https://github.com/nodejs/node/pull/22302)
+* \[WIP] fs: feature detection for recursive mkdir\[Sync] [#22302](https://github.com/nodejs/node/pull/22302)
   * We added the ability to create directories recursively.  Landed as an option to an
     existing method.  Due to that, it is not easy to detect.
   * Myles proposed symbol, but don’t have consensus yet. Other option being discussed
@@ -47,7 +47,7 @@
 * Password Hashing API [#21766](https://github.com/nodejs/node/issues/21766)
   * Chalker, no updates defer to next week.
 
-* tty: make \_read throw ERR_TTY_WRITABLE_NOT_READABLE [#21654](https://github.com/nodejs/node/pull/21654)
+* tty: make \_read throw ERR\_TTY\_WRITABLE\_NOT\_READABLE [#21654](https://github.com/nodejs/node/pull/21654)
   * Reached consensus to proceed with PR.
   * Issue was opened on libuv, but no fast progress.
   * Matteo will land this and we will revert if libuv updates or we get the required
@@ -71,7 +71,7 @@
     a few tests and evangelization.
   * No other updates.
 
-## Q&A, Other
+## Q\&A, Other
 
 * Question: does Facebook hire Node.js developers?
   * We don’t know

--- a/meetings/2018-08-29.md
+++ b/meetings/2018-08-29.md
@@ -21,7 +21,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * JS Interactive & Node Community Corner - short update [#211](https://github.com/nodejs/admin/issues/211)
   * Quick update from Tracy/Greg/Laura
@@ -32,7 +32,7 @@
   * Matteo asked that his be delayed as there is discussion in the issue
   * We agreed to remove from agenda and it can be added back if there is a reason later.
 
-* \[WIP\] fs: feature detection for recursive mkdir\[Sync\] [#22302](https://github.com/nodejs/node/pull/22302)
+* \[WIP] fs: feature detection for recursive mkdir\[Sync] [#22302](https://github.com/nodejs/node/pull/22302)
   * Need a more general conversation needed about feature detection
   * Added to agenda to queue up discussion
   * Cannot land until a decision was made
@@ -101,7 +101,7 @@
 
 * No questions this week.
 
-## Q&A, Other
+## Q\&A, Other
 
 ## Upcoming Meetings
 

--- a/meetings/2018-09-05.md
+++ b/meetings/2018-09-05.md
@@ -24,7 +24,7 @@
 
 * Matteo: Working in assembling the agenda for the collaborator summit.
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -94,7 +94,7 @@
   * this has been open long enough can proceed.
   * Matteo has volunteered to create the repo tomorrow morning
 
-## Q&A, Other
+## Q\&A, Other
 
 * Is the mentor program still on?
   * Yes but due to such high demand team is still figuring out how to address the need.

--- a/meetings/2018-09-12.md
+++ b/meetings/2018-09-12.md
@@ -37,7 +37,7 @@
   * Code and learn, about 300 people who will be attending. If you are at the conference please
     come and mentor.
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.*
+_Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting._
 
 ### nodejs/TSC
 
@@ -55,7 +55,8 @@
   * last time Rich volunteered try to round up input
   * In progress, push to next week
 
-* \[WiP\] buffer: runtime-deprecate buffer constructor in sync mode [#22584](https://github.com/nodejs/node/pull/22584)
+* \[WiP] buffer: runtime-deprecate buffer constructor in sync mode [#22584](https://github.com/nodejs/node/pull/22584)
+
 * buffer: runtime-deprecate Buffer constructor everywhere by default [#21351](https://github.com/nodejs/node/pull/21351)
   * Gabriel making progress on filing PR’s , need to update the ones that he has done.
   * Anna, Chalker is only one advocating, so we should push to next week.
@@ -77,6 +78,7 @@
   * Modules
     * Developer survey being developed, testing out content. Hope to present at developer
       summit or Code and Learn
+
   * New fork to do patching on ES modules itself to work on defining minimal kernel that
     does not preclude larger feature set, may have identified some pull requests to send back
     Core
@@ -109,7 +111,7 @@
     * Spun up repo, some people nominated to the team, discussing how to engage and get
       started.  <https://github.com/nodejs/open-standards/>
 
-## Q&A, Other
+## Q\&A, Other
 
 * No questions this week.
 

--- a/meetings/2018-09-19.md
+++ b/meetings/2018-09-19.md
@@ -27,7 +27,7 @@
 
 * No announcements this week
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -43,7 +43,7 @@
   * Anatoli, only closed because did not want to continue to rebase
   * Remove from TSC agenda and let it run its course.
 
-* \[WiP\] buffer: runtime-deprecate buffer constructor in sync mode [#22584](https://github.com/nodejs/node/pull/22584)
+* \[WiP] buffer: runtime-deprecate buffer constructor in sync mode [#22584](https://github.com/nodejs/node/pull/22584)
   * Nikita, current work in progress, need some tests from CITGM.
   * Would appreciate any help in testing modules
   * 11.x server major cutoff is Oct 1st, but there is some wiggle room
@@ -67,7 +67,7 @@
     * Some progress was made towards fixing canary (thanks @refack!).
       Need more eyes on the PR: [#22920](https://github.com/nodejs/node/pull/22920)
     * N-API - focus on AsyncWorker, Evangelism, examples and test suite. See
-    <https://github.com/nodejs/abi-stable-node/issues/338>
+      <https://github.com/nodejs/abi-stable-node/issues/338>
   * Workers
     * Inspector support for workers was added, merged yesterday
     * Rich has opened issue on exit criteria for experimental status
@@ -84,7 +84,7 @@
   * Matteo, TSC panel, asking for questions issue open to ask for questions in advance:
     <https://github.com/nodejs/TSC/issues/602>
 
-## Q&A, Other
+## Q\&A, Other
 
 * No questions this week.
 

--- a/meetings/2018-09-26.md
+++ b/meetings/2018-09-26.md
@@ -8,24 +8,30 @@
 ## Present
 
 * Ali Ijaz Sheikh @ofrobots (TSC)
+
 * Michael Dawson @mhdawson (TSC)
+
 * Gabriel Schulhof @gabrielschulhof (TSC)
+
 * Jeremiah Senkpiel @Fishrock123 (TSC)
+
 * Rich Trott @Trott (TSC)
+
 * Rod Vagg @rvagg (TSC)
 
 * Tracy Lee (Foundation/Guest)
+
 * Medina Davis (Foundation/Guest)
 
 ## Agenda
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
-* \[WiP\] buffer: runtime-deprecate buffer constructor in sync mode [#22584](https://github.com/nodejs/node/pull/22584)
+* \[WiP] buffer: runtime-deprecate buffer constructor in sync mode [#22584](https://github.com/nodejs/node/pull/22584)
   * Nikita, particular way to do runtime deprecation warnings based on timing, check
     out issue.
   * We need to make a decision on if it can go into 11.x, otherwise time may just run out.
@@ -37,7 +43,7 @@
   * Medina on the group point of contact, so if you need something talk to her
   * On track to hit about 1000 attendees
   * Community corner, lots of good programming including Node.js TSC panel
-  * Friday is code and learn with ~300 people registered, so all hands on deck in terms
+  * Friday is code and learn with \~300 people registered, so all hands on deck in terms
     of coming to help out.
   * Special thanks to Telus and Netflix who are sponsoring collaborator summit (lunch+)
   * Agendas are posted for collaborator summit and community corner.
@@ -56,7 +62,7 @@
   * OpenSSL, team announced they have support, will start next week. Will happen before
     December 2019.
 
-## Q&A, Other
+## Q\&A, Other
 
 * Brian English -> Can non-collaborators mentor at the code and learn.
   * Rich people who have contributed a reasonable number of commits, then likely yes.

--- a/meetings/2018-10-03.md
+++ b/meetings/2018-10-03.md
@@ -21,7 +21,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * To everybody attending the collaborator summit at Node+JS Interaticve.  Please make sure
   to take survey about attendance of sessions in the collaboration summit (Vancouver 2018)
@@ -60,7 +60,7 @@
 * Establishing a communication channel for embargoed communication [#382](https://github.com/nodejs/community-committee/issues/382)
   * Will track progerss CommComm makes on this, taking off agenda for now.
 
-## Q&A, Other
+## Q\&A, Other
 
 * No questions this week.
 

--- a/meetings/2018-10-17.md
+++ b/meetings/2018-10-17.md
@@ -24,7 +24,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -80,9 +80,12 @@
     * In some ways our C++ is basically V8 C++, because it has been based on using
       the V8 APIs
     * Style should be aligned with V8 style because of this dependency.
+
   * Most of non-const references are overloads, most of the time they still use pointers
+
   * We could probably list out specific examples as opposed to saying pointers are always
     Preferred.
+
   * Rich kick back to github
 
   * Nikita
@@ -116,7 +119,7 @@
 
 * Tracking issue for updating TSC on Board Meetings [#476](https://github.com/nodejs/TSC/issues/476)
   * Short board meeting last week, mostly going through the numbers from the conference
-    * just under 1000 tickets sold ~20% growth in terms of attendance and funds raised
+    * just under 1000 tickets sold \~20% growth in terms of attendance and funds raised
   * Announced “intent” to merge, had open town hall
   * Invited to join discussion in nodejs/bootstrap -  <https://github.com/nodejs/bootstrap/issues/10>
 
@@ -152,7 +155,7 @@
     * Also discussion of how we might want to participate.
     * Minutes will be PR’d into summit agenda, issue #106
 
-## Q&A, Other
+## Q\&A, Other
 
 * No questions this week.
 

--- a/meetings/2018-10-24.md
+++ b/meetings/2018-10-24.md
@@ -20,14 +20,14 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
 * buffer: fix crash for invalid index types [#23795](https://github.com/nodejs/node/pull/23795)
   * removed from the agenda before the meeting
 
-* fs: behaviour of readFile and writeFile with file descriptors [23433]( https://github.com/nodejs/node/issues/23433)
+* fs: behaviour of readFile and writeFile with file descriptors [23433](https://github.com/nodejs/node/issues/23433)
   * Behaviour is inconsistent with the documentation.
   * Read and Write behave differently
   * PR exists to update documentation
@@ -47,7 +47,7 @@
     * Working on V8 7.1 for master: node-test-pull-request green but node-test-commit-v8-linux
       fails on IBM platforms (missing dependency).
 
-## Q&A, Other
+## Q\&A, Other
 
 ## Upcoming Meetings
 

--- a/meetings/2018-10-31.md
+++ b/meetings/2018-10-31.md
@@ -22,7 +22,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * New collaborator nominations
   * Peter Marshall (<https://github.com/nodejs/node/issues/23849>)
@@ -78,7 +78,7 @@
     * Agreed that its probably ok to make members of the team, members of the Node.js org
       as we do for other teams.
 
-## Q&A, Other
+## Q\&A, Other
 
 * Steven K - is there  slack channel
   * No official Node.js project channel.

--- a/meetings/2018-11-07.md
+++ b/meetings/2018-11-07.md
@@ -24,7 +24,7 @@ Welcome to our new collaborators @psmarshall and @shisama!
 
 * Ouyang Yadong (@oyyd) nominated to be a collaborator (<https://github.com/nodejs/node/issues/23955>)
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### fs: behaviour of readFile and writeFile with file descriptors [#23433](https://github.com/nodejs/node/issues/23433)
 
@@ -49,7 +49,7 @@ V8 Currency (Michaël): Nothing to report this week.
 
 Async Hooks (Ali): Performance hooks, moving to get rid of the destroy hook so we can expose Promises hooks and make things faster.
 
-## Q&A, Other
+## Q\&A, Other
 
 * No questions
 

--- a/meetings/2018-11-14.md
+++ b/meetings/2018-11-14.md
@@ -11,7 +11,7 @@ N/A In person meeting cancelled.
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ## Agenda
 
@@ -39,7 +39,7 @@ N/A In person meeting cancelled.
     * Ongoing work to improve node-core-utils command for V8 backports.
     * Onboarded @ryzokuken to help to keep the canary branch up-to-date
 
-## Q&A, Other
+## Q\&A, Other
 
 ## Upcoming Meetings
 

--- a/meetings/2018-12-05.md
+++ b/meetings/2018-12-05.md
@@ -20,7 +20,7 @@
 
 * NodeConf.eu will be held 10th - 13th November 2019
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -28,7 +28,7 @@
   * Express broken because of recent behavior change in the case of a parse error
   * Broke the dependency on-finished module that is not in CITGM, and it is neither covered in the express test suite (<https://github.com/nodejs/citgm/issues/631>)
   * Need better support and coverage for these, back to the issue tracker
-* Fixing child_process module to check values passed strictly to the options object [#24267](https://github.com/nodejs/node/pull/24267)
+* Fixing child\_process module to check values passed strictly to the options object [#24267](https://github.com/nodejs/node/pull/24267)
   * The options object can be polluted via the Object prototype which can lead to security vulnerability
   * Disagreement on whether we should land this for this specific API instead of doing it for every options in all the APIs
   * Looking for more input
@@ -43,7 +43,7 @@
 * Travel Fund Updates [#426](https://github.com/nodejs/community-committee/issues/426)
 * Node Store Launch [#425](https://github.com/nodejs/community-committee/issues/425)
 
-## Q&A, Other
+## Q\&A, Other
 
 ## Upcoming Meetings
 

--- a/meetings/2018-12-12.md
+++ b/meetings/2018-12-12.md
@@ -31,7 +31,7 @@
     community release and this provides a work around.
   * Removed from agenda for now.
 
-* Fixing child_process module to check values passed strictly to the options object [#24267](https://github.com/nodejs/node/pull/24267)
+* Fixing child\_process module to check values passed strictly to the options object [#24267](https://github.com/nodejs/node/pull/24267)
   * controversial as there is disagreement in the issue as to whether this should land.
   * Back to github and invite Liran to next TSC meeting to provide a deeper dive and then
     we can decide on next steps.
@@ -97,7 +97,7 @@
   * Talking to foundation about moving to red bubble so that we can avoid having to pre-buy
     swag. The advantage is that they print on demand.
 
-## Q&A, Other
+## Q\&A, Other
 
 * No questions this week.
 

--- a/meetings/2018-12-19.md
+++ b/meetings/2018-12-19.md
@@ -28,11 +28,11 @@
 
 * No announcements this week.
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
-* Fixing child_process module to check values passed strictly to the options object [#24267](https://github.com/nodejs/node/pull/24267)
+* Fixing child\_process module to check values passed strictly to the options object [#24267](https://github.com/nodejs/node/pull/24267)
   * Liran gave a good overview
   * We had discussion that it only plugs one small part of the ways similar attacks could take
     place.
@@ -93,7 +93,7 @@
 * Design Presentation: Node.js Website Design Direction Proposal [#433](https://github.com/nodejs/community-committee/issues/433)
   * Michael failed to line up Adam for this week, will try to do that for Jan 2nd meeting.
 
-## Q&A, Other
+## Q\&A, Other
 
 ## Upcoming Meetings
 

--- a/meetings/2019-01-02.md
+++ b/meetings/2019-01-02.md
@@ -17,7 +17,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -35,7 +35,7 @@
 * Strategic Initiatives - Tracking Issue [#423](https://github.com/nodejs/TSC/issues/423)
   * No updates
 
-## Q&A, Other
+## Q\&A, Other
 
 ## Upcoming Meetings
 

--- a/meetings/2019-01-16.md
+++ b/meetings/2019-01-16.md
@@ -26,7 +26,7 @@
 
 ### nodejs/TSC
 
-* NODE_MODULE_VERSION for Electron Major Releases [#651](https://github.com/nodejs/TSC/issues/651)
+* NODE\_MODULE\_VERSION for Electron Major Releases [#651](https://github.com/nodejs/TSC/issues/651)
   * We will defer this until we have quorum and some of the people more involved on the call.
 * Nominating @trott to rejoin the TSC. [#650](https://github.com/nodejs/TSC/issues/650)
   * No objections.
@@ -35,7 +35,7 @@
 * Strategic Initiatives - Tracking Issue [#423](https://github.com/nodejs/TSC/issues/423)
   * None of the champions for the strategic initiatives were able to attend today.
 
-## Q&A, Other
+## Q\&A, Other
 
 ## Upcoming Meetings
 

--- a/meetings/2019-01-23.md
+++ b/meetings/2019-01-23.md
@@ -20,7 +20,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -29,7 +29,7 @@
 
 ### nodejs/TSC
 
-* NODE_MODULE_VERSION for Electron Major Releases [#651](https://github.com/nodejs/TSC/issues/651)
+* NODE\_MODULE\_VERSION for Electron Major Releases [#651](https://github.com/nodejs/TSC/issues/651)
   * Issue is with projects that bundle Node.js but use different versions of the
     dependencies (for example V8 or OpenSSL)
   * Gabriel - single number poses some issues as it means that more versions of the
@@ -54,7 +54,7 @@
   * Python 3 and Gyp (PRing into list)
     * Being kicked off, thanks @thefourtheye
 
-## Q&A, Other
+## Q\&A, Other
 
 * No questions today.
 

--- a/meetings/2019-01-30.md
+++ b/meetings/2019-01-30.md
@@ -18,17 +18,20 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/TSC
 
 * Tracking issue for updating TSC on Board Meetings [#476](https://github.com/nodejs/TSC/issues/476)
   * Myles not here defer to next time.
+
 * Strategic Initiatives - Tracking Issue [#423](https://github.com/nodejs/TSC/issues/423)
   * N-API - focus on backporting tsfn
+
 * Open SSL evolution
   * PR open 1.1.1a from Sam Roberts
   * Some progress on TLS 1.3 as well
+
 * V8 Currency - nothing too special to report.
   * Believes canary is fine
   * open pull request to update to V8 7.2
@@ -38,6 +41,7 @@
   * Ali, if it is going to happen better to be sooner than later. If it’s beyond 7.6
     probably ok, if earlier then may be an issue.
   * Michael Z will find out the plans and report back.
+
 * Python 3 and GYP, good to help support that effort with reviews etc.
 
 * process: remove unhandled rejection deprecation warning[25747](https://github.com/nodejs/node/pull/25747)
@@ -52,7 +56,7 @@
     issue to ask Chalker if he can do that and then we can go
     from there.
 
-## Q&A, Other
+## Q\&A, Other
 
 * No questions this week
 

--- a/meetings/2019-02-14.md
+++ b/meetings/2019-02-14.md
@@ -48,7 +48,7 @@ See <https://github.com/nodejs/bootstrap/tree/master/proposals>
   * Core Promise APIs: new PR opened by Matteo - generate a promise out of a ‘once’ eventemitter event: <https://github.com/nodejs/node/pull/26078>.
   * Python & GYP: Made most core python scripts be compat with both python 2 & 3. Working on gyp core now. Trying to get both python 2 & 3 into the build/test matrix in CI.
 
-## Q&A, Other
+## Q\&A, Other
 
 ## Upcoming Meetings
 

--- a/meetings/2019-02-20.md
+++ b/meetings/2019-02-20.md
@@ -23,7 +23,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * Gireesh has been nominated as a TSC member.  As per process he is attending a few
   meetings before the vote. Welcome to your first meeting :)
@@ -73,7 +73,7 @@
     modules not successful, top level await proposal still being worked.  Decorators may be
     another one that people might want to look at.  Work with IETF to standardized .mjs.
 
-## Q&A, Other
+## Q\&A, Other
 
 * No questions this week.
 

--- a/meetings/2019-03-14.md
+++ b/meetings/2019-03-14.md
@@ -24,7 +24,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * Matteo, call for proposals for NodeConfEU open, please join: <https://sessionize.com/nodeconf-eu-2019/>.
 
@@ -38,7 +38,7 @@
   * use the NSS cert list, but since we don't have a whitelist we will allow more certs
     than Mozilla does use the NSS cert list but remove symantec, which means we will allow
     less certs than Mozilla does (but our users are more technical than Firefox browser users
-    -- well, some are -- and they have programmable access to add the symantec certs)
+    \-- well, some are -- and they have programmable access to add the symantec certs)
     reverse engineering the Mozilla whitelist code, and reproduce it in node.js, so we allow exactly the certs that Mozilla allows
   * Rod, we don’t know the scope of  what might be disallowed.  That’s why Mozilla has
     Taken an incremental approach.
@@ -101,6 +101,7 @@
   * [Doc](http://bit.ly/making-async-hooks-fast-enough) related to improving async hooks performance
   * Full details in the summary and [videos](https://github.com/nodejs/diagnostics/issues/203#issuecomment-472534669)
     for the recent Diagnostics Summit.
+
 * Open Web standards
   * new key value store for web that presented, was using namespace that was using
     ‘std:’. Just shows one example of what might be used.
@@ -115,7 +116,7 @@
 * Platform/compiler proposal for 12.x from Build WG.
   * Rod provided an overview of <https://docs.google.com/spreadsheets/d/1bLTnriy4sCnoOb7yTC0QWuApuGC8lChCcr_7A3UxEPc/edit#gid=0>
 
-## Q&A, Other
+## Q\&A, Other
 
 ## Upcoming Meetings
 

--- a/meetings/2019-03-27.md
+++ b/meetings/2019-03-27.md
@@ -32,11 +32,11 @@
   <https://github.com/nodejs/node/pull/26714>
   * gcc 6
   * Almost no feedback on macOS support proposal. Build minimum is 10.13 and
-      XCode 10 with minimum support run on 10.11. (Rich says that seems
-      reasonable.)
+    XCode 10 with minimum support run on 10.11. (Rich says that seems
+    reasonable.)
   * Python 2/3: We will have to support both out of the gate, but we don't
-      want to be locked into supporting Python 2 for 18 months or whatever after
-      it goes EOL.
+    want to be locked into supporting Python 2 for 18 months or whatever after
+    it goes EOL.
 * Currently 30 open pull requests labeled semver-major. Attention, TSC folks!
   <https://github.com/nodejs/node/search?q=is%3Apr+is%3Aopen+label%3Asemver-major&type=Issues>
 * New ESM implementation proposed! <https://github.com/nodejs/node/pull/26745>
@@ -60,7 +60,7 @@
   * N-API: thread-safe function backports have landed in v8.x.
   * Streams: No significant movement since last time.
 
-## Q&A, Other
+## Q\&A, Other
 
 No questions.
 

--- a/meetings/2019-04-10.md
+++ b/meetings/2019-04-10.md
@@ -18,13 +18,13 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * Matteo: Still looking for sessions for collaborator summit, and you should be thinking about
-    Attending. Right before JSConfEU 30, 31st of May. Lots of links in the notes
-    github.com/nodejs/summit.  If you want to use the travel fund and a member of a project
-    in OpenJS foundation please apply. Call For Proposals:
-    <https://github.com/nodejs/summit/issues/149>. Register: <https://github.com/nodejs/summit/issues/152>
+  Attending. Right before JSConfEU 30, 31st of May. Lots of links in the notes
+  github.com/nodejs/summit.  If you want to use the travel fund and a member of a project
+  in OpenJS foundation please apply. Call For Proposals:
+  <https://github.com/nodejs/summit/issues/149>. Register: <https://github.com/nodejs/summit/issues/152>
 
 ### nodejs/node
 
@@ -62,7 +62,7 @@
     3 installed on rest of build machines.
   * 2 new ones, startup performance the build resources.
 
-## Q&A, Other
+## Q\&A, Other
 
 * No questions this week.
 

--- a/meetings/2019-04-17.md
+++ b/meetings/2019-04-17.md
@@ -22,7 +22,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * Myles, 8.16.0 released yesterday, includes some N-API fixes to ensure compatibility across
   Node.js versions 10.x and higher.  Unsure if there will be any more minors since 8.x is in
@@ -94,7 +94,7 @@
 Build Resources
 
 * Nothing much to report this week. Will put together brief doc describing the problem and
-    proposed solutions get some input and then figure out next steps.
+  proposed solutions get some input and then figure out next steps.
 
 ### nodejs/security-wg
 
@@ -102,7 +102,7 @@ Build Resources
   * Sam, no objections, Rod, Matteo in favor. Not super clear what we will get but we’ll
     give it a shot.
 
-## Q&A, Other
+## Q\&A, Other
 
 ## Upcoming Meetings
 

--- a/meetings/2019-04-24.md
+++ b/meetings/2019-04-24.md
@@ -23,7 +23,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node-gyp
 
@@ -47,17 +47,22 @@
 
 * Call for Papers (CFP) review process for Node+JS Interactive - Sarah from Foundation.
   * Making a few changes to the CFP review process
+
   * Had a CFP review committee last year, hoping to make it broader this year
+
   * Want to make sure there is an open invitation to participate: <https://github.com/openjs-foundation/bootstrap/issues/148>
+
   * Have 2 co-chairs who will be final decision makers on content:
     * Tracy Hinds
     * Christian Bromann
+
   * <https://docs.google.com/document/d/1c0y-XSssZdEZGyCo0FVU6Wnd2TM3Ye-63xi18xjKVGM/edit>
 
   * There has been some discussion around changing the name of the conference.  Two options
     being discussed.
     * Some feedback from TSC members that name suggestions don’t communicate the reason
       for the conference so we need to be careful in what we choose.
+
   * Planning for blog post that outlines process once ready to send out CFP.
 
 * Nominating @jasnell to rejoin TSC [#694](https://github.com/nodejs/TSC/issues/694)
@@ -97,7 +102,7 @@
       for this week. There is a draft (containing the problem description only at
       this point) in an open Build repo issue and it is being actively discussed.
 
-## Q&A, Other
+## Q\&A, Other
 
 ## Upcoming Meetings
 

--- a/meetings/2019-05-15.md
+++ b/meetings/2019-05-15.md
@@ -20,7 +20,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * Myles - Call for submissions for Node+JS Interactive is open, please submit. <https://events.linuxfoundation.org/events/nodejs-interactive-2019/program/call-for-proposals-cfp/>
 
@@ -50,6 +50,7 @@
     Modules.  Discussion around export maps.  New field in package.json to explicitly state
     deep modules, would help define contract as to what is public or not. Last discussion is
     around how to require esm, is controversial. Still hopeful on timeline to unflag by October.
+
   * Open Web standards
     * TC39 meeting just after JSConfEU in Berlin.
     * Will be session at upcoming collab summit
@@ -60,13 +61,15 @@
   * QUIC/HTTP3
     * Working on implementation in nodejs/quic, idea is to implement basic quic protocol and
       Http3.
+
   * plan to show at collaborator summit
+
   * NearForm and protocol labs are sponsoring time it.
 
   * Build resources
     * Was going to discuss with build team in meeting this week but was cancelled.
 
-## Q&A, Other
+## Q\&A, Other
 
 ## Upcoming Meetings
 

--- a/meetings/2019-06-05.md
+++ b/meetings/2019-06-05.md
@@ -19,7 +19,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -56,9 +56,9 @@
       forward with moving Workers out of experimental state after going through
       the WebMessaging web platform tests and making sure that our implementation
       aligns with them (that is currently in progress), and adding Workers-using
-      modules (e.g. workerpool at ~250k downloads/month) to CITGM.
+      modules (e.g. workerpool at \~250k downloads/month) to CITGM.
 
-## Q&A, Other
+## Q\&A, Other
 
 ## Upcoming Meetings
 

--- a/meetings/2019-06-19.md
+++ b/meetings/2019-06-19.md
@@ -21,7 +21,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * <https://github.com/nodejs/node/issues/27731> - Nominating Jiawen Geng @gengjiawen to be a Collaborator . Gireesh and Matteo will be onboarding Jiawen on 06/20
 
@@ -57,7 +57,7 @@
     * Will have V8 7.5 in next release
     * Still plan to get 7.6 in before 12.x goes to LTS
 
-## Q&A, Other
+## Q\&A, Other
 
 ## Upcoming Meetings
 

--- a/meetings/2019-06-26.md
+++ b/meetings/2019-06-26.md
@@ -19,7 +19,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -39,6 +39,7 @@
 ### nodejs/TSC
 
 * Nominating @BethGriggs to the TSC [#718](https://github.com/nodejs/TSC/issues/718)
+
 * doc: update TSC charter [#698](https://github.com/nodejs/TSC/pull/698)
   * discussed today in the CPC meeting and it was agreed that it is ready to land.
   * Michael has submitted PR to clarify CPC governance for review/approval of
@@ -58,7 +59,7 @@
   * Some conversation spurred by Sam.  Need to talk to a number of the build WG
     Members. Wish had more progress.
 
-## Q&A, Other
+## Q\&A, Other
 
 ## Upcoming Meetings
 

--- a/meetings/2019-07-03.md
+++ b/meetings/2019-07-03.md
@@ -23,7 +23,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -38,9 +38,9 @@
     * some TSC members were not convinced we needed them and it could just overcomplicate
       things
   * Two more things have come up for Myles (who has always wanted them) which indicate
-      they would be needed.
+    they would be needed.
     * There is PR
-    * WASI, setting up to be under wasi_unstable:
+    * WASI, setting up to be under wasi\_unstable:
     * Some layered APIs in browser that are using std:
     * Work in TC39 to standardize built in modules as js:
     * Bullish that we should use nodejs:, would be willing to head over to IANA to
@@ -79,7 +79,7 @@
 * Nominating @BethGriggs to the TSC [#718](https://github.com/nodejs/TSC/issues/718)
   * FYI only
 * doc: update TSC charter [#698](https://github.com/nodejs/TSC/pull/698)
-  * Just waiting on cpc governance update and then this should land (~7-10 days)
+  * Just waiting on cpc governance update and then this should land (\~7-10 days)
 * Tracking issue for updating TSC on Board Meetings [#476](https://github.com/nodejs/TSC/issues/476)
 * Strategic Initiatives - Tracking Issue [#423](https://github.com/nodejs/TSC/issues/423)
   * Modules
@@ -109,7 +109,7 @@
 * Build resources
   * Rich, need to make an appointment with Michael as next step.
 
-## Q&A, Other
+## Q\&A, Other
 
 ## Upcoming Meetings
 

--- a/meetings/2019-07-10.md
+++ b/meetings/2019-07-10.md
@@ -21,7 +21,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -52,7 +52,7 @@
     * Gabriel found modules with several hundreds of thousands of downloads/month,
       <https://github.com/nodejs/abi-stable-node/issues/346#issuecomment-508648674>
 
-## Q&A, Other
+## Q\&A, Other
 
 ## Upcoming Meetings
 

--- a/meetings/2019-07-24.md
+++ b/meetings/2019-07-24.md
@@ -20,7 +20,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * Michael: OpenJS board meeting this Friday
 * Rich: 12.7.0 released
@@ -52,13 +52,14 @@
     * Progress update: <https://github.com/Fishrock123/bob/issues/40>.
     * Trying to organize meeting around effort to discuss some of the key issues.  <https://github.com/Fishrock123/bob/issues/43>
     * Planning to move into Node.js org soon
+
 * V8 currency
   * Michaël Zasso: nothing special to report this week
 
 * Build resources - Rich, Michael D, Rod have had some discussions. Nothing to report
   but moving forward slowly.
 
-## Q&A, Other
+## Q\&A, Other
 
 ## Upcoming Meetings
 

--- a/meetings/2019-07-29.md
+++ b/meetings/2019-07-29.md
@@ -22,7 +22,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -77,16 +77,17 @@
   * Core promise APIs
     * No update
   * New streams
-    * Last week’s July progress update <https://github.com/Fishrock123/bob/issues/40> *
+    * Last week’s July progress update <https://github.com/Fishrock123/bob/issues/40> \*
   * V8 - 7.6 is stable, will update the PR by the end of the week and work on integration in
     Node.js 12. Canary is fine.
+
 * Quic/HTTP3
   * good size checklist in issue
   * Making progress, tracking spec. Fairly complicate.
   * Most work is to work around limitations in Node APIs to get good perf
   * Hoping to land as experimental Oct/Nov
 
-## Q&A, Other
+## Q\&A, Other
 
 ## Upcoming Meetings
 

--- a/meetings/2019-08-14.md
+++ b/meetings/2019-08-14.md
@@ -23,7 +23,7 @@
 
 ### Announcements
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * Security release coming out tomorrow. Links with all details: <https://nodejs.org/en/blog/vulnerability/aug-2019-security-releases/>
 
@@ -67,7 +67,7 @@
     * Goal is to be able to support both Python 2 and Python 3 by end of year
     * Some recommendations
       * we should look at using virtual envs, de-couples from OS version and gives us
-          better control
+        better control
       * Should adopt GYP3 fork
       * Need to update build machines to support both Python 2 and Python 3
     * Key issues
@@ -89,7 +89,7 @@
     * Raised awareness that if anybody does have concerns/issues please post in issue or
       reach out to Matteo or Michael.
 
-## Q&A, Other
+## Q\&A, Other
 
 ## Upcoming Meetings
 

--- a/meetings/2019-08-21.md
+++ b/meetings/2019-08-21.md
@@ -31,7 +31,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 

--- a/meetings/2019-08-28.md
+++ b/meetings/2019-08-28.md
@@ -30,14 +30,14 @@
 * CPC update
   * Travel Fund, org of Collab summit.
     * Request for feedback on admin repo, management of fund will move to CPC and be
-        opened up to other projects.
+      opened up to other projects.
     * Org of summit and repo will move CPC org
 * Board
   * Link to the public board meeting: <https://www.youtube.com/watch?v=krND7nWRUqE>
   * Of note, date for next years Node+JS Interactive (2020) may shift. Possibly late spring/early
-      summer, October also might be considered. Event space availability is one constraint.
+    summer, October also might be considered. Event space availability is one constraint.
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 

--- a/meetings/2019-09-11.md
+++ b/meetings/2019-09-11.md
@@ -30,7 +30,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * CPC side
   * Matteo: working away doing the job. Few projects applying, working through the process
@@ -112,6 +112,7 @@
   * Michael will update the calendar entry.
 
 * Nominating @tniessen for the TSC [#746](https://github.com/nodejs/TSC/issues/746)
+
 * Nominating @BethGriggs to the TSC [#718](https://github.com/nodejs/TSC/issues/718)
   * Agreed that these can move forward.
   * As per charter needs vote

--- a/meetings/2019-09-18.md
+++ b/meetings/2019-09-18.md
@@ -26,17 +26,17 @@
 ### CPC and Board Meeting Updates
 
 * Michael: Next board meeting is 1 week from Friday. Nothing on the admin project board to discuss
-    at this point, please let me know if there is anything I should be brigning up.
+  at this point, please let me know if there is anything I should be brigning up.
 
 * CPC update.
   * Michael: Mostly work on governance around how projects are review/brought into foundation. As
-      discussed before also work on moving Travel fund up to OpenJS level and Code of Conduct handling
-      process.
+    discussed before also work on moving Travel fund up to OpenJS level and Code of Conduct handling
+    process.
 
   * Myles: good time to get involved if you have views on strategic procjects to have in foundation
-      or the process to review/accept projects.
+    or the process to review/accept projects.
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -97,8 +97,8 @@
     * @gdams
     * @gibfahn
     * @thefourtheye
-Those in attendance did not raise objections and will be counted as +1 votes for that proposal.
-Michael to post that in the recert issue and to ask rest of TSC members to vote.
+      Those in attendance did not raise objections and will be counted as +1 votes for that proposal.
+      Michael to post that in the recert issue and to ask rest of TSC members to vote.
 
 ## Strategic Initiatives
 
@@ -107,4 +107,4 @@ Michael to post that in the recert issue and to ask rest of TSC members to vote.
 * **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
-~
+\~

--- a/meetings/2019-09-25.md
+++ b/meetings/2019-09-25.md
@@ -32,7 +32,7 @@
   * progress on CoC proprosal
   * working on project progression
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -54,8 +54,8 @@
       to make python 3 compatible.
   * [ ] node-gyp: release so that npm can pick it up <https://github.com/nodejs/node-gyp/issues/1791#issuecomment-533715634>
     * working on doing round trip. Blocked by OSX bug. Christian is working on that.
-  * [ ] re-vendor npm's gyp back into nodejs/node **/deps/npm/node_modules/node-gyp**
-  * [ ] Travis CI does not test ./configure --ninja test #29415   ***help needed***
+  * [ ] re-vendor npm's gyp back into nodejs/node **/deps/npm/node\_modules/node-gyp**
+  * [ ] Travis CI does not test ./configure --ninja test #29415   _**help needed**_
     * Sam, some discussion about testing configure options, not all are tested.  Some tested
       in docker. Question is why this one?  Less vital if the tap2junit lands.
   * [ ] node-gyp: Accept Python 3 by default (_semver-major_) nodejs/node-gyp#1844 (macOS fails)

--- a/meetings/2019-10-16.md
+++ b/meetings/2019-10-16.md
@@ -29,15 +29,15 @@
   * another lager project.  More to come.
 * Michael - nvm was also announced last week.
 * Rich - call for people to test with 13.x RCs that Beth has been putting out.  Release is
-    planned for next Tuesday.
+  planned for next Tuesday.
 * Matteo - collaborator summit occuring at Node+JS Interactive. Please consider coming,
-    travel fund is available, call for topics is open.  No fixed deadline, but as soon as possible
-    to help organizers.
+  travel fund is available, call for topics is open.  No fixed deadline, but as soon as possible
+  to help organizers.
 * James - NodeConf.eu - will be having small Code+Learn.
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * Matteo:
 * Michael: board meeting next week, let me know if there is anything that needs to be raised
@@ -86,19 +86,19 @@
   * Can add export map section to package.json to limit what can be exported through
     something like require(‘lodash/fp’)
   * talking about how you would self reference (references in your own map).  Something
-    like require(‘~/fp’).
+    like require(‘\~/fp’).
   * This issue primarily has consensus on landing, but high level question is which sigil to
-    use @ or ~. For example: require(‘@/fp’) || require(‘~/fp’), import ‘@/fp’ || import ‘~/fp’
-  * Some objections to ~ as it already means things on linux, could be confusing as it does
-    not refer to home directory.  ~ has also been used in some other cases
+    use @ or ~~. For example: require(‘@/fp’) || require(‘~~/fp’), import ‘@/fp’ || import ‘\~/fp’
+  * Some objections to \~ as it already means things on linux, could be confusing as it does
+    not refer to home directory.  \~ has also been used in some other cases
   * Since request, behaviour has been moved behind flag while they work on investigating
     ecosystem interaction.
   * Does anybody have strong feelings on the issue
-  * James agree with concerns with ~
+  * James agree with concerns with \~
   * Rich, experimental TSC does not need to decide
   * Sounds like TSC is split.
-  * Gabriel, scripts use ~ for $HOME
-  * Myles, those in favor ~ being HOME for module makes sense.
+  * Gabriel, scripts use \~ for $HOME
+  * Myles, those in favor \~ being HOME for module makes sense.
 
 * build: ongoing list of actions for Python 3 compatibility [#25789](https://github.com/nodejs/node/issues/25789)
   * npm landed, has new node-gyp

--- a/meetings/2019-10-23.md
+++ b/meetings/2019-10-23.md
@@ -31,7 +31,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 Board: Michael: board meeting this week no issues on board, please let me know if you have anything to add.
 
@@ -111,9 +111,9 @@ CPC: focus is on onboarding new projects, but also new projects as well. This in
   * looks to be blocked by macOS issue (Xcode 8)
   * 7.9 will not be stable this month anyway.
 * Had to patch a few files to gyp in canary. V8 removed embedded built ins
-    Don’t think we used it, would be a concern if node.js embedders use it
-    Also removed ability to build V8 without snapshots.  Michael Z will follow up
-    with Myles to see if we think there is a risk to native modules.
+  Don’t think we used it, would be a concern if node.js embedders use it
+  Also removed ability to build V8 without snapshots.  Michael Z will follow up
+  with Myles to see if we think there is a risk to native modules.
 
 ## Upcoming Meetings
 

--- a/meetings/2019-11-06.md
+++ b/meetings/2019-11-06.md
@@ -27,7 +27,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * Board Update - nothing on the project board for items to bring to the board
   * <https://github.com/nodejs/admin/projects/1>

--- a/meetings/2019-11-20.md
+++ b/meetings/2019-11-20.md
@@ -24,7 +24,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * CPC
   * Focus is on onboarding

--- a/meetings/2019-11-27.md
+++ b/meetings/2019-11-27.md
@@ -29,7 +29,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 

--- a/meetings/2019-12-04.md
+++ b/meetings/2019-12-04.md
@@ -31,7 +31,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * CPC update
   * Lot of activities on the onboarding side.
@@ -69,7 +69,7 @@
   experimental), massive PR.
 
 * Startup performance:
-  * Adding documentation about node_mksnapshot and mkcodecache.
+  * Adding documentation about node\_mksnapshot and mkcodecache.
   * Working on v8::External optimization (so that we can go back to the context-independent v8::External which can be included in isolate snapshots, instead of using the embedder field which can’t)
 
 * Build resources - still discussing with board, nothing to report at this time.

--- a/meetings/2020-01-08.md
+++ b/meetings/2020-01-08.md
@@ -4,7 +4,7 @@
 
 * **Recording**:  <https://youtu.be/owCRMkiAWWY>
 * **GitHub Issue**: <https://github.com/nodejs/TSC/issues/796>
-* **Minutes Google Doc**: $MINUTES_DOC$
+* **Minutes Google Doc**: $MINUTES\_DOC$
 
 ## Present
 
@@ -36,7 +36,7 @@
     director seat would be used for next year as it was only dedicated to the Node.js project for the
     first year)
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -66,6 +66,7 @@
 * http2: make compat finished match http/1 [#24347](https://github.com/nodejs/node/pull/24347)
   * waiting on review from  James
   * Anatoli has worked through issue with Ronag, believes it is ready to go now, so unblocked.
+
 * process: add CLI opt to hide experimental warnings [31000](https://github.com/nodejs/node/pull/31000)
   * TSC members asked that we discuss this week to get started.
   * James, sets bad precedent, we have the warnings as we don’t want people to use them in
@@ -92,7 +93,7 @@
   * James, we need to make sure there is active monitoring for overall tone and messaging, but
     basic idea of team with annual renewal makes sense
   * nomination criteria might be more stringent with explicit approval (as opposed to
-  self-nominate and in unless objections)
+    self-nominate and in unless objections)
   * General ask is to think/review and comment in the issue.
 
 ## Strategic Initiatives

--- a/meetings/2020-01-15.md
+++ b/meetings/2020-01-15.md
@@ -26,7 +26,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * Michael: vote underway at board level for one-off approval to cover travel request (see admin repo) is
   underway to cover as we don't have the 2020 allocation finaliazed yet
@@ -62,7 +62,7 @@
     storage and believe it is something that makes sense in core as it's common issue for APM
     and need coordination with core so good to be in core.
   * Rich: we should probably move forward on getting TSC consensus. Michael has action to open
-  issue to do this.
+    issue to do this.
 
 ### nodejs/TSC
 

--- a/meetings/2020-01-22.md
+++ b/meetings/2020-01-22.md
@@ -24,7 +24,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * Michael: Board meeting this week. Quick overview of requests to board.
 * Michael: CPC discussions to be aware of
@@ -35,7 +35,7 @@
 
 ### nodejs/node
 
-* doc: add runkit embeds[#30241]( https://github.com/nodejs/node/pull/30241)
+* doc: add runkit embeds[#30241](https://github.com/nodejs/node/pull/30241)
   * Issues from last time:
     * executing JavaScript code from their domain in our region.
     * tracking our users
@@ -66,7 +66,7 @@
       * Websocket is used to send code over from website and then back to the browser when you hit
         run.
       * Only connect to Runkit if you select run button
-      * enabled through example by adding “runnable”  after ```js
+      * enabled through example by adding “runnable”  after \`\`\`js
 
   * Other users
     * npm already has this on their site (has button that says try on runkit)

--- a/meetings/2020-02-05.md
+++ b/meetings/2020-02-05.md
@@ -29,7 +29,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 

--- a/meetings/2020-02-26.md
+++ b/meetings/2020-02-26.md
@@ -30,10 +30,10 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * Board meeting this week.
-* Michael: Microsoft identified a 2 people who between them will have ~ 1day/week to contribute
+* Michael: Microsoft identified a 2 people who between them will have \~ 1day/week to contribute
   on the build side.  Had initial touch base and am getting them connection to build WG like
   recent new Google person.
 

--- a/meetings/2020-03-11.md
+++ b/meetings/2020-03-11.md
@@ -30,7 +30,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * Bethany:  Node.js 14.x PR has been opened, will be updated each week.  March 24 is the
   SemVer major cutoff. After that point majors require no objections from the TSC to land in v14.x.

--- a/meetings/2020-03-18.md
+++ b/meetings/2020-03-18.md
@@ -31,7 +31,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * Board
   * Guidance on member companies provided additional directed funding documented here:
@@ -79,15 +79,15 @@
   going LTS in October) but others believe we can do sooner.  Would still stay as experimental.
   * Matteo, not convinced we should remove warning until it is stable.
   * Myles, believe it is pretty much production ready. Work is around improving warning and
-      edge cases.
+    edge cases.
   * Matteo, have a number of specific cases that are not yet covered, will share list as
-      input to the experimental exit criteria
+    input to the experimental exit criteria
   * Myles do want to get to point were we remove warning before it exits Experimental so
-      that we do get more adoption before doing that.
+    that we do get more adoption before doing that.
   * We remove warnings for Async Hooks, promised APIs, possibly N-API.  Don’t think
-      we have any governance that requires warning for Experimental
+    we have any governance that requires warning for Experimental
   * Next step is to document criteria to be met before removing the warning. Already at the
-      point were there are no plans for major changes.
+    point were there are no plans for major changes.
 
 * Core promise APIs, still moving forward, some areas like http where not sure yet what we
   should do.

--- a/meetings/2020-04-01.md
+++ b/meetings/2020-04-01.md
@@ -33,7 +33,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 #### CPC
 
@@ -44,7 +44,7 @@
 #### Board
 
 * Board met last Friday
-* Nothing too much to call out*
+* Nothing too much to call out\*
 * Brian actively working on tooling for signed off support.
 
 ### nodejs/node
@@ -54,8 +54,8 @@
 
 * Update npm on all supported release lines to address CVE scored 9.8 in minimist package [#32296](https://github.com/nodejs/node/issues/32296)
   * PR for every release line ready which handles this. Already landed on 13.x. Waiting
-  for build change to allow build bot to build on OSX 15.x, plan is for them to be part
-  of next 10 and 12 release (both on 7th).
+    for build change to allow build bot to build on OSX 15.x, plan is for them to be part
+    of next 10 and 12 release (both on 7th).
 
 ### nodejs/Release
 

--- a/meetings/2020-04-08.md
+++ b/meetings/2020-04-08.md
@@ -36,7 +36,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -48,7 +48,7 @@
   * Myles: time critical part is whether it makes it into 14.x.
   * Rich: this can go into a later 14.x version since it is Minor so possibly not time sensitive.
   * Sam at least the patch is not too intrusive, but APIs continue to change.
-  * That the QUICs PR was split into multiple PRs (ng*, openssl, quics) makes it much more reviewable, thanks @jasnell
+  * That the QUICs PR was split into multiple PRs (ng\*, openssl, quics) makes it much more reviewable, thanks @jasnell
   * Matteo's only concern is on the OpenSSL side, the rest looks fine.  Questions is what
     happens if it breaks.
   * Myles, could we have patch in tree and apply as part of build as opposed to being in.

--- a/meetings/2020-04-16.md
+++ b/meetings/2020-04-16.md
@@ -30,7 +30,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -76,7 +76,7 @@
 * work on the implementation is continuing. The OpenSSL patch did not require any updates for
   OpenSSL 1.1.1f. We'll see what happens with the upcoming 1.1.1g. As a backup plan, I have
   started investigating what it would take to implement the QUIC support as a native addon and
-  the work is absolutely *not* trivial. The implementation currently relies on a significant part of
+  the work is absolutely _not_ trivial. The implementation currently relies on a significant part of
   Node.js core internals that are not exposed via N-API so the ideal path is still landing in core.
 
 ### Build resources update

--- a/meetings/2020-04-23.md
+++ b/meetings/2020-04-23.md
@@ -27,7 +27,7 @@
 * Board meeting this, week.
   * James asked about DCO side of things.
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 

--- a/meetings/2020-04-29.md
+++ b/meetings/2020-04-29.md
@@ -30,13 +30,14 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * OpenJS conference schedule announced
 
 ### nodejs/node
 
 * Dispute of "block running on EOL Windows versions #31954" - Alternative Suggestion [#33034](https://github.com/nodejs/node/issues/33034)
+
 * src,win: Replacement of unsupported versions of Windows runtime exit [#33108](https://github.com/nodejs/node/pull/33108)
   * We actively check windows version and exit if no longer supported
   * Complaints that not free upgrade from Windows 7 to Windows 10 so until an issue
@@ -97,7 +98,7 @@
   * On track to remove flag on next 12.x SemVer minor
   * Most feedback is around loaders and what you can’t do (for example things rewire does)
   * Modules team a year ago separated out work on loaders as it was leading to stand-still
-  * If looking to stabilize in ~Oct would be good to understand loaders reqs and do loaders
+  * If looking to stabilize in \~Oct would be good to understand loaders reqs and do loaders
     need to be stable for modules to be stable? Matteo does believe loaders need to be
     stable if modules are stable.  Could be a good time to ask people from the Diagnostics
     WG.  Matteo, not feasible to run server in production without stable loaders.

--- a/meetings/2020-05-07.md
+++ b/meetings/2020-05-07.md
@@ -29,13 +29,14 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * No announcements this week.
 
 ### nodejs/node
 
 * src,win: Replacement of unsupported versions of Windows runtime exit. [#33108](https://github.com/nodejs/node/pull/33108)
+
 * Dispute of "block running on EOL Windows versions #31954" - Alternative Suggestion [#33034](https://github.com/nodejs/node/issues/33034)
   * active discussion in issue, lets let it go for another week.
 
@@ -74,7 +75,7 @@
 
 * Promises:
   * There are some discussion around Thenable and AsyncLocalStorage in nodejs/node#33189.
-  * Promise hooks (used by async_hooks) are going to get faster by nodejs/node#32891.
+  * Promise hooks (used by async\_hooks) are going to get faster by nodejs/node#32891.
 
 * Build resources:
   * Have gotten info from one potential provider, $ amount is larger enough that we need to consider how

--- a/meetings/2020-05-14.md
+++ b/meetings/2020-05-14.md
@@ -27,11 +27,12 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
 * src,win: Replacement of unsupported versions of Windows runtime exit. [#33108](https://github.com/nodejs/node/pull/33108)
+
 * Dispute of "block running on EOL Windows versions #31954" - Alternative Suggestion [#33034](https://github.com/nodejs/node/issues/33034)
   * <https://github.com/nodejs/node/pull/33176>
   * James, raised concern about env variable, but happy given explanations.
@@ -41,7 +42,7 @@
   * Matheus mentioned its moving forward well.
   * nothing else to discuss this week.
 
-* \[Regression in 14.1.0 - Windows\] `stdout` is sometimes empty [#33166](https://github.com/nodejs/node/issues/33166)
+* \[Regression in 14.1.0 - Windows] `stdout` is sometimes empty [#33166](https://github.com/nodejs/node/issues/33166)
   * Matteo: specific combinations of build then run environment needed to
     cause.  Seems to be hit in github actions. Problem is that we don’t
     have enough windows expertise. Tracked down to a commit, don’t

--- a/meetings/2020-05-21.md
+++ b/meetings/2020-05-21.md
@@ -23,14 +23,15 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
-* \[Regression in 14.1.0 - Windows\] `stdout` is sometimes empty [#33166](https://github.com/nodejs/node/issues/33166)
+* \[Regression in 14.1.0 - Windows] `stdout` is sometimes empty [#33166](https://github.com/nodejs/node/issues/33166)
   * Agreed this could be removed from Agenda.
 
 * src,win: Replacement of unsupported versions of Windows runtime exit. [#33108](https://github.com/nodejs/node/pull/33108)
+
 * Dispute of "block running on EOL Windows versions #31954" - Alternative Suggestion [#33034](https://github.com/nodejs/node/issues/33034)
   * Looks like it’s progressing in <https://github.com/nodejs/node/pull/33176>, nothing
     to discuss in the meeting.
@@ -57,7 +58,9 @@
 ## Strategic Initiatives
 
 * Startup time
+
 * Relanding the blocking v8 patch <https://chromium-review.googlesource.com/c/v8/v8/+/2212085>
+
 * <https://github.com/nodejs/node/pull/32761> was closed though the technical disagreement is still not settled (for differences between <https://github.com/nodejs/node/pull/32761> and <https://github.com/nodejs/node/pull/32984>, see the discussions in <https://docs.google.com/document/d/15bu038I36oILq5t4Qju1sS2nKudVB6NSGWz00oD48Q8/edit?usp=sharing>, would love more input there to break the tie). As @jasnell mentioned in <https://github.com/nodejs/node/pull/32761#issuecomment-628972927> I think this reveals that we have some issues with the current process. Some points that I can think of
   * There should've been a better way to communicate about active efforts to avoid duplication of work and competition. In this case there were occasional updates in the tracking issue <https://github.com/nodejs/node/issues/17058>, related PRs and meetings, but those were not visible enough and still lead to conflicts
   * We need more reviewers for certain tasks or certain subsystems, ideally more than two people (to break the tie when there are technical disagreements) and from more than one party (to avoid bias). I don't think it's a good idea to always escalate these to TSC, because not all of us are interested in or familiar with the same part of the code base, and so we don't always get the attention we ask for if the disagreement involves substantial amount of reading or context. Maybe a team + CODEOWNERS structure can help

--- a/meetings/2020-06-04.md
+++ b/meetings/2020-06-04.md
@@ -32,7 +32,7 @@
 
 * No updates this week
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 

--- a/meetings/2020-07-02.md
+++ b/meetings/2020-07-02.md
@@ -23,7 +23,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 

--- a/meetings/2020-07-09.md
+++ b/meetings/2020-07-09.md
@@ -30,7 +30,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 

--- a/meetings/2020-07-16.md
+++ b/meetings/2020-07-16.md
@@ -30,7 +30,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * FYI - changes to Foundation bylaws approved recently and published. See <https://github.com/openjs-foundation/cross-project-council/issues/590> for some info about changes.
 

--- a/meetings/2020-08-06.md
+++ b/meetings/2020-08-06.md
@@ -27,7 +27,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 

--- a/meetings/2020-08-13.md
+++ b/meetings/2020-08-13.md
@@ -19,12 +19,12 @@
 ### Announcements
 
 * Mary: Change to collaborator guide, if you object make sure to use the requests changes to indicate you don’t want it to land unless your comments/objections are addressed
-* Mary: Survey on unhandled rejections is up, please participate. ~ 500 participants so far, but would like about 2000 before closing, if we get answers at same rate we should meet that.
+* Mary: Survey on unhandled rejections is up, please participate. \~ 500 participants so far, but would like about 2000 before closing, if we get answers at same rate we should meet that.
 * Mary: Commit queue pull request will land later today, will let us land using a label. Once it lands the Triage team will be able to land PRs as well, but only if it meets all of the requirements so it should be safe. If you object please say so on meeting issue or the pull request.
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 

--- a/meetings/2020-08-27.md
+++ b/meetings/2020-08-27.md
@@ -26,11 +26,11 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
-* \[v14.x backport\] stream: simpler and faster Readable async iterator  [#34887](https://github.com/nodejs/node/pull/34887)
+* \[v14.x backport] stream: simpler and faster Readable async iterator  [#34887](https://github.com/nodejs/node/pull/34887)
   * Matteo added as FYI to the agenda.
 
 * Rename default branch from "master" to "main" or something similar [#33864](https://github.com/nodejs/node/issues/33864)
@@ -55,7 +55,7 @@
     * one issue is `people use npm because it’s the default`
     * one issue is that people don’t get to choose, it’s the projects which make the decision
     * each package manager has slightly different behaviour so you have to use the one
-        that is used for the project.
+      that is used for the project.
     * The question is not which is best, but how to best let the co-exist.
     * He’s going to take us through the package-manager-manager flow, shared screen
   * Chalker - <https://github.com/tribou/words/blob/master/package.json#L7-L11> (random repo from gh search)

--- a/meetings/2020-09-03.md
+++ b/meetings/2020-09-03.md
@@ -34,7 +34,7 @@
 
 ### nodejs/node
 
-* \[v14.x backport\] stream: simpler and faster Readable async iterator  [#34887](https://github.com/nodejs/node/pull/34887)
+* \[v14.x backport] stream: simpler and faster Readable async iterator  [#34887](https://github.com/nodejs/node/pull/34887)
   * Please review/comment on the issue
   * Myles, see Matteo chiming that it is a good thing so comfortable that it will land, personally
     ok to move forward as long as CI is green.

--- a/meetings/2020-09-16.md
+++ b/meetings/2020-09-16.md
@@ -28,7 +28,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * No updates from Board
   * No updates on the CPC front.
@@ -40,6 +40,7 @@
 
 * doc: change requirements for objection dismissal [#35037](https://github.com/nodejs/node/pull/35037)
   * Discussion around the bigger problem
+
   * On the specific issue
     * Matteo objects, but adding “unless the objector marks their objection as final”
     * Ruben, this addresses a common case where the objection is non-responsive at all
@@ -49,14 +50,14 @@
     * James will take a stab on alternative approach.
 
 * util: add util.parseArgs() [#35015](https://github.com/nodejs/node/pull/35015)
-  *
+  \*
 
 * doc: drop minimum waiting time as hard guideline [#33879](https://github.com/nodejs/node/pull/33879)
   * James, proposal by Anna, following contribution survey
   * objections in thread that it makes is more difficult for people internationally
   * compromise proposal ->
-      Reduce the current time limits to 24 hours with two sign offs, at least one of which is from
-      relevant CODEOWNERS team, or 72 hours with one sign off.
+    Reduce the current time limits to 24 hours with two sign offs, at least one of which is from
+    relevant CODEOWNERS team, or 72 hours with one sign off.
   * however, objections have not weighed in.
   * Agreement was to open issue in TSC repo with proposed resolution (option 3 along audit of code owners), unless there are objections  in 1week we will go with that.  Michael has action to open that issue.
 

--- a/meetings/2020-09-24.md
+++ b/meetings/2020-09-24.md
@@ -24,18 +24,18 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
-* module: CJS exports detection for modules with __esModule export [#33416](https://github.com/nodejs/node/pull/33416)
+* module: CJS exports detection for modules with \_\_esModule export [#33416](https://github.com/nodejs/node/pull/33416)
   * Release modules unflagged in 12.x, lots of feedback
   * Biggest frustration is that is does not support name exports for CommonJS modules
   * Tried different options including going through TC39, but no clear/spec compliant way
     of doing it.
   * Since CommonJS is dynamic you’d need to load the full module
   * Close to agreement on PR with addition of change to limit to just those with
-    __esmodule export (typically added by transpilers like webpack).  Accuracy would
+    \_\_esmodule export (typically added by transpilers like webpack).  Accuracy would
     be in the 90% range in this case, for all modules would be 70%
   * When it gets it wrong, you don’t get the export, objection is that it would be confusing
     if some modules work and others don’t. Error message would give them the correct
@@ -46,11 +46,11 @@
   * Guy, feedback is the expectation is that this works, and when it is not its a detriment to
     The ecosystem
   * Guy, on the other hand it is a heuristic, so not 100% and can see the objection.
-  * Added __esmodule flag as that improves the accuracy, but that only covers the transpilation
+  * Added \_\_esmodule flag as that improves the accuracy, but that only covers the transpilation
     case, so the restriction is too restrictive.  Guy, would prefer to have apply to all ES modules,
   * Collaborator would be blocking on that.
-  * Mary, disagree that __esmodule flag approach gives higher accuracy. From user experience
-    the user does not care if transpiled or not, so limiting to__esmodules actually reduces
+  * Mary, disagree that \_\_esmodule flag approach gives higher accuracy. From user experience
+    the user does not care if transpiled or not, so limiting to\_\_esmodules actually reduces
     the accuracy. Better user experience to cover broader case. Should be able to improve the
     experience later on.
   * Michael only concern with respect to the proposed PR.

--- a/meetings/2020-10-01.md
+++ b/meetings/2020-10-01.md
@@ -8,15 +8,25 @@
 ## Present
 
 * Anatoli Papirovski @apapirovski (TSC)
+
 * Beth Griggs @BethGriggs (TSC)
+
 * Ruben Bridgewater @BridgeAR (TSC)
+
 * Сковорода Никита Андреевич @ChALkeR (TSC)
+
 * Colin Ihrig @cjihrig (TSC)
+
 * Gabriel Schulhof @gabrielschulhof (TSC)
+
 * Gireesh Punathil @gireeshpunathil (TSC)
+
 * Matteo Collina @mcollina (TSC)
+
 * Michael Dawson @mhdawson (TSC)
+
 * Myles Borins @MylesBorins (TSC)
+
 * Rich Trott @Trott (TSC)
 
 * Benjamin Coe @bcoe (Guest)
@@ -29,7 +39,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -39,7 +49,7 @@
     following:
     1. Let's mark the current API as stable, since it's used a lot
     2. Rename the current API to e.g., `rm` while keeping the current API as alias
-        to the new one
+       to the new one
     3. The alias gets deprecated
     4. Add a new function that has the stricter version
 

--- a/meetings/2020-10-08.md
+++ b/meetings/2020-10-08.md
@@ -24,7 +24,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 

--- a/meetings/2020-10-29.md
+++ b/meetings/2020-10-29.md
@@ -26,14 +26,14 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * Board meeting this week. Nothing new that I have to bring up with them.
 
 ### nodejs/node
 
 * [34895](https://github.com/nodejs/node/pull/34895), blocked on on TSC approvals.
-  * new top module -> diagnostics_channel
+  * new top module -> diagnostics\_channel
   * @Qard owns namespace in npm, so no chance of collision
   * Needs 2 TSC approvals
   * No objections/concerns raised in the meeting.

--- a/meetings/2020-11-11.md
+++ b/meetings/2020-11-11.md
@@ -23,7 +23,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * No updates this week
 

--- a/meetings/2020-12-09.md
+++ b/meetings/2020-12-09.md
@@ -22,7 +22,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * Nothing in particular to note this week.
 

--- a/meetings/2021-01-14.md
+++ b/meetings/2021-01-14.md
@@ -28,7 +28,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * CPC director election this month, let your CPC rep (Mary, Joe) know if you have thoughts/input
 

--- a/meetings/2021-02-04.md
+++ b/meetings/2021-02-04.md
@@ -25,7 +25,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * CPC director election now open, if you have feedback talk to Mary/Joe who
   are the Node.js CPC representatives.
@@ -52,6 +52,7 @@
   * Readme icons (CI status etc) are also likely affected for repos that have those.
 
 * Michael to rename TSC one
+
 * Beth will look into Release one
 
 ### nodejs/docker-node

--- a/meetings/2021-02-25.md
+++ b/meetings/2021-02-25.md
@@ -27,7 +27,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * Board meeting this week, let me know if there is anything you think I should be raising, nothing
   that I am aware of.
@@ -47,6 +47,7 @@
     TSC. Has been lots of discussion.
   * Myles, there has been other discussions like package manager manager, should include in
     vote, some of concerns as well.
+
 * Include Yarn, Include PMM, Leave as is for now
   * Before we vote, invite author to argue in favor of the requests
   * Myles, should we do a survey to gather more information that will help TSC members decide

--- a/meetings/2021-03-18.md
+++ b/meetings/2021-03-18.md
@@ -27,7 +27,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * board meeting next week, let Michael know if there is anything that he should raise. Currently
   nothing on this list
@@ -35,8 +35,11 @@
 ### nodejs/node
 
 * There are a number of open PRs in the nodejs/node repo that are waiting for approvals from TSC members to land: <https://github.com/nodejs/node/pulls?q=is%3Apr+is%3Aopen+label%3A%22review+wanted%22++label%3Asemver-major>. Since the v16 semver cutoff is getting close, I think it would be worth mentioning it in the meeting.
+
 * Rich pointed out we are past the cutoff date
+
 * Beth, we might have a few days as 4 weeks before release date
+
 * The originator mentioned this one as potentially the most important: <https://github.com/nodejs/node/pull/37246>
 
 * doc: move Derek Lewis back to collaborators [#37726](https://github.com/nodejs/node/pull/37726)

--- a/meetings/2021-03-25.md
+++ b/meetings/2021-03-25.md
@@ -24,7 +24,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 

--- a/meetings/2021-04-08.md
+++ b/meetings/2021-04-08.md
@@ -29,12 +29,13 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * Pending charter changes in the TSC repo in a pull request.
 * Mary is our rep again for the next year. Congratulations, Mary!
 
 ### nodejs/node
+
 * doc: mark callback-based fs API as legacy [#37948](https://github.com/nodejs/node/pull/37948)
   * Matteo: Last comment by Tobias matches my sentiment.
   * Robert: Callback API is unsafe. If you use a file descriptor after closing, behavior is undefined. This problem does not exist with promise API.
@@ -92,7 +93,7 @@
   * Matteo: corepack literally has no runtime dependencies.
   * Michael: If yarn is installed transparently via corepack, does it look like we are responsible for security issues in it?
   * Nikita: I’m against bundling yarn directly but I’m in favor of a script to install a package manager. I’ll elaborate on GitHub later.
-  **Action  **: Michael will open an issue in the TSC repo to gather comments before moving to a vote. Basically, pick corepack, pick bundling yarn, or pick neither.
+    \*\*Action  \*\*: Michael will open an issue in the TSC repo to gather comments before moving to a vote. Basically, pick corepack, pick bundling yarn, or pick neither.
 
 * TLS: improve compliance with shutdown standard, remove hacks [#36111](https://github.com/nodejs/node/pull/36111)
   * no time this week
@@ -125,6 +126,7 @@
   * no time this week
 
 ## Strategic Initiatives
+
 * no time this week
 
 ## Upcoming Meetings

--- a/meetings/2021-04-15.md
+++ b/meetings/2021-04-15.md
@@ -23,7 +23,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * Board meeting a week tomorrow, don’t currently have anything on the list to bring up, let me
   know if there is anything I’m not aware of.

--- a/meetings/2021-04-22.md
+++ b/meetings/2021-04-22.md
@@ -26,7 +26,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -85,7 +85,7 @@
   * Ask Chalker to get updated data and then we’ll move based on that.
 
 * Nominations for TSC Membership [#1000](https://github.com/nodejs/TSC/issues/1000)
-  * +1's through email and in meeting:
+  * \+1's through email and in meeting:
     * Gireesh
     * Tobias
     * Rich

--- a/meetings/2021-04-29.md
+++ b/meetings/2021-04-29.md
@@ -27,7 +27,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * elections for votings for non-impact projects and reps for CPC are underway.
 

--- a/meetings/2021-05-20.md
+++ b/meetings/2021-05-20.md
@@ -26,7 +26,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * No updates this week.
 

--- a/meetings/2021-06-10.md
+++ b/meetings/2021-06-10.md
@@ -25,7 +25,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 

--- a/meetings/2021-06-23.md
+++ b/meetings/2021-06-23.md
@@ -25,7 +25,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -37,6 +37,7 @@
 * Automating npm updates with a bot [#38879](https://github.com/nodejs/node/issues/38879)
   * Tobias: Believe this is resolved and Rich closed it.
   * Rich: Resolved and closed.
+
 * Future of the Node HTTP Client  [#38533](https://github.com/nodejs/node/issues/38533)
   * Rich: Left a comment similar to the one left for Adding HTML form data handling to core.
 

--- a/meetings/2021-07-01.md
+++ b/meetings/2021-07-01.md
@@ -50,7 +50,7 @@
 
 * Resigning from CPC Voting Member [#1043](https://github.com/nodejs/TSC/issues/1043)
   * Robert: what is CPC
-    *
+    \*
   * Matteo: I can take it as long as I don’t have to join meetings
   * Mary: will check with CPC if that’s ok
 * To be or not to be in core [#1041](https://github.com/nodejs/TSC/issues/1041)

--- a/meetings/2021-07-14.md
+++ b/meetings/2021-07-14.md
@@ -25,7 +25,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 No board meeting updates
 
@@ -62,6 +62,7 @@ No board meeting updates
 
 * doc: remove section on export control [#617](https://github.com/nodejs/admin/pull/617)
   * landed, so nothing to talk about.
+
 ## Strategic Initiatives
 
 * V8 Currency

--- a/meetings/2021-07-22.md
+++ b/meetings/2021-07-22.md
@@ -29,7 +29,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** before the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** before the meeting.
 
 * Board meeting this week, but nothing Michael has to bring to board on behalf of Node.js
   project.
@@ -59,21 +59,29 @@
   * Matteo, once the case is where they are in the way is that they conflict with
     the way JEST works, Error object thrown by assert will be different from what
     your application (instance of Error returns false)
+
 * Ruben, from his perspective, does not make sense only to move a small
   proportion as other codes can still break.
+
 * Michael, making a subset of APIs better/safer has some value, but the question
   is the benefit versus the cost in terms of risk
+
 * Chalker +1 to what Michael says and primordials don’t address prototype pollution.
+
 * Tobias, I think the idea behind primordials is nice to have, but the question boils down to: is it
   worth the burden and efforts? less readable code, performance problems, inconsistencies,
   unclear scope (e.g., should objects returned by core APIs have properties attached to the
   Object prototype by the user?), "non-standard JavaScript" being a burden for contributors, etc.
   Is it realistic to ever reach a consistent state in which the core behaves consistently?
+
 * Antoine agrees with what Chalker and Tobias have said.
+
 * Ruben next step, get a small group together to propose what “Limit Scope” would mean
+
 * Rich will coordinate calls between those and others who might be involved:
   Antoine, Ruben, Tobias, Chalker will send out to at least TSC to see if other people are
   interested.
+
 * Gireesh summary, when we started, we did not have a full definition of the scope. Now that we
   see issues (performance, more challenging to understand code), we are re-evaluating? Rich:
   at a high level, yes. Revalidate original reasons and possibly continue if they make sense
@@ -84,6 +92,7 @@
   * Alex here from the mentorship initiative to tell us a bit about it
   * Work with groups in the project to find needs, then work to find mentees who are
     a good fit.
+
 * Resigning from CPC Voting Member [#1043](https://github.com/nodejs/TSC/issues/1043)
   * Rich is willing if nobody else wants to do it, he will, but it would be great if somebody
     wanted to do more with OpenJS would pick it up
@@ -110,4 +119,4 @@
 ## Upcoming Meetings
 
 * **Node.js Foundation Calendar**: <https://nodejs.org/calendar>
-Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
+  Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.

--- a/meetings/2021-07-29.md
+++ b/meetings/2021-07-29.md
@@ -22,7 +22,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 

--- a/meetings/2021-08-04.md
+++ b/meetings/2021-08-04.md
@@ -31,7 +31,7 @@
 * No updates on board front
 * No updates on CPC front this week. Rich is now our official representative.
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -78,18 +78,18 @@
 * Core Promise APIs
   * Core Promise Initiative status update: nodejs/node#37947 is ready to land, pending more recent
 
-| Module name            | Promise replacement candidate             |
-| ---------------------- | ----------------------------------------- |
-| `child_process`        | _TBD_                                     |
-| `cluster`              | _TBD_                                     |
-| `crypto`               | Web Crypto API                            |
-| `dns`                  | `dns/promises`                            |
-| `fs`                   | `fs/promises`                             |
-| `http`/`http2`/`https` | `undici`                                  |
+| Module name            | Promise replacement candidate               |
+| ---------------------- | ------------------------------------------- |
+| `child_process`        | _TBD_                                       |
+| `cluster`              | _TBD_                                       |
+| `crypto`               | Web Crypto API                              |
+| `dns`                  | `dns/promises`                              |
+| `fs`                   | `fs/promises`                               |
+| `http`/`http2`/`https` | `undici`                                    |
 | `readline`             | <https://github.com/nodejs/node/pull/37947> |
-| `stream`               | `stream/promises`                         |
-| `timers`               | `timers/promises`                         |
-| `zlib`                 | _TBD_                                     |
+| `stream`               | `stream/promises`                           |
+| `timers`               | `timers/promises`                           |
+| `zlib`                 | _TBD_                                       |
 
 * V8 Currency
   * V8 9.2 landed on Node.js 16.6.0.

--- a/meetings/2021-08-25.md
+++ b/meetings/2021-08-25.md
@@ -26,7 +26,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * No updates this week
 
@@ -69,7 +69,9 @@
 ### nodejs/TSC
 
 * Node.js - Internet Bug Bounty 2.0 Invite [#1063](https://github.com/nodejs/TSC/issues/1063)
+
 * Agreement that we have consensus in the issue, we can say yes.
+
 * Michael will post the answer in the issue (Done 8/25/21).
 
 * To be or not to be in core [#1041](https://github.com/nodejs/TSC/issues/1041)

--- a/meetings/2021-09-23.md
+++ b/meetings/2021-09-23.md
@@ -25,7 +25,7 @@
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 * Board meeting tomorrow but nothing on my list which are Node.js related
 * No CPC updates this week.

--- a/meetings/io.js/2014-10-09.md
+++ b/meetings/io.js/2014-10-09.md
@@ -34,7 +34,7 @@
     of the issues in it so this can wait.
   * @indutny suggested a bot that auto-responds. @isaacs thought an
     autoresponder was a little inhuman. It was agreed that the best thing to do
-    is have a bot that comments on the issue *once a tag is added* that is
+    is have a bot that comments on the issue _once a tag is added_ that is
     specific to that tag and run in concert with humans tagging issues.
   * @piscisaureus really wants to find a way for him to tell if someone already
     looked at an issue so that him, trevor, ben, and fedor don't independently

--- a/meetings/io.js/2014-10-29.md
+++ b/meetings/io.js/2014-10-29.md
@@ -1,6 +1,6 @@
 * Update on Build
   * @rvagg is working on getting the builds consistently green
-  before moving on to more complicated things.
+    before moving on to more complicated things.
 * @issacs brought up the Joyent Advisory board
   * Some confusion out there about Node Forward vs. Advisory Board
   * @mikeal updated the messaging on the website to be clearer
@@ -8,25 +8,25 @@
 * Libuv move
   * The libuv contributors want to move to the libuv org.
   * @mikeal will email @indutny and other libuv contributors to ask them
-  to log an issue about this on their repo for transparency and so that
-  this is not a surprise to Joyent
+    to log an issue about this on their repo for transparency and so that
+    this is not a surprise to Joyent
 * Update on "release buckets"
   * doesn't make sense while we're private, we'll wait until it is public again
 * `node-forward/node` going public
   * when we made the repo private it was messaged as only being for "four weeks"
   * "four weeks" is up on November 8th
   * someone on the Advisory Board needs to remind Joyent of this in the
-  next advisory board meeting so they aren't suprised by it even though
-  it was communicated to them when it was first made public.
+    next advisory board meeting so they aren't suprised by it even though
+    it was communicated to them when it was first made public.
   * @mikeal will work on the messaging in the README to make it clear this is
-  a "soft" fork and not a "hard" fork.
+    a "soft" fork and not a "hard" fork.
   * ramifications of going public will be discussed in next week's TC meeting as
-  well
+    well
 * @mikeal proposed a change in TC meeting process
   * it's impossible to schedule all the timezones involved in every meeting
   * every Monday create a "Weekly TC Agenda" Issue people can contribute to
   * the TC members who care about that Agenda will state they want to be in the
-  meeting
+    meeting
   * @mikeal will work to schedule the TC members who care for a hangout
 * people are using and liking gitter
   * we'll consider moving from IRC to gitter once the repo is public again

--- a/meetings/io.js/2014-12-10.md
+++ b/meetings/io.js/2014-12-10.md
@@ -11,7 +11,7 @@ Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeti
 * Is it io.js, IO.js, or something else? <https://github.com/nodejs/io.js/issues/118>
 * Build automation update
 * extending options from a prototype
-<https://github.com/nodejs/io.js/issues/62>
+  <https://github.com/nodejs/io.js/issues/62>
 * Separate I/O tests from simple, so simple tests can be run in parallel
 * Statement / stance from TC on exposing a Promises API <https://github.com/nodejs/io.js/issues/11>
 

--- a/meetings/io.js/2014-12-17.md
+++ b/meetings/io.js/2014-12-17.md
@@ -42,7 +42,7 @@ Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeti
 * Bert: important because it’s tied to the version of V8, not practical to put it in npm because one is needed for each version
 * Isaac: this is minimal and shouldn’t set a standard for just adding more stuff to core (i.e. keep core minimal), so +1
 
-+1 from Isaac, +1 from Bert, **no disagreement amongst group, consensus has been reached on bundling a tick processor with releases.**
+\+1 from Isaac, +1 from Bert, **no disagreement amongst group, consensus has been reached on bundling a tick processor with releases.**
 
 ### Release Cycle Proposal #168
 
@@ -56,9 +56,9 @@ Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeti
 
 <https://github.com/nodejs/io.js/pull/176>
 
-* Limiting node_modules search path to $HOME as a top-level
-* Isaac ~ -1 on this because EACCES already happens when you don’t have permission
-* Isaac and Bert bikeshedded Windows C:\ writability and security on Windows. i.e. if someone can install code on a shared system above where a node application is running (e.g. C:\) then you could have untrusted code run by your application.
+* Limiting node\_modules search path to $HOME as a top-level
+* Isaac \~ -1 on this because EACCES already happens when you don’t have permission
+* Isaac and Bert bikeshedded Windows C:\ writability and security on Windows. i.e. if someone can install code on a shared system above where a node application is running (e.g. C:) then you could have untrusted code run by your application.
 * Isaac: this PR is only addressing projects running in the home directory.
 * Rod: module system is locked-down, TC needs to come to consensus that this is a _security_ issue and therefore warrants breaking it.
 * Chris: `useradd node_modules` is a situation this could be a problem
@@ -78,7 +78,7 @@ Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeti
 * Rod: in an open model, it’s up to TC and those with commit access to take the initiative to just close things, given enough warning and chance for discussion and better arguments.
 * Isaac: builtins (like Blog of FileReader) are TC39 / WhatWG groups out there that are doing this at the language & V8 level and we pull from there. It should be straightforward to close those issues.
 * Bert: the roadmap shouldn’t be about locking down the dev process and tightly limiting scope of what’s added.
-* **Agreed that feedback to all contributors (including TC), regarding closing issues: close issues that are instinctively bad and worth closing (close can be undone), anything potentially controversial can be flagged with a “will close” but give ~ 1 week for discussion, disagreement, lobbying etc.**
+* **Agreed that feedback to all contributors (including TC), regarding closing issues: close issues that are instinctively bad and worth closing (close can be undone), anything potentially controversial can be flagged with a “will close” but give \~ 1 week for discussion, disagreement, lobbying etc.**
 
 ### Logos
 

--- a/meetings/io.js/2014-12-30.md
+++ b/meetings/io.js/2014-12-30.md
@@ -46,7 +46,7 @@ Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeti
 
 <https://github.com/nodejs/io.js/pull/206>
 
-* #157 has a long discussion on this: <https://github.com/nodejs/io.js/issues/157>
+* \#157 has a long discussion on this: <https://github.com/nodejs/io.js/issues/157>
 * Chris: +1 on a PR adding this
 * Trevor: it just returns a global, no point
 * Bert: not the way that JS adds new features; discussed the new Intl addition to joyent/node, in favor of making more things requirable rather than adding new globals all the time

--- a/meetings/io.js/2015-01-07.md
+++ b/meetings/io.js/2015-01-07.md
@@ -43,8 +43,8 @@ Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeti
 * isaac: no io.js, vacation
 * mikeal: nada
 * rod: build build build ci ci ci.  re-did all the build slaves on Jenkins, introduced a bunch more.  Ansible scripts for linux machines (CentOS 5,6,7, Ubuntu all LTS + Current 14.10 +32bit versions, 2 ARM v7s one virtual one physical, 2 of each Windows 2012,2008, a couple interim OS X machines more permanent ones coming from Voxer soon).  <https://github.com/nodejs/build> Still lacking specific Jenkins setup and secrets.  Working on release process.
-    mikeal: issue re release?
-    rod: not yet, a lot of little bugs to get CI working consistently.  No grand plan for what’s in release yet.
+  mikeal: issue re release?
+  rod: not yet, a lot of little bugs to get CI working consistently.  No grand plan for what’s in release yet.
 
 ### Review of last meeting
 
@@ -125,26 +125,33 @@ Long discussion:
 Rod rambled on about build & release:
 
 * Lots of minor test failures to take care of and make sure there are no serious blockers: <https://jenkins-iojs.nodesource.com/job/iojs+any-pr+multi/>
+
 * is osx 32-bit necessary? group agreed to leave it out.
+
 * binary naming: Ben currently taking care of renaming, Bert will help out with a solution for windows
+
 * release blobs:
   * source
   * windows 32, 64
   * osx 64-bit, built on 10.10 - specify minimum requirement in XCode (apparently)
   * linux, centos 5, libstdc++ static - Ben says we shouldn't have to, although Rod found it necessary when built with Debian Weezy, give Ben access to CentOS box to try it out
   * linux armv7 (built on Ubuntu 14.04) (perhaps armv6 for rpi, but compile should not hold up a release--drop in later?)
-  * Windows bare files, Bert explained the files currently released in nodejs.org/dist/*/
+  * Windows bare files, Bert explained the files currently released in nodejs.org/dist/\*/
     * node.lib downloaded by node-gyp for compile
     * node.pdb contains debug information (may not be needed, not used by the group, perhaps someone asked for it?), leave it out
     * node.exe is useful where an .msi is a problem to run (no admin access)
     * Rod proposed to move to a .zip for these for 32 and 64, but this may be a problem to get ready for release, discuss further with Bert
+
 * Version number - all agreed to go with 1.0.0, but it should be clearly labeled as an initial “beta”-type release for the project.
+
 * Website for blog/announce/news, Rod proposed Mikeal take responsibility for now until we find a better owner / team, Mikeal agreed.
+
 * Dist folder structure
   * Agreed to keep iojs.org/dist/ to mirror nodejs.org/dist, other things via symlinks and html hyperlinks.
   * Maybe have a iojs.org/downloads/v1/1.0.0/… and perhaps a text/html thing with links to each relevant release
 
 * Bert: Node still merging in 0.10 to 0.12, is there anything that should be merged in 0.10 that we really need?
+
 * intl: Bert kind of hates this patch.  joyent/node is moving towards building with small icu, you get intl object, but only supports english.  CAN build with another icu to add other intls. Bert to open an issue to discuss further. May leave out ICU completely from 1.0.0.
 
 ### Next meeting

--- a/meetings/io.js/2015-01-13.md
+++ b/meetings/io.js/2015-01-13.md
@@ -14,11 +14,11 @@ Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeti
 * governance: Add new Collaborators #234 <https://github.com/nodejs/io.js/issues/234>
 * The state of ES6 on io.js _(re V8 upgrade policy)_ #251 <https://github.com/nodejs/io.js/issues/251>
   Quick recap:
-  * Whether if it is ok to release 1.0.0 with V8 3.31.74 minus ES6 Classes and Object Literals Extensions, considering that the initial version of io.js will be "beta" quality and probably the stable version will coincide with the stable release of V8 3.31 (~6 weeks), which will have these features reinstated.
+  * Whether if it is ok to release 1.0.0 with V8 3.31.74 minus ES6 Classes and Object Literals Extensions, considering that the initial version of io.js will be "beta" quality and probably the stable version will coincide with the stable release of V8 3.31 (\~6 weeks), which will have these features reinstated.
   * How to handle V8 updates with semver so that if the same issue arised with a different timing it could mean a bump to 2.0.0.
   * Community suggestions:
     * Different version naming (e.g. 1.x+v8beta, 1.x+v8dev, 1.x+v8canary)
-    * Avoid BC by moving from tip-of-stable-Chrome-branch to the next tip-of-stable-Chrome-branch (~6 weeks release cycle)
+    * Avoid BC by moving from tip-of-stable-Chrome-branch to the next tip-of-stable-Chrome-branch (\~6 weeks release cycle)
   * How do nightly builds fit into the process.
 * 1.0.0 release checklist <https://github.com/nodejs/io.js/issues/302>
 

--- a/meetings/io.js/2015-01-21.md
+++ b/meetings/io.js/2015-01-21.md
@@ -149,7 +149,7 @@ Part of previous discussion
 
 * Bert:
   * joyent/node has small-icu enabled by default making `Intl` work
-  * can get it working but it makes the binary twice as big (~8M more)
+  * can get it working but it makes the binary twice as big (\~8M more)
 * Domenic: ideally we would track browsers and just include it
 * Ben: V8 adds ICU by default but you need to opt-out, which we do
 * Action: **Invite Steven Loomis to the next TC meeting to discuss further**

--- a/meetings/io.js/2015-01-28.md
+++ b/meetings/io.js/2015-01-28.md
@@ -15,7 +15,7 @@ Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeti
   * doc: add releases document detail release cycle [#630](https://github.com/nodejs/io.js/issues/630) / proposal from @chrisdickinson
 * dgram: implicit binds should be exclusive [#325](https://github.com/nodejs/io.js/issues/325) / minor version bump / @bnoordhuis
 * buffer: implement `iterable` interface [#525](https://github.com/nodejs/io.js/issues/525)  / minor version bump / @bnoordhuis
-* replace util.isType() with typeof [#607](https://github.com/nodejs/io.js/issues/607) / general use of util.is*() in core re perf
+* replace util.isType() with typeof [#607](https://github.com/nodejs/io.js/issues/607) / general use of util.is\*() in core re perf
 * docs: lower the maximum stability level to "stable" [#633](https://github.com/nodejs/io.js/pull/633)
 * maintain our own package registries for io.js related packages [#640](https://github.com/nodejs/io.js/issues/640#issuecomment-71882645)
 * Working Groups PR [#599](https://github.com/nodejs/io.js/pull/599)
@@ -71,14 +71,14 @@ Apologies from:
   * took exit poll to get reactions
   * notes here: <https://gist.github.com/chrisdickinson/80df88b9089c19e0459e>
 * Rod: how do we iterate?
-* Chris: Do it again next week with ~4 more
+* Chris: Do it again next week with \~4 more
 * Discussed timezones and how that works
 
 ### Stabilization and Release Cycles and Process
 
 [#405](https://github.com/nodejs/io.js/issues/405) / further discussion / @iojs/tc
 
-***Also:*** doc: add releases document detail release cycle [#630](https://github.com/nodejs/io.js/issues/630) / proposal from @chrisdickinson
+_**Also:**_ doc: add releases document detail release cycle [#630](https://github.com/nodejs/io.js/issues/630) / proposal from @chrisdickinson
 
 Moved straight to Chris’ proposal:
 
@@ -106,7 +106,7 @@ Moved straight to Chris’ proposal:
 
 ### replace util.isType() with typeof
 
-[#607](https://github.com/nodejs/io.js/issues/607) / general use of util.is*() in core re perf
+[#607](https://github.com/nodejs/io.js/issues/607) / general use of util.is\*() in core re perf
 
 * Bert: find with direct comparisons and checks where it makes sense (undefined, simple stuff)
 * Isaac: hate it all, they are difficult to inline so manually inline--pick one and use it across all

--- a/meetings/io.js/2015-02-04.md
+++ b/meetings/io.js/2015-02-04.md
@@ -47,7 +47,7 @@ Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeti
   * doc: add releases document detail release cycle [#630](https://github.com/nodejs/io.js/issues/630) / proposal from @chrisdickinson
 * dgram: implicit binds should be exclusive [#325](https://github.com/nodejs/io.js/issues/325) / minor version bump / @bnoordhuis
 * buffer: implement `iterable` interface [#525](https://github.com/nodejs/io.js/issues/525)  / minor version bump / @bnoordhuis
-* replace util.isType() with typeof [#607](https://github.com/nodejs/io.js/issues/607) / general use of util.is*() in core re perf
+* replace util.isType() with typeof [#607](https://github.com/nodejs/io.js/issues/607) / general use of util.is\*() in core re perf
 * docs: lower the maximum stability level to "stable" (<https://github.com/nodejs/io.js/pull/633>)
 * maintain our own package registries for io.js related packages (<https://github.com/nodejs/io.js/issues/640#issuecomment-71882645>)
 * Working Groups PR (<https://github.com/nodejs/io.js/pull/599>)
@@ -60,18 +60,29 @@ Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeti
 @vkurchatkin questions:
 
 * the future of assert module;
+
 * relationship between assert and CommonJS Unit Testing spec;
+
 * particular #636 bug;
+
 * what "deep equality" means and how it should deal with prototypes;
+
 * [#639](https://github.com/nodejs/io.js/pull/639) proposal
 
 * Isaac: CommonJS is gone & dead, good ideas have to stand on their own
+
 * Mikeal: assert probably shouldn’t be in core
+
 * Isaac: it’s useful for testing Node itself and useful for runtime asserts
+
 * Rod asked if anyone had any objections to the changes because perhaps Validmir should just be given a blessing to go ahead and improve it.
+
 * Domenic: medium risk, low reward, perhaps slate this for a 2.0 release.
+
 * Lots of discussion about the technical merits
+
 * Ben: the `a.prototype !== b.prototype` is clearly a bug in the initial implementation, it should have been checking `__proto__`
+
 * Rod: new deepStrictEqual() does that check properly
 
 Conclusion: accept both of
@@ -83,7 +94,7 @@ Conclusion: accept both of
 
 1. deepEqual = No prototype checking
 2. deepStrictEqual = proper prototype checking
-Passed without objection
+   Passed without objection
 
 ### Release PGP key strategy and policy / @rvagg
 

--- a/meetings/io.js/2015-02-18.md
+++ b/meetings/io.js/2015-02-18.md
@@ -16,11 +16,11 @@ Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeti
 * lib: fix process.send() sync i/o regression [#774](https://github.com/nodejs/io.js/issues/774) / @bnoordhuis
 * Implement unhandled rejection tracking [#758](https://github.com/nodejs/io.js/issues/758) / @rvagg / how can we help this land
 * Logo / Brand Treatment
-[website/181](https://github.com/nodejs/website/issues/181) @ mikeal
-<https://www.behance.net/gallery/23269525/IOJS-logo-concept>
+  [website/181](https://github.com/nodejs/website/issues/181) @ mikeal
+  <https://www.behance.net/gallery/23269525/IOJS-logo-concept>
 * Stability Policy/Statement & Roadmap
-[#725](https://github.com/nodejs/io.js/issues/725) / @mikeal
-[roadmap/14](https://github.com/nodejs/roadmap/issues/14) / @mikeal
+  [#725](https://github.com/nodejs/io.js/issues/725) / @mikeal
+  [roadmap/14](https://github.com/nodejs/roadmap/issues/14) / @mikeal
 
 ## Minutes
 

--- a/meetings/io.js/2015-03-04.md
+++ b/meetings/io.js/2015-03-04.md
@@ -39,7 +39,7 @@ Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeti
 * Chris: reviewing PRs, onboarding Julian, Christian, Brian, Robert, Ben. Code for core module discovery / use in packages in npm.
 * Domenic: Streams work WHATWG sync with io.js streams ideas.
 * Fedor: fixing bugs, PRs
-* Isaac: coding for fun, node-tap rewrite, global/window alias discussions, node_modules flattening, Windows stuff. Looking in to TLS issues for io.js and 0.12, TLS over Pound causes problems, possibly OpenSSL problem.
+* Isaac: coding for fun, node-tap rewrite, global/window alias discussions, node\_modules flattening, Windows stuff. Looking in to TLS issues for io.js and 0.12, TLS over Pound causes problems, possibly OpenSSL problem.
 * Mikeal: Website and Evangelism WG work, lots of new collabs and work, getting things in sync
 * Rod: Releases, Windows bug / Jenkins drama, ARMv8 support
 * Trevor: Buffer.indexOf(), nextTick perf improvement
@@ -64,7 +64,7 @@ Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeti
 [#774](https://github.com/nodejs/io.js/issues/774) / @bnoordhuis
 
 * Ben: @orangemocha did some work on Windows for libuv, unsure if this helps.
-* Bert: process.send() has been made sync on *nix because otherwise it’s a breaking change, but on Windows it’s always been async so changing it to sync would also be a breaking change. So the situation is crazy.
+* Bert: process.send() has been made sync on \*nix because otherwise it’s a breaking change, but on Windows it’s always been async so changing it to sync would also be a breaking change. So the situation is crazy.
 * Isaac: ideal is that they behave the same and behave well
 * Discussion about whether this would be a breaking change or a bugfix
 * Bikeshed, moving to GitHub
@@ -85,11 +85,11 @@ Domenic: but, doing that operation would be a good thing to do in a major versio
 
 Isaac/Mikeal: yes, but don’t do that for `util._extend`, too many people use it.
 
-Chris: *gives example of how this would have been helpful for a recent refactor*
+Chris: _gives example of how this would have been helpful for a recent refactor_
 
 Ben: how will the test suite test internal functions from then on?
 
-Chris: there would be a flag, e.g. --allow_internal_modules.
+Chris: there would be a flag, e.g. --allow\_internal\_modules.
 
 Mikeal: I like it.
 
@@ -111,7 +111,7 @@ This will get rolled in to the major version issue Chris is putting together.
 
 [#1010](https://github.com/nodejs/io.js/issues/1010) / @piscisaureus
 
-Bert: I’m not sure I believe in this any more; the major reason I wanted this was that building native addons is terrible, but people brought up that the native part of the web socket implementations only do some bitwise buffer stuff and so we could probably just add *those* to core.
+Bert: I’m not sure I believe in this any more; the major reason I wanted this was that building native addons is terrible, but people brought up that the native part of the web socket implementations only do some bitwise buffer stuff and so we could probably just add _those_ to core.
 
 Discussion of how we should probably just add more Buffer methods to core.
 
@@ -149,7 +149,7 @@ We should publicly state that we’re interested in supporting HTTP/2 in the rel
 * Fedor: this feels more like a major version?
 * Domenic: do we consider forcing people to run “npm rebuild” a breaking change?
 * Chris: I think I agree that users should not expect to have to rebuild within the same major version.
-* Mikeal: how often does a V8 ABI change happen *after that V8 gets into stable Chrome*?
+* Mikeal: how often does a V8 ABI change happen _after that V8 gets into stable Chrome_?
 * Domenic: not sure, but would suspect not often at all. Maybe we should check with V8.
 * Ben: yes, not often.
 * Fedor: having a call with V8 might be helpful.

--- a/meetings/io.js/2015-03-18.md
+++ b/meetings/io.js/2015-03-18.md
@@ -52,7 +52,7 @@ Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeti
 
 ### [#1140](https://github.com/nodejs/io.js/pull/1140) Revert stream base / @piscisaureus / merge policy questions
 
-* Bert: in favour of stream_base now and don’t want it reverted given the fixes that have been made. The real problem was the introduction of a major change that lead to a lot of breakage and a lot of fix commits. Proposed that we have a “ng” (or similar) branch with releases for testing before merging.
+* Bert: in favour of stream\_base now and don’t want it reverted given the fixes that have been made. The real problem was the introduction of a major change that lead to a lot of breakage and a lot of fix commits. Proposed that we have a “ng” (or similar) branch with releases for testing before merging.
 * Chris: agree that we need a canary policy of some kind to deal with this
 * Bert: feature flags are a good way of dealing with this and letting them test changes
 * Ben: time-based releases like Rust and Chrome

--- a/meetings/io.js/2015-04-01.md
+++ b/meetings/io.js/2015-04-01.md
@@ -40,7 +40,7 @@ Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeti
 * Fedor: rewrote io.js in Go, deciding whether it should be go.io or io.go
 * Jeremiah: managing issues, reviewing PRs, investigating timers bugs
 * Mikeal: io.js charter / Linux foundation work
-* Trevor: looking into beforeExit/timer unref/uv_loop_alive interactions; Node API compliance working group docs (not io.js ... might be fed into the Foundation)
+* Trevor: looking into beforeExit/timer unref/uv\_loop\_alive interactions; Node API compliance working group docs (not io.js ... might be fed into the Foundation)
 * Rod: released 1.6.3; GitHub DDOS and CI errors/timeouts are frustrating
 
 ### Review of last meeting

--- a/meetings/io.js/2015-04-08.md
+++ b/meetings/io.js/2015-04-08.md
@@ -12,9 +12,9 @@
 Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeting.
 
 * [#1101](https://github.com/nodejs/io.js/pull/1101) http: allow HTTP to return an HTTPS server / @silverwind / the use of a `tls` option to trigger `https` module functionality
-* [#1301](https://github.com/nodejs/io.js/pull/1301) Util(.is*) Deprecations / @Fishrock123 & @brendanashworth / [this comment](https://github.com/nodejs/io.js/pull/1301#issuecomment-90829575) asking for an opinion from the TC on how to move forward
-* Discuss <https://github.com/jasnell/dev-policy> [[comment by @mikeal]](https://github.com/nodejs/io.js/issues/1369#issuecomment-90955688)
-* Discuss / Review the `require(‘.’)` situation [[comments by @silverwind and @Fishrock123]](https://github.com/nodejs/io.js/issues/1369#issuecomment-90933134)
+* [#1301](https://github.com/nodejs/io.js/pull/1301) Util(.is\*) Deprecations / @Fishrock123 & @brendanashworth / [this comment](https://github.com/nodejs/io.js/pull/1301#issuecomment-90829575) asking for an opinion from the TC on how to move forward
+* Discuss <https://github.com/jasnell/dev-policy> [\[comment by @mikeal\]](https://github.com/nodejs/io.js/issues/1369#issuecomment-90955688)
+* Discuss / Review the `require(‘.’)` situation [\[comments by @silverwind and @Fishrock123\]](https://github.com/nodejs/io.js/issues/1369#issuecomment-90933134)
 
 ### Present
 
@@ -50,7 +50,7 @@ Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeti
 
 ### [#1101](https://github.com/nodejs/io.js/pull/1101) http: allow HTTP to return an HTTPS server
 
-***@silverwind / the use of a `tls` option to trigger `https` module functionality***
+_**@silverwind / the use of a `tls` option to trigger `https` module functionality**_
 
 Jeremiah: two options we have (that we’ve discussed) are a tls option, or just auto-detect if you provide appropriate options.
 
@@ -78,9 +78,9 @@ Ben: what happens when iojs is compiled without TLS support?
 
 **Conclusion**: punt on this. Initial feedback is that if we were to go down this route, we would slightly prefer the explicit tls option; however, there needs to be a discussion about the listen() idea, and also about compilation without TLS.
 
-### [#1301](https://github.com/nodejs/io.js/pull/1301) Util(.is*) Deprecations
+### [#1301](https://github.com/nodejs/io.js/pull/1301) Util(.is\*) Deprecations
 
-***@Fishrock123 & @brendanashworth / [this comment](https://github.com/nodejs/io.js/pull/1301#issuecomment-90829575) asking for an opinion from the TC on how to move forward***
+_**@Fishrock123 & @brendanashworth / [this comment](https://github.com/nodejs/io.js/pull/1301#issuecomment-90829575) asking for an opinion from the TC on how to move forward**_
 
 Bert: what’s the point?
 
@@ -162,15 +162,15 @@ Domenic: I don’t think that’s fair. Every change is breaking to someone; eve
 
 Mikeal: it seemed weird…
 
-Domenic: I always thought NODE_PATH was deprecated. Should we warn about people using it?
+Domenic: I always thought NODE\_PATH was deprecated. Should we warn about people using it?
 
-Ben: I understand that someone is already using the new require behavior, so reverting it would be backward-incompatible. So we have a few options: 1) add a hack that makes NODE_PATH interactions with require('.') work as they used to; 2) say “sorry” and keep as-is
+Ben: I understand that someone is already using the new require behavior, so reverting it would be backward-incompatible. So we have a few options: 1) add a hack that makes NODE\_PATH interactions with require('.') work as they used to; 2) say “sorry” and keep as-is
 
 Bert: I’m sympathetic to adding the hack and a warning.
 
-Domenic: agree. And maybe try to kill NODE_PATH in 3.x.
+Domenic: agree. And maybe try to kill NODE\_PATH in 3.x.
 
-**Conclusion: hack plus a warning that shows up in this hacky case (“hey, you’re using the require-dot trick with NODE_PATH; we made it work because we’re nice people, but we want to take it away in 2.x, so gear up”). In 2.x, probably warn on any use of NODE_PATH at all.**
+**Conclusion: hack plus a warning that shows up in this hacky case (“hey, you’re using the require-dot trick with NODE\_PATH; we made it work because we’re nice people, but we want to take it away in 2.x, so gear up”). In 2.x, probably warn on any use of NODE\_PATH at all.**
 
 ### Bert shows off his CI prototype
 

--- a/meetings/io.js/2015-04-15.md
+++ b/meetings/io.js/2015-04-15.md
@@ -29,7 +29,7 @@ Extracted from <https://github.com/nodejs/io.js/labels/tc-agenda> prior to meeti
 ### Review of last meeting
 
 * [#1101](https://github.com/nodejs/io.js/pull/1101) http: allow HTTP to return an HTTPS server
-* [#1301](https://github.com/nodejs/io.js/pull/1301) Util(.is*) Deprecations
+* [#1301](https://github.com/nodejs/io.js/pull/1301) Util(.is\*) Deprecations
 * [Dev Policy](https://github.com/jasnell/dev-policy)
 * Isaac
 * [#1365](https://github.com/nodejs/io.js/issues/1356) `require('.')`

--- a/meetings/io.js/2015-04-22.md
+++ b/meetings/io.js/2015-04-22.md
@@ -102,7 +102,7 @@ Ben: process.send() ready but not merged, any objections? - no objections.
 
 Chris: <https://github.com/nodejs/io.js/milestones/2.0.0> new label “land-on-master” to indicate PRs that are still targeting the v1.x branch.
 
-Ben & Bert discussed Ben’s possible timers rewrite - Ben implemented a heap and red-black tree in JS, turned out to be a bit faster but not complete yet and Ben has been distracted on other projects. **
+Ben & Bert discussed Ben’s possible timers rewrite - Ben implemented a heap and red-black tree in JS, turned out to be a bit faster but not complete yet and Ben has been distracted on other projects. \*\*
 
 ### [#1413](https://github.com/nodejs/io.js/issues/1413) Combined node.js/io.js TC/Core Call
 

--- a/meetings/io.js/2015-05-13.md
+++ b/meetings/io.js/2015-05-13.md
@@ -12,7 +12,7 @@
 Extracted from <https://github.com/iojs/io.js/labels/tc-agenda> prior to meeting.
 
 * V8 4.4 to remove indexed properties via external data [#1451](https://github.com/iojs/io.js/issues/1451)
-* NODE_PATH deprecation [#1627](https://github.com/iojs/io.js/issues/1627)
+* NODE\_PATH deprecation [#1627](https://github.com/iojs/io.js/issues/1627)
 * Join the Node Foundation? [#1664](https://github.com/iojs/io.js/issues/1664)
 * Put `*Sync` methods behind a flag in some future major version [#1665](https://github.com/iojs/io.js/issues/1665)
 * TC Nominations
@@ -63,12 +63,12 @@ Extracted from <https://github.com/iojs/io.js/labels/tc-agenda> prior to meeting
 * ‘smalloc’ has to go away when we land this V8, thankfully it’s not been around for long but this is a forced deprecation & removal.
 * currently usage of ‘smalloc’ gives a deprecation warning, as of v2.0.0
 * @jeisinger has been backporting some APIs needed for Buffer, NAN will have to catch up but @kkoopa is involved
-* Domenic: V8 4.3 will be next week, 7 weeks from now will be 4.4 (~1 week behind Chrome release)
+* Domenic: V8 4.3 will be next week, 7 weeks from now will be 4.4 (\~1 week behind Chrome release)
 * Trevor: no major problems with JS API, most problems will be in the C++ API, should be able to shim to ease it
 
-### NODE_PATH deprecation [#1627](https://github.com/iojs/io.js/issues/1627)
+### NODE\_PATH deprecation [#1627](https://github.com/iojs/io.js/issues/1627)
 
-* Jeremiah: there was a suggestion to deprecate NODE_PATH entirely, debate is over deprecation or not, lots of people appear to be finding novel uses of it.
+* Jeremiah: there was a suggestion to deprecate NODE\_PATH entirely, debate is over deprecation or not, lots of people appear to be finding novel uses of it.
 * Domenic: maybe we should document it
 * Chris: it is documented, Googling shows that it’s been ingrained into the Node background, there’s lots of info out there about how it’s used
 * Domenic: <https://iojs.org/api/modules.html#modules_loading_from_the_global_folders>
@@ -112,10 +112,13 @@ Action: Mikeal to make the move happen in a coordinated way so we get redirects 
 ### TC Nominations
 
 * Shigeki Ohtsu @shigeki [#1501](https://github.com/iojs/io.js/issues/1501)
+
 * Brian White @mscdex [#1500](https://github.com/iojs/io.js/issues/1500)
+
 * @mikeal [#1481](https://github.com/iojs/io.js/issues/1481)
 
 * Mikeal: joining
+
 * Rod: timing is awkward with convergence but I’d like to make sure that Shigeki and Brian have a path to join the TC and not have that delayed too much
 
 ### Public QA via #io.js channel on Freenode

--- a/meetings/node.js/2014-12-10.md
+++ b/meetings/node.js/2014-12-10.md
@@ -34,10 +34,10 @@ expressed:
 * It is not clear what impact it would have on binary modules.
 
 * Users would need to upgrade their toolchain, as V8 moved to C++11. It's not a
-problem for individual developers, as they can upgrade easily most of the
-time. However, it could be a problem for distributions (an example is CentOS),
-and people who followed the 0.11.x branch for a long time and don't expect
-such a change.
+  problem for individual developers, as they can upgrade easily most of the
+  time. However, it could be a problem for distributions (an example is CentOS),
+  and people who followed the 0.11.x branch for a long time and don't expect
+  such a change.
 
 Moreover, everyone agreed that performing this upgrade that late in the
 development process and so close to a new stable relase is risky.

--- a/meetings/node.js/2014-12-16.md
+++ b/meetings/node.js/2014-12-16.md
@@ -19,7 +19,7 @@ today (12/16/2014) or tomorrow (12/17/2014).
 ### 0.10.35
 
 It is still not clear if and when a 0.10.35 version will be released, but
-Chris Dickinson already identified \[one of his pull-requests\](TODO: Chris,
+Chris Dickinson already identified \[one of his pull-requests]\(TODO: Chris,
 could you please provide the link to your PR about improving buffers'
 performance?) as a good candidate for inclusion in this release.
 

--- a/meetings/node.js/2014-12-18.md
+++ b/meetings/node.js/2014-12-18.md
@@ -46,14 +46,14 @@ The participants also agreed to implement this at the C++ layer.
 The 0.10.34 version released on 12/17/2014 has three different issues:
 
 * SSL/TLS connections to some servers, including amazon servers throw an
-exception because of an untrusted certificate. Participants agreed to fix this
-issue by putting 1024 bits length certificates back in the trusted
-certificates store.
+  exception because of an untrusted certificate. Participants agreed to fix this
+  issue by putting 1024 bits length certificates back in the trusted
+  certificates store.
 
 * A minor timer issue due to a typo in a fix for a memory leak.
 
 * A less minor timer issue due to a bug in the refactoring of `_unrefActive`
-done to improve performance.
+  done to improve performance.
 
 ## Discussions around tools for developers of Node
 

--- a/meetings/node.js/2015-01-15.md
+++ b/meetings/node.js/2015-01-15.md
@@ -16,7 +16,7 @@ The only topic that was discussed during this meeting was the Node.js website.
 
 Robert suggested adding HTTPS access for Node.js' website. TJ mentioned that
 there is already a HTTPS endpoint on the website, but that clients (browsers,
-etc.) are not *redirected* by default from http to https, because doing so was
+etc.) are not _redirected_ by default from http to https, because doing so was
 breaking a lot of people (e.g nvm).
 
 Proposed solution by TJ: redirect everything by default to https except

--- a/meetings/node.js/2015-02-09.md
+++ b/meetings/node.js/2015-02-09.md
@@ -95,7 +95,7 @@ Trevor: You can't transition all asynchronous APIs to promises (e.g event
 emitters)
 
 Trevor: 1st priority should be to refactor some core layers to use lower level
-APIs to improve performance (e.g http should use tcp_wrap instead of
+APIs to improve performance (e.g http should use tcp\_wrap instead of
 lib/net.js).
 
 Trevor: Before supporting promises at the core layer, we'd have to do some
@@ -164,7 +164,7 @@ comparison with nginx and cluster seems to be 3x slower. Could need a rewrite.
 Jacob: Lots of users who directly use cluster module, sometimes by just
 copy/pasting code from the doc. I would say cluster is used widely.
 
-TJ: Preference would have been to improve child_process and have userland
+TJ: Preference would have been to improve child\_process and have userland
 modules implement clustering features.
 
 ## James Snell: Crypto improvements
@@ -194,7 +194,7 @@ versions of node, could help both users and the core team to investigate bugs.
 
 TJ: I believe IBM has another toolchain that they use.
 
-## Erik Toth: What's the plan with async_wrap?
+## Erik Toth: What's the plan with async\_wrap?
 
 Dan Shaw: Gathering input from potential users currently.
 

--- a/meetings/node.js/2015-02-19.md
+++ b/meetings/node.js/2015-02-19.md
@@ -24,15 +24,15 @@
 * Robert Kowalski
   * Progress:
     * I fixed the bad merge for <https://github.com/joyent/node-documentation>-
-    generator and will continue to work on it, next items are .markdown
-    support and sending a PR to node and node-website to make use of the
-    module.
+      generator and will continue to work on it, next items are .markdown
+      support and sending a PR to node and node-website to make use of the
+      module.
 
     * It is [not possible any more to accidentally deploy an outdated version of the website](https://github.com/joyent/node-website/commit/dc1ab6f2037a9005d7fc44e73001bf9067e25d5b).
 
   * Blocked by:
     * I'm still waiting for a fixed SSl Cert for <https://blog.nodejs.org/> to
-    continue with <https://github.com/joyent/node-website/issues/68>.
+      continue with <https://github.com/joyent/node-website/issues/68>.
 
 ## Current state of v0.12.0
 
@@ -43,7 +43,7 @@ released. I believe Trevor is working on most of them right now.
 
 Trevor: Yes, I'm currently investigating.
 
-#### V8 max_old_space issue
+#### V8 max\_old\_space issue
 
 See <https://github.com/joyent/node/pull/9200#issuecomment-75001656>.
 
@@ -95,7 +95,7 @@ See <https://github.com/joyent/node/issues/4356>.
 Alexis: issue with installer on Windows. Julien: fixed in io.js. Alexis: I
 will take care of this.
 
-### TCP_NODELAY issue
+### TCP\_NODELAY issue
 
 See <https://github.com/joyent/node/issues/9235>.
 

--- a/meetings/node.js/2015-02-26.md
+++ b/meetings/node.js/2015-02-26.md
@@ -37,7 +37,7 @@ Expecting pull request in next week or so.
 James looking at 2 aspects:
 
 * Internationalize Node itself, going to start on this next week.  Will use ICU
-if present, if not still need to figure out what the fallback will be.
+  if present, if not still need to figure out what the fallback will be.
 * Resource bundle loading.
 
 ### Next Releases
@@ -45,19 +45,19 @@ if present, if not still need to figure out what the fallback will be.
 #### 0.10.X
 
 * In maintenance mode, new releases generally to  address security or larger
-performance issues.
+  performance issues.
 * 0.10.37 to go out this week, early next.  Main update is newer version of
-libuv.
+  libuv.
 * TJ asked Michael to look to do some pre-validation on AIX.
 
 #### 0.12.X
 
 * Some failing tests in 0.12 head now.
 * Working to get jenkins job in place that can be run before integrating
-changes.
+  changes.
 * Seeing some memory issues, some because node generates more garbage some
-because V8 gc is less aggressive. TJ still investigating some others which
-look to be real issues.
+  because V8 gc is less aggressive. TJ still investigating some others which
+  look to be real issues.
 
 #### 0.12.1 release
 

--- a/meetings/node.js/2015-03-05.md
+++ b/meetings/node.js/2015-03-05.md
@@ -38,36 +38,36 @@ provide feedback to the external teams.
 #### 0.10.37
 
 * Upgrade to libuv 0.10.36 in progress, code review planned for today, should
-land soon.
+  land soon.
 
 * 0.10.37 will possibly go out next week.
 
 * Priority issues for 0.10.37 - issue #9092 and reverting change to url that
-caused a regression.
+  caused a regression.
 
 #### 0.12.1 release
 
 Key priority issues:
 
 * libuv upgrade to 1.4.0, down to 1 test failing on OSX, ok on windows side now,
-Julien working on this.
+  Julien working on this.
 
 * V8 lateral upgrade, Trevor still working on identifying goood V8 level (issue
-9185).
+  9185\).
 
 * Issue #8540, #9204 discussing whether to pull fix from io.js or one developed in
-Node.js based on which is better.
+  Node.js based on which is better.
 
 * Issue #9245, Trevor working on this, 2 ways to make callback and depending on
-which one is called can lead to subtle bugs.
+  which one is called can lead to subtle bugs.
 
 * Issue #9339 - to be reviewed and committed
 
 * Issue #9317 - fix available in io.js other core team members to review to see
-if it can be pulled in.
+  if it can be pulled in.
 
 * Issue #9235 - ensuring NODELAY is on for all platforms.  Michael would like it
-on for AIX Julien/Alexis to review in context of Windows and other platforms.
+  on for AIX Julien/Alexis to review in context of Windows and other platforms.
 
 * Issue #9334 - tests fail when run in deep directory paths.  Julien and other
-core team members to review and comment.
+  core team members to review and comment.

--- a/meetings/node.js/2015-03-12.md
+++ b/meetings/node.js/2015-03-12.md
@@ -109,7 +109,7 @@ TJ: libuv uses monotonic time for all its operations. In node, the last
 remaining place where we were using wall clock has been fixed in 0.10.30 or
 0.10.31.
 
-Trevor: libuv uses epoll_wait, does it use monotonic/hrtime on all
+Trevor: libuv uses epoll\_wait, does it use monotonic/hrtime on all
 systems?
 
 TJ: Generally yes.

--- a/meetings/node.js/2015-04-09.md
+++ b/meetings/node.js/2015-04-09.md
@@ -47,7 +47,7 @@ Potential Security Issue:
 
 * Julien will send an email to security@ with a description for a discussion.
 * Validate the concerns of this issue and determine if it should be included
-with the RC4 fix.
+  with the RC4 fix.
 
 IBM runs a lot of tests on multiple platforms for their releases, and the RC4
 fixes for v0.10 have been internally validated.

--- a/meetings/node.js/2015-04-16.md
+++ b/meetings/node.js/2015-04-16.md
@@ -56,7 +56,7 @@ JGI: Need to get the main scenarios, come up with use cases first.
 MD: This is a tempoary fix, most people (hopefully) are using defaults.
 
 TJ: This setting is used more in minor versions, when people are
-bringing up \[some version of an\] app.
+bringing up \[some version of an] app.
 
 #### Wrong checksum for node v0.12.2
 
@@ -89,7 +89,7 @@ JGI: Need to document openssl upgrades:
 
 * Upgrades can be confusing
 * Often these upgrades are done in 'less than ideal' situations
-(pressure to fix a critical issue).
+  (pressure to fix a critical issue).
 
 #### Documenting how to upgrade v8
 
@@ -116,7 +116,7 @@ TJ: - hard but necessary -- there's a lot of work to do around merging
 two projects:
 
 * Need to work together to maintain stable release (LTS/platform etc)
-has to be comfortable integrating into the entire project.
+  has to be comfortable integrating into the entire project.
 * Innovation + ideals of LTS working group.  Required amount of tension.
 * Hopefully good agendas.
 

--- a/meetings/node.js/2015-04-30.md
+++ b/meetings/node.js/2015-04-30.md
@@ -72,9 +72,9 @@ James: Initial convergance plan: <https://github.com/jasnell/dev-policy/pull/66>
 James: nothing set in stone. Current plan:
 
 * io.js organization transferred to nodejs organization. Will keep everything
-they've already setup.
+  they've already setup.
 * joyent/node and other joyent/node-related repos will also be transferred to
-this organization.
+  this organization.
 * Both joyent/node and iojs/iojs repos would be under the foundation.
 * For the converged repo, a fork of iojs repo would be created.
 * New repo would be the next major release.

--- a/meetings/node.js/2015-05-21.md
+++ b/meetings/node.js/2015-05-21.md
@@ -39,10 +39,10 @@ After discussion we agreed that we need to provide more information so that peop
 a better idea of what will be changing and the impact.  More specifically:
 
 * gather list of breaking changes that will be in converged repo so that we can document
-and better communicate what will be different
+  and better communicate what will be different
 
 * reach out broadly to users to gather input on what their specific concerns might be
-in terms of an LTS release, including timing, content etc.
+  in terms of an LTS release, including timing, content etc.
 
 Overall we want to figure out what the right answer is and be open to that alternative.
 


### PR DESCRIPTION
Use remark-preset-lint-node@3.2.0 to format all markdown docs via `npx
remark . -o` after updating remark-preset-lint-node.