### PR TITLE
add initial vote data

### DIFF
--- a/votes/2021-09-29-0.json
+++ b/votes/2021-09-29-0.json
@@ -1,0 +1,18 @@
+{
+  "description": "Moving an inactive collaborator to emeritus",
+  "refs": ["https://github.com/nodejs/node/pull/40115#issuecomment-930656531"],
+  "votes": {
+    "Trott": 1,
+    "ronag": 1,
+    "mcollina": 1,
+    "apapirovski": 1,
+    "aduh95": 1,
+    "cjihrig": 1,
+    "targos": 1,
+    "BridgeAR": 1,
+    "fhinkel": 1,
+    "jasnell": 1,
+    "mhdawson": 1,
+    "gireeshpunathil": 0
+  }
+}

--- a/votes/2021-10-19-0.json
+++ b/votes/2021-10-19-0.json
@@ -1,0 +1,22 @@
+{
+  "description": "Nominating Richard Lau",
+  "refs": ["https://github.com/nodejs/TSC/issues/1096"],
+  "votes": {
+    "Trott": 1,
+    "ChALkeR": 1,
+    "tniessen": 1,
+    "MylesBorins": 1,
+    "mhdawson": 1,
+    "cjihrig": 1,
+    "BethGriggs": 1,
+    "aduh95": 1,
+    "ronag": 1,
+    "mcollina": 1,
+    "targos": 1,
+    "gireeshpunathil": 1,
+    "apapirovski": 1,
+    "joyeecheung": 1,
+    "BridgeAR": 1,
+    "mmarchini": 1
+  }
+}

--- a/votes/README.md
+++ b/votes/README.md
@@ -1,0 +1,13 @@
+This directory contains JSON files recording the votes (including abstentions)
+of TSC members. This is used by automation to determine when TSC members are
+inactive, per the TSC charter.
+
+The format of the file names is `YYYY-MM-DD-N.json` where N is an integer. It
+will usually be `0` but will need to be incremented if there is more than one
+vote on a given day. (The day itself is imprecise anyway as a vote can take many
+days to be completed and the day will be different depending on the time zone
+being used to determine it.)
+
+The votes are represented as `1` for a vote in favor, `0` for an abstention, and
+`-1` for a vote against. Abstentions must be explicit. People who did not
+participate in the vote are not listed in the JSON file.


### PR DESCRIPTION
This is a final step before being able to automate the identification of
inactive TSC members per the charter.