### PR TITLE
chore: update package-lock dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -613,13 +613,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/co": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
-      "integrity": "sha512-CQsjCRiNObI8AtTsNIBDRMQ4oMR83CzEswHYahClvul7gKk+lDQiOKv+5qh7LQWf5sh6jkZNispz/QlsZxyNgA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/collapse-white-space": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
@@ -3121,27 +3114,14 @@
       }
     },
     "node_modules/remark-lint-no-trailing-spaces": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-no-trailing-spaces/-/remark-lint-no-trailing-spaces-2.0.1.tgz",
-      "integrity": "sha512-cj8t+nvtO6eAY2lJC7o5du8VeOCK13XiDUHL4U6k5aw6ZLr3EYWbQ/rNc6cr60eHkh5Ldm09KiZjV3CWpxqJ0g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-trailing-spaces/-/remark-lint-no-trailing-spaces-3.0.2.tgz",
+      "integrity": "sha512-4KxOdzZ+BlCZDu9yYsKGOfB8fknukxYD+9VhI1I5l7Ns7TgqdYq4k/qwUfTHpQ4TF9aokL/tOpsEGOc4PGKTKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "unified-lint-rule": "^1.0.2"
-      }
-    },
-    "node_modules/remark-lint-no-trailing-spaces/node_modules/unified-lint-rule": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/unified-lint-rule/-/unified-lint-rule-1.0.6.tgz",
-      "integrity": "sha512-YPK15YBFwnsVorDFG/u0cVVQN5G2a3V8zv5/N6KN3TCG+ajKtaALcy7u14DCSrJI+gZeyYquFL9cioJXOGXSvg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "wrapped": "^1.0.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
+        "unified-lint-rule": "^3.0.0",
+        "vfile-location": "^5.0.3"
       }
     },
     "node_modules/remark-lint-no-undefined-references": {
@@ -3438,9 +3418,9 @@
       }
     },
     "node_modules/remark-preset-lint-node": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/remark-preset-lint-node/-/remark-preset-lint-node-5.1.0.tgz",
-      "integrity": "sha512-Nt7f1K37qUQZ9OomkXyCH0vsKihQ+qXR+4+r8Emw67hfOrVWhNzJw2jy96bJHMMWLPD1Fp4Q8cSGQxhthaORkQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/remark-preset-lint-node/-/remark-preset-lint-node-5.1.1.tgz",
+      "integrity": "sha512-50xkDDNJEOk/f1+BuzMi2Mz65YIw6xALmmh4WfrAhdNdRXCw4tf4jmCxThHR0u2te2YSH8H4osrbjC5dxSq6Wg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3467,7 +3447,7 @@
         "remark-lint-no-shell-dollars": "^4.0.0",
         "remark-lint-no-table-indentation": "^5.0.0",
         "remark-lint-no-tabs": "^4.0.0",
-        "remark-lint-no-trailing-spaces": "^2.0.1",
+        "remark-lint-no-trailing-spaces": "^3.0.2",
         "remark-lint-prohibited-strings": "^4.0.0",
         "remark-lint-rule-style": "^4.0.0",
         "remark-lint-strong-marker": "^4.0.0",
@@ -3606,13 +3586,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/sliced": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
-      "integrity": "sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/space-separated-tokens": {
       "version": "2.0.2",
@@ -4366,17 +4339,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/wrapped": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wrapped/-/wrapped-1.0.1.tgz",
-      "integrity": "sha512-ZTKuqiTu3WXtL72UKCCnQLRax2IScKH7oQ+mvjbpvNE+NJxIWIemDqqM2GxNr4N16NCjOYpIgpin5pStM7kM5g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "co": "3.1.0",
-        "sliced": "^1.0.1"
       }
     },
     "node_modules/yaml": {


### PR DESCRIPTION
`npm ci && npm run test` will now report the line/column numbers for trailing spaces.