### PR TITLE
Adjust charter to simplify automated removal rules

### DIFF
--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -62,7 +62,8 @@ through accessible public postings.
 
 TSC members are expected to regularly participate in TSC activities.
 
-A TSC member is automatically removed from the TSC if, during a 3-month period, all of the following are true:
+A TSC member is automatically removed from the TSC if, during a 3-month period,
+all of the following are true:
 
 * They attend fewer than 25% of the regularly scheduled meetings.
 * They do not participate in any TSC votes.
@@ -82,7 +83,7 @@ including:
 * Maintaining the list of additional Collaborators.
 * Development process and any coding standards.
 * Mediating technical conflicts between Collaborators or Foundation
-projects.
+  projects.
 
 The TSC will define Node.js project’s release vehicles.
 
@@ -170,14 +171,14 @@ looking to participate in the development effort.
 ## Section 9. Definitions
 
 * **Contributors**: contribute code or other artifacts, but do not have
-the right to commit to the code base. Contributors work with the
-project’s Collaborators to have code committed to the code base. A
-Contributor may be promoted to a Collaborator by the TSC. Contributors should
-rarely be encumbered by the TSC and never by the CPC or OpenJS Foundation Board.
+  the right to commit to the code base. Contributors work with the
+  project’s Collaborators to have code committed to the code base. A
+  Contributor may be promoted to a Collaborator by the TSC. Contributors should
+  rarely be encumbered by the TSC and never by the CPC or OpenJS Foundation Board.
 
 * **Project**: a technical collaboration effort, e.g. a subsystem, that
-is organized through the project creation process and approved by the
-TSC.
+  is organized through the project creation process and approved by the
+  TSC.
 
 [Condorcet]: https://en.wikipedia.org/wiki/Condorcet_method
 [Consensus Seeking]: https://en.wikipedia.org/wiki/Consensus-seeking_decision-making


### PR DESCRIPTION
This is a charter change, so it would require CPC approval.

The reason for this change is that the current automatic removal rules are unworkable. We currently have (I believe) 5 TSC members who do not meet the 25% meeting attendance requirement. Of those 5, at least one has participated in a vote, leaving us with 4 TSC members who may be eligible for supposedly-automatic removal. However, "does not participate in TSC discussions" is impossible to automate or even be certain about. I suspect that with that criteria, only 1 of the TSC members is eligible for automatic removal. But even that, I can't be sure. And it's awkward to bring it up. That's why it's supposed to be automatic! Because we're so bad at this!

So, I propose two changes to make this a possible-to-automate process similar to the automated Collaborator-removal process we have now in the main repo.

1. Eliminate the impossible-to-automate "participate in TSC discussions" loophole. That's what this change does.
2. Start keeping track of votes in documents that are kept in this repository, similar to the way we have meeting attendees documented in the meeting minutes. There are possible variations on this, but the point is that there is one source of truth about who did and did not participate in votes.

Once those two changes are done, we can look at automating the process so that it is actually automatic in reality, and not merely on paper.

@nodejs/tsc 