### PR TITLE
fix(votes): typo in `closeVote.yml`

### DIFF
--- a/.github/workflows/closeVote.yml
+++ b/.github/workflows/closeVote.yml
@@ -29,7 +29,7 @@ jobs:
             --jq '[
               (.comments | map(.body | select(contains("-----BEGIN SHAMIR KEY PART-----"))) | "comments=" + tostring),
               ("head=" + .headRefName),
-              (.commits | length - 1 | "nbOfBallots=" + tostring),
+              (.commits | length - 1 | "numberOfBallots=" + tostring),
               ("URL=" + .url)
             ] | join("\n")' >> "$GITHUB_OUTPUT"
         env:


### PR DESCRIPTION
There's a discrepancy in the file causing the workflow to fail https://github.com/nodejs/TSC/blob/2fb3417f6893d04adb8a00f66521eb812c6d9789/.github/workflows/closeVote.yml#L57