### PR TITLE
Update charter to address membership challenges

### DIFF
--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -17,60 +17,47 @@ In the case of the Node.js project, it is delegated to the Node.js
 Technical Steering Committee (“TSC”). OpenJS Foundation’s business
 leadership is the Board of Directors (the “Board”).
 
-This Technical Steering Committee Charter reflects a carefully
-constructed balanced role for the TSC and the CPC in the governance of
-the OpenJS Foundation. The charter amendment process is for the TSC to
-propose changes using simple majority of the full TSC, the proposed
-changes being subject to review and approval by the CPC. The CPC may
-additionally make amendments to the TSC charter at any time, though the
-CPC will not interfere with day-to-day discussions, votes or meetings
-of the TSC.
+The charter amendment process is for the voting members of the TSC to propose
+for review and approval by the CPC. The CPC may additionally make amendments to
+the TSC charter at any time, though the CPC will not interfere with day-to-day
+discussions, votes or meetings of the TSC.
 
 ## Section 3. Establishment of the TSC
 
 TSC memberships are not time-limited. There is no maximum size of the TSC.
-The size is expected to vary in order to ensure adequate coverage of important
-areas of expertise, balanced with the ability to make decisions efficiently.
-The TSC must have at least four members.
+The TSC must have at least four voting members.
 
 There is no specific set of requirements or qualifications for TSC
-membership beyond these rules. The TSC may add additional members to the
+membership beyond these rules. The TSC may add additional voting members to the
 TSC by a standard TSC motion. A TSC member may be removed from the
-TSC by voluntary resignation, by a standard TSC motion, or in accordance to the
-participation rules described below.
+TSC by voluntary resignation or by a standard TSC motion.
 
-Changes to TSC membership should be posted in the agenda, and may be suggested
-as any other agenda item.
-
-No more than one-fourth of the TSC members may be affiliated with the
-same employer. If removal or resignation of a TSC member, or a change of
-employment by a TSC member, creates a situation where more than
-one-fourth of the TSC membership shares an employer, then the situation
+No more than one-fourth of the TSC voting members may be affiliated with the
+same employer. If removal or resignation of a TSC voting member, or a change of
+employment by a TSC voting member, creates a situation where more than
+one-fourth of the TSC voting membership shares an employer, then the situation
 must be immediately remedied by the resignation or removal of one or more
-TSC members affiliated with the over-represented employer(s).
-
-The TSC may, at its discretion, invite any number of non-voting observers to
-participate in the public portion of TSC discussions and meetings.
+TSC voting members affiliated with the over-represented employer(s).
 
 The TSC shall meet regularly using tools that enable participation by the
 community (e.g. weekly on a Google Hangout On Air, or through any other
 appropriate means selected by the TSC). The meeting shall be directed by
 the TSC Chairperson. Responsibility for directing individual meetings may be
-delegated by the TSC Chairperson to any other TSC member. Minutes or an
+delegated by the TSC Chairperson to any other TSC voting member. Minutes or an
 appropriate recording shall be taken and made available to the community
 through accessible public postings.
 
-TSC members are expected to regularly participate in TSC activities.
+TSC voting members are expected to regularly participate in TSC activities.
 
-A TSC member is automatically removed from the TSC if, during a 3-month period,
-all of the following are true:
+A TSC voting member is automatically converted to a TSC regular member if,
+during a 3-month period, all of the following are true:
 
 * They attend fewer than 25% of the regularly scheduled meetings.
-* They do not participate in any TSC votes.
+* They do not participate in three consecutive TSC votes.
 
 ## Section 4. Responsibilities of the TSC
 
-Subject to such policies as may be set by the CPC, the TSC is
+Subject to such policies as may be set by the CPC, the TSC voting members are
 responsible for all technical development within the Node.js project,
 including:
 
@@ -85,20 +72,20 @@ including:
 * Mediating technical conflicts between Collaborators or Foundation
   projects.
 
-The TSC will define Node.js project’s release vehicles.
+The TSC voting members will define Node.js project’s release vehicles.
 
 ## Section 5. Node.js Project Operations
 
-The TSC will establish and maintain a development process for the Node.js
-project. The development process will establish guidelines
+The TSC voting members will establish and maintain a development process for the
+Node.js project. The development process will establish guidelines
 for how the developers and community will operate. It will, for example,
 establish appropriate timelines for TSC review (e.g. agenda items must be
 published at least a certain number of hours in advance of a TSC
 meeting).
 
 The TSC and entire technical community will follow any processes as may
-be specified by the OpenJS Foundation Board relating to the intake and license compliance
-review of contributions, including the OpenJS Foundation IP Policy.
+be specified by the OpenJS Foundation Board relating to the intake and license
+compliance review of contributions, including the OpenJS Foundation IP Policy.
 
 ## Section 6. Elections
 
@@ -117,8 +104,8 @@ election is required if there is only one candidate and no objections to
 the candidate's election. Elections shall be done within the projects by
 the Collaborators active in the project.
 
-The TSC will elect from amongst voting TSC members a TSC Chairperson to
-work on building an agenda for TSC meetings and a OpenJS
+The TSC voting members will elect from amongst voting TSC members a TSC
+Chairperson to work on building an agenda for TSC meetings and a OpenJS
 Cross Project Council (CPC) voting member to represent the TSC in
 the OpenJS Foundation for a term of one year. The Chair and voting CPC
 member may be (but are not required to be) the same person.
@@ -129,41 +116,37 @@ of terms a TSC Chairperson or voting CPC member may serve.
 ## Section 7. Voting
 
 For internal project decisions, Collaborators shall operate under Lazy
-Consensus. The TSC shall establish appropriate guidelines for
+Consensus. The TSC voting members shall establish appropriate guidelines for
 implementing Lazy Consensus (e.g. expected notification and review time
 periods) within the development process.
 
-The TSC follows a [Consensus Seeking][] decision making model. When an agenda
-item has appeared to reach a consensus the moderator will ask "Does anyone
-object?" as a final call for dissent from the consensus.
+The TSC voting members follow a [Consensus Seeking][] decision making model.
+When an agenda item has appeared to reach a consensus the moderator will ask
+"Does anyone object?" as a final call for dissent from the consensus.
 
-If an agenda item cannot reach a consensus a TSC member can call for
-either a closing vote or a vote to table the issue to the next meeting.
-The call for a vote must be seconded by a majority of the TSC or else the
-discussion will continue.
-
-For all votes, a simple majority of all TSC members for, or against, the issue
-wins. A TSC member may choose to participate in any vote through abstention.
+For all votes, a simple majority of all TSC voting members for, or against, the
+issue wins. A TSC voting member may choose to participate in any vote through
+abstention.
 
 All changes to this charter must be approved by the CPC.
 
 ## Section 8. Project Roles
 
 The Node.js git repository is maintained by the TSC and
-additional Collaborators who are added by the TSC on an ongoing basis.
+additional Collaborators who are added by the TSC voting members on an ongoing
+basis.
 
-Individuals making significant and valuable contributions,
-“Contributor(s)”, are made Collaborators and given commit-access to the
-project. These individuals are identified by the TSC and their addition
-as Collaborators is discussed during a TSC meeting. Modifications of the
-contents of the git repository are made on a collaborative basis as defined in
-the development process.
+Individuals making significant and valuable contributions are made Collaborators
+and given commit-access to the project. These individuals are identified by the
+TSC and their addition as Collaborators is discussed during a TSC meeting.
+Modifications of the contents of the git repository are made on a collaborative
+basis as defined in the development process.
 
 Collaborators may opt to elevate significant or controversial
 modifications, or modifications that have not found consensus to the TSC
 for discussion by assigning the `tsc-agenda` tag to a pull request or
-issue. The TSC should serve as the final arbiter where required. The TSC
-will maintain and publish a list of current Collaborators, as
+issue. The TSC voting members should serve as the final arbiter where required.
+The TSC will maintain and publish a list of current Collaborators, as
 well as a development process guide for Collaborators and Contributors
 looking to participate in the development effort.
 


### PR DESCRIPTION
Change "TSC Member" to "TSC Voting Member", and change "TSC Emeritus Member" to "TSC Member". This lets the TSC somewhat mirror the CPC, where only about 1/3 of the members actually vote (and most of the other members aren't in fact active, but it doesn't adversely affect the CPC).