### PR TITLE
doc: clarify regular member expectation

### DIFF
--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -55,6 +55,13 @@ TSC voting members are expected to regularly participate in TSC activities.
 
 A TSC voting member is automatically converted to a TSC regular member if
 they do not participate in three consecutive TSC votes.
+Regular membership is expected to be a temporary status, with the
+expectation that the regular member will return to be active and be
+converted to voting members after a period of time.
+A TSC regular member can be asked to become emeritus in the event that they
+are not able to participate in TSC activities for an extended period of time.
+An emeritus member can ask to be reactivated as a regular member by a standard TSC
+motion, otherwise, they will need to be re-elected as a voting member.
 
 ## Section 4. Responsibilities of the TSC
 


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/55524
This PR wants to set the right expectation on regular membership:
- A regular member can be asked to be moved to emeritus if inactive for extended period of time
- A regular member is a temporary status
- Emeritus member can be moved back to voting member if there is consensus otherwise will need to be re nominated

This makes it easier to be moved to emeritus, without having to stay as a regular member indefinitely.

Otherwise regular membership its a weird status where someone does not fullfil the role of TSC but does not lose the ability of regaining it even after prolonged period of inactivity.

@nodejs/tsc 