### PR TITLE
doc: fix core repo `doc/guides` links

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ To request access, [open an issue](https://github.com/nodejs/TSC/issues/new).
 
 ## Strategic initiatives
 
-* [Strategic initiatives](https://github.com/nodejs/node/blob/HEAD/doc/guides/strategic-initiatives.md)
+* [Strategic initiatives](https://github.com/nodejs/node/blob/HEAD/doc/contributing/strategic-initiatives.md)
 
 ## Working Groups
 

--- a/Security-Team.md
+++ b/Security-Team.md
@@ -126,7 +126,7 @@ The expected workflow for issues reported to Node.js is:
    * Once a PR (typically in nodejs-private) is ready for release, add a comment
      indicating when the release is expected.
    * The security release steward will follow the
-     [security release process](https://github.com/nodejs/node/blob/master/doc/guides/security-release-process.md).
+     [security release process](https://github.com/nodejs/node/blob/HEAD/doc/contributing/security-release-process.md).
 3. `RESOLVED`: State for an issue that has had a fix published. Issues in this
    state should be disclosed. The security steward sets this state.
 4. Final states for issues that we will not fix:

--- a/Strategic-Initiatives.md
+++ b/Strategic-Initiatives.md
@@ -1,1 +1,1 @@
-This document has been moved to <https://github.com/nodejs/node/blob/HEAD/doc/guides/strategic-initiatives.md>.
+This document has been moved to <https://github.com/nodejs/node/blob/HEAD/doc/contributing/strategic-initiatives.md>.


### PR DESCRIPTION
`doc/guides` was moved to `doc/contributing` in
https://github.com/nodejs/node/pull/41408.

Signed-off-by: Darshan Sen <raisinten@gmail.com>