### PR TITLE
fix: add missing header in minutes doc

### DIFF
--- a/meetings/2022-10-19.md
+++ b/meetings/2022-10-19.md
@@ -21,6 +21,8 @@
 * Tobias Nießen @tniessen (TSC)
 * Rich Trott @Trott (TSC)
 
+## Agenda
+
 ### Announcements
 
 * New Releases


### PR DESCRIPTION
Our tooling depends on this header so we should land this quickly before the find-inactive-folks job runs and wrongly flags James again. The heading structure of the minutes is wrong without it anyway. Announcements should not be a sub-header of Present.