### PR TITLE
chore: fix mistranslation in WORKING_GROUPS.md

### DIFF
--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -337,7 +337,7 @@ Each language community maintains its own membership.
 * [nodejs-it - Italian (Italiano)](https://github.com/nodejs/nodejs-it)
 * [nodejs-ja - Japanese (日本語)](https://github.com/nodejs/nodejs-ja)
 * [nodejs-ka - Georgian (ქართული)](https://github.com/nodejs/nodejs-ka)
-* [nodejs-ko - Korean (조선말)](https://github.com/nodejs/nodejs-ko)
+* [nodejs-ko - Korean (한국어)](https://github.com/nodejs/nodejs-ko)
 * [nodejs-mk - Macedonian (Mакедонски)](https://github.com/nodejs/nodejs-mk)
 * [nodejs-ms - Malay (بهاس ملايو)](https://github.com/nodejs/nodejs-ms)
 * [nodejs-nl - Dutch (Nederlands)](https://github.com/nodejs/nodejs-nl)


### PR DESCRIPTION
There is a mistranslation about 'Korean' in WORKING_GROUPS.md.

[nodejs-ko](https://github.com/nodejs/nodejs-ko) is the community in Republic of Korea,
but 조선말 means North Korean. It's a different country.

For reference, 'Korean' had been translated as [한국어](https://github.com/nodejs/nodejs.org/blob/88f8ca74c67b439aca43b456162694028622bd35/locale/en/about/working-groups.md?plain=1#L147) in [nodejs.org](https://github.com/nodejs/nodejs.org).

- [Related issue in nodejs.org](https://github.com/nodejs/nodejs-ko/issues/344)
- [Related commit in nodejs.org](https://github.com/nodejs/nodejs.org/commit/bede521bde283fadea94b291b74ffb0d8dac3435)