### PR TITLE
doc: add script used to generate PR for minutes

### DIFF
--- a/meetings/gen-meeting.sh
+++ b/meetings/gen-meeting.sh
@@ -1,0 +1,10 @@
+git checkout -b minutes-$(date +'%Y-%m-%d') || git checkout minutes-$(date +'%Y-%m-%d')
+git reset --hard upstream/main
+git fetch upstream
+git rebase upstream/main
+curl -L https://docs.google.com/document/d/$1/export?format=txt >$(date +"%Y-%m-%d").md
+dos2unix $(date +"%Y-%m-%d").md
+npx markdownlint-cli --fix $(date +"%Y-%m-%d").md
+sed -i  's/ *$//' $(date +"%Y-%m-%d").md
+git branch |grep \*
+


### PR DESCRIPTION
This adds the script I used to generate the PR from the google doc after meetings.  You need to be in the meetings directory of a copy of the TSC repo that was checked out. The parameter is the GUID like value in the google meeting doc link.

Adding so that I don't lose it and so other people who Chair TSC meetings can use if they want to as well.