### PR TITLE
doc: update charter section on voting

### DIFF
--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -125,9 +125,11 @@ The TSC voting members follow a [Consensus Seeking][] decision making model.
 When an agenda item has appeared to reach a consensus the moderator will ask
 "Does anyone object?" as a final call for dissent from the consensus.
 
-For all votes, a simple majority of all TSC voting members for, or against, the
-issue wins. A TSC voting member may choose to participate in any vote through
-abstention.
+For all votes, the winning candidate option is the one that wins a simple
+majority of all TSC voting members in every head-to-head election against each
+of the other candidates. A TSC voting member may choose to participate in any
+vote through abstention. As long as a vote is open, TSC voting members' choices
+must not be disclosed, to avoid influencing other voting members. 
 
 All changes to this charter must be approved by the CPC.
 

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -129,7 +129,7 @@ For all votes, the winning candidate option is the one that wins a simple
 majority of all TSC voting members in every head-to-head election against each
 of the other candidates. A TSC voting member may choose to participate in any
 vote through abstention. As long as a vote is open, TSC voting members' choices
-must not be disclosed, to avoid influencing other voting members. 
+must not be disclosed, to avoid influencing other voting members.
 
 All changes to this charter must be approved by the CPC.
 


### PR DESCRIPTION
I've considered adding requirements regarding what tool to use, but after giving it some more thoughts, it's probably better if the choice of the tool is not chartered so if we need/want to change it, it doesn't require CPC approval. Instead, let's edit the charter so it forbids the use of a voting solution that would lack the features we deem important:

- The wording around how the "winner" is defined currently seems to assume there would be always two candidates. Although the current wording is not invalid for many-candidate votes depending how one define the word "vote", it makes more sense to write it in a way that assume there might be more than two candidates.
- Added a sentence that requires ballots not to be disclose before the vote closes. It's been a few years we've operated this way, IMO the upsides clearly outweigh the tradeoffs.

