### PR TITLE
add minutes for March 22 2023 meeting

### DIFF
--- a/meetings/2023-03-22.md
+++ b/meetings/2023-03-22.md
@@ -2,9 +2,9 @@
 
 ## Links
 
-* **Recording**:  
-* **GitHub Issue**: https://github.com/nodejs/TSC/issues/1357
-* **Minutes Google Doc**: https://docs.google.com/document/d/1GHFR458LYzZmsZecjOjd570Dep3abO6isyB1OhV_Kxk/edit
+* **Recording**:
+* **GitHub Issue**: <https://github.com/nodejs/TSC/issues/1357>
+* **Minutes Google Doc**: <https://docs.google.com/document/d/1GHFR458LYzZmsZecjOjd570Dep3abO6isyB1OhV_Kxk/edit>
 
 ## Present
 
@@ -22,14 +22,14 @@
 
 ### Announcements
 
-Nodejsconf.it - https://2023.nodejsconf.it/ - 30th of Sept
+Nodejsconf.it - <https://2023.nodejsconf.it/> - 30th of Sept
 NodeConf.eu - 6th-8th of November
 Open Source Summit Bilbao - CFP is open.
 Open Source Vancouver - Collab Summit on the 9th of May
 
 ### CPC and Board Meeting Updates
 
-*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+\*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 ### nodejs/node
 
@@ -37,7 +37,7 @@ Open Source Vancouver - Collab Summit on the 9th of May
 
 Currently 19 votes. One -1, a few abstentions, majority of +1s. Matteo proposes to call it, no objection from the group.
 
-* Increase default 'max_semi_space_size' value to reduce GC overhead in V8 [#42511](https://github.com/nodejs/node/issues/42511)
+* Increase default 'max\_semi\_space\_size' value to reduce GC overhead in V8 [#42511](https://github.com/nodejs/node/issues/42511)
 
 Ronag summarizes the issues
 Matteo states that it might actually lead to memory reduction due to smaller promotions to old space.
@@ -63,7 +63,7 @@ Matteo recommends folks to raise their concerns in the issues.
 ## Strategic Initiatives
 
 V8 Currency:
-V8 11.2 is in beta in Chrome and there is a PR open https://github.com/nodejs/node/pull/46815
+V8 11.2 is in beta in Chrome and there is a PR open <https://github.com/nodejs/node/pull/46815>
 Workaround for compiling in ARM64 Windows
 Issues with WebAssembly / ARM, @targos to investigate today
 Almost ready to land
@@ -71,17 +71,16 @@ Not sure we will be updating to the next version
 Which version of V8 will be supported for the longest time? What version should we use for Node v20 release? Targos to give recommendations.
 
 SEA:
-Joyee has sent a PR for the layout for https://github.com/nodejs/node/pull/47125 
+Joyee has sent a PR for the layout for <https://github.com/nodejs/node/pull/47125>
 Matteo: why do we need a layout?
 Joyee: it’s need to support snapshots.
 Darshan: also pre-baked CLI argos
 
 ShadowRealm:
-stacktrace decoration is coming https://github.com/nodejs/node/pull/47107.
+stacktrace decoration is coming <https://github.com/nodejs/node/pull/47107>.
 
 ## Upcoming Meetings
 
 * **Node.js Project Calendar**: <https://nodejs.org/calendar>
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
-

--- a/meetings/2023-03-22.md
+++ b/meetings/2023-03-22.md
@@ -2,7 +2,7 @@
 
 ## Links
 
-* **Recording**:
+* **Recording**: <https://www.youtube.com/watch?v=jM8D4QqEmwI>
 * **GitHub Issue**: <https://github.com/nodejs/TSC/issues/1357>
 * **Minutes Google Doc**: <https://docs.google.com/document/d/1GHFR458LYzZmsZecjOjd570Dep3abO6isyB1OhV_Kxk/edit>
 

--- a/meetings/2023-03-22.md
+++ b/meetings/2023-03-22.md
@@ -22,10 +22,10 @@
 
 ### Announcements
 
-Nodejsconf.it - <https://2023.nodejsconf.it/> - 30th of Sept
-NodeConf.eu - 6th-8th of November
-Open Source Summit Bilbao - CFP is open.
-Open Source Vancouver - Collab Summit on the 9th of May
+* Nodejsconf.it - <https://2023.nodejsconf.it/> - 30th of Sept
+* NodeConf.eu - 6th-8th of November
+* Open Source Summit Bilbao - CFP is open.
+* Open Source Vancouver - Collab Summit on the 9th of May
 
 ### CPC and Board Meeting Updates
 

--- a/meetings/2023-03-22.md
+++ b/meetings/2023-03-22.md
@@ -63,21 +63,21 @@ Matteo recommends folks to raise their concerns in the issues.
 ## Strategic Initiatives
 
 V8 Currency:
-V8 11.2 is in beta in Chrome and there is a PR open <https://github.com/nodejs/node/pull/46815>
-Workaround for compiling in ARM64 Windows
-Issues with WebAssembly / ARM, @targos to investigate today
-Almost ready to land
-Not sure we will be updating to the next version
-Which version of V8 will be supported for the longest time? What version should we use for Node v20 release? Targos to give recommendations.
+* V8 11.2 is in beta in Chrome and there is a PR open <https://github.com/nodejs/node/pull/46815>
+* Workaround for compiling in ARM64 Windows
+* Issues with WebAssembly / ARM, @targos to investigate today
+* Almost ready to land
+* Not sure we will be updating to the next version
+* Which version of V8 will be supported for the longest time? What version should we use for Node v20 release? Targos to give recommendations.
 
 SEA:
-Joyee has sent a PR for the layout for <https://github.com/nodejs/node/pull/47125>
-Matteo: why do we need a layout?
-Joyee: it’s need to support snapshots.
-Darshan: also pre-baked CLI argos
+* Joyee has sent a PR for the layout for <https://github.com/nodejs/node/pull/47125>
+* Matteo: why do we need a layout?
+* Joyee: it’s need to support snapshots.
+* Darshan: also pre-baked CLI argos
 
 ShadowRealm:
-stacktrace decoration is coming <https://github.com/nodejs/node/pull/47107>.
+* stacktrace decoration is coming <https://github.com/nodejs/node/pull/47107>.
 
 ## Upcoming Meetings
 

--- a/meetings/2023-03-22.md
+++ b/meetings/2023-03-22.md
@@ -1,0 +1,87 @@
+# Node.js Technical Steering Committee (TSC) Meeting 2023-03-22
+
+## Links
+
+* **Recording**:  
+* **GitHub Issue**: https://github.com/nodejs/TSC/issues/1357
+* **Minutes Google Doc**: https://docs.google.com/document/d/1GHFR458LYzZmsZecjOjd570Dep3abO6isyB1OhV_Kxk/edit
+
+## Present
+
+* Antoine du Hamel @aduh95 (TSC)
+* Ruben Bridgewater @BridgeAR (TSC)
+* Gireesh Punathil @gireeshpunathil (TSC)
+* Joyee Cheung @joyeecheung (TSC)
+* Chengzhong Wu @legendecas (TSC)
+* Matteo Collina @mcollina (TSC)
+* Darshan Sen @RaisinTen (TSC)
+* Robert Nagy @ronag (TSC)
+* Michaël Zasso @targos (TSC)
+
+## Agenda
+
+### Announcements
+
+Nodejsconf.it - https://2023.nodejsconf.it/ - 30th of Sept
+NodeConf.eu - 6th-8th of November
+Open Source Summit Bilbao - CFP is open.
+Open Source Vancouver - Collab Summit on the 9th of May
+
+### CPC and Board Meeting Updates
+
+*Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+
+### nodejs/node
+
+* stream: bump default highWaterMark [#46608](https://github.com/nodejs/node/pull/46608)
+
+Currently 19 votes. One -1, a few abstentions, majority of +1s. Matteo proposes to call it, no objection from the group.
+
+* Increase default 'max_semi_space_size' value to reduce GC overhead in V8 [#42511](https://github.com/nodejs/node/issues/42511)
+
+Ronag summarizes the issues
+Matteo states that it might actually lead to memory reduction due to smaller promotions to old space.
+Ronag: No PR yet about it, bumping to the performance team
+
+### nodejs/TSC
+
+* Update charter to address membership challenges [#1350](https://github.com/nodejs/TSC/pull/1350)
+
+Matteo: this landed, nothing to say.
+
+* Proposal: Making performance team a working group [#1343](https://github.com/nodejs/TSC/issues/1343)
+
+Matteo to take the action to create a pr for the strategic initiative
+
+### nodejs/admin
+
+* Moving all translation to Crowdin and retiring all i18n groups [#763](https://github.com/nodejs/admin/issues/763)
+
+No one objects.
+Matteo recommends folks to raise their concerns in the issues.
+
+## Strategic Initiatives
+
+V8 Currency:
+V8 11.2 is in beta in Chrome and there is a PR open https://github.com/nodejs/node/pull/46815
+Workaround for compiling in ARM64 Windows
+Issues with WebAssembly / ARM, @targos to investigate today
+Almost ready to land
+Not sure we will be updating to the next version
+Which version of V8 will be supported for the longest time? What version should we use for Node v20 release? Targos to give recommendations.
+
+SEA:
+Joyee has sent a PR for the layout for https://github.com/nodejs/node/pull/47125 
+Matteo: why do we need a layout?
+Joyee: it’s need to support snapshots.
+Darshan: also pre-baked CLI argos
+
+ShadowRealm:
+stacktrace decoration is coming https://github.com/nodejs/node/pull/47107.
+
+## Upcoming Meetings
+
+* **Node.js Project Calendar**: <https://nodejs.org/calendar>
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
+


### PR DESCRIPTION
I don't see the recording at https://www.youtube.com/@nodejs-foundation/streams. Maybe we didn't stream today's meeting? I left the recording blank in the minutes. Please update to indicate either the URL of the recording or a few words to say it wasn't streamed. Then pull it out of draft mode. Thanks!