### PR TITLE
charter: remove meeting attendance requirement

### DIFF
--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -65,7 +65,6 @@ TSC members are expected to regularly participate in TSC activities.
 A TSC member is automatically removed from the TSC if, during a 3-month period,
 all of the following are true:
 
-* They attend fewer than 25% of the regularly scheduled meetings.
 * They do not participate in any TSC votes.
 
 ## Section 4. Responsibilities of the TSC


### PR DESCRIPTION
This commit removes the requirement for TSC meeting attendance. After this change, there is currently only one item in the list of TSC member requirements. I decided to leave the list in place under the assumption that other list items may be added in the future.

Fixes: https://github.com/nodejs/TSC/issues/1338