### PR TITLE
Clarify the Charter so that contractors are explicity counted as affialiated

### DIFF
--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -37,7 +37,8 @@ can be used to change a regular TSC member to a voting TSC member, or to change
 a voting TSC member to a regular TSC member.
 
 In order to ensure adequate representation of the interests of diverse stakeholders,
-no more than one-fourth of the TSC voting membership may be affiliated with the same company or other entity. 
+no more than one-fourth of the TSC voting membership may be affiliated with the same
+company or other entity.
 If a change in TSC voting membership or a change of affiliation by a TSC voting member
 creates a situation where more than one-fourth of the TSC voting membership are
 affiliated with the same company, then the situation must be immediately remedied

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -43,7 +43,7 @@ If a change in TSC voting membership or a change of employment by a TSC voting m
 creates a situation where more than one-fourth of the TSC voting membership are
 affiliated with the same company, then the situation must be immediately remedied
 by the removal of voting member status from one or more TSC voting members affiliated
-with the over-represented company. 
+with the over-represented company.
 
 The TSC shall meet regularly using tools that enable participation by the
 community (e.g. weekly on a Google Hangout On Air, or through any other

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -36,10 +36,11 @@ TSC by voluntary resignation or by a standard TSC motion. A standard TSC motion
 can be used to change a regular TSC member to a voting TSC member, or to change
 a voting TSC member to a regular TSC member.
 
-No more than one-fourth of the TSC voting members may be affiliated with the
-the same company (by any possible means, both as employment and contractual
-obligations).
-If a change in TSC voting membership or a change of employment by a TSC voting member
+In order to ensure that hostile takeovers of the Node.js project are not possible,
+no company or other entity may influence more than one-fourth of the TSC voting membership.
+As a result, no more than one-fourth of the TSC voting members may be affiliated with the
+the same company.
+If a change in TSC voting membership or a change of affiliation by a TSC voting member
 creates a situation where more than one-fourth of the TSC voting membership are
 affiliated with the same company, then the situation must be immediately remedied
 by the removal of voting member status from one or more TSC voting members affiliated

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -38,8 +38,6 @@ a voting TSC member to a regular TSC member.
 
 In order to ensure that hostile takeovers of the Node.js project are not possible,
 no more than one-fourth of the TSC voting membership may be affiliated with the same company or other entity. 
-As a result, no more than one-fourth of the TSC voting members may be affiliated with the
-the same company.
 If a change in TSC voting membership or a change of affiliation by a TSC voting member
 creates a situation where more than one-fourth of the TSC voting membership are
 affiliated with the same company, then the situation must be immediately remedied

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -36,7 +36,7 @@ TSC by voluntary resignation or by a standard TSC motion. A standard TSC motion
 can be used to change a regular TSC member to a voting TSC member, or to change
 a voting TSC member to a regular TSC member.
 
-In order to ensure that hostile takeovers of the Node.js project are not possible,
+In order to ensure adequate representation of the interests of diverse stakeholders,
 no more than one-fourth of the TSC voting membership may be affiliated with the same company or other entity. 
 If a change in TSC voting membership or a change of affiliation by a TSC voting member
 creates a situation where more than one-fourth of the TSC voting membership are

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -37,11 +37,13 @@ can be used to change a regular TSC member to a voting TSC member, or to change
 a voting TSC member to a regular TSC member.
 
 No more than one-fourth of the TSC voting members may be affiliated with the
-same employer. If change in TSC voting membership or a change of
-employment by a TSC voting member creates a situation where more than
-one-fourth of the TSC voting membership shares an employer, then the situation
-must be immediately remedied by the removal of voting member status from one or
-more TSC voting members affiliated with the over-represented employer(s).
+the same company (by any possible means, both as employment and contractual
+obligations).
+If a change in TSC voting membership or a change of employment by a TSC voting member
+creates a situation where more than one-fourth of the TSC voting membership are
+affiliated with the same company, then the situation must be immediately remedied
+by the removal of voting member status from one or more TSC voting members affiliated
+with the over-represented company. 
 
 The TSC shall meet regularly using tools that enable participation by the
 community (e.g. weekly on a Google Hangout On Air, or through any other

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -37,7 +37,7 @@ can be used to change a regular TSC member to a voting TSC member, or to change
 a voting TSC member to a regular TSC member.
 
 In order to ensure that hostile takeovers of the Node.js project are not possible,
-no company or other entity may influence more than one-fourth of the TSC voting membership.
+no more than one-fourth of the TSC voting membership may be affiliated with the same company or other entity. 
 As a result, no more than one-fourth of the TSC voting members may be affiliated with the
 the same company.
 If a change in TSC voting membership or a change of affiliation by a TSC voting member

--- a/TSC-Charter.md
+++ b/TSC-Charter.md
@@ -38,10 +38,10 @@ a voting TSC member to a regular TSC member.
 
 In order to ensure adequate representation of the interests of diverse stakeholders,
 no more than one-fourth of the TSC voting membership may be affiliated with the same
-company or other entity.
+company/entity.
 If a change in TSC voting membership or a change of affiliation by a TSC voting member
 creates a situation where more than one-fourth of the TSC voting membership are
-affiliated with the same company, then the situation must be immediately remedied
+affiliated with the same company/entity, then the situation must be immediately remedied
 by the removal of voting member status from one or more TSC voting members affiliated
 with the over-represented company.
 


### PR DESCRIPTION
Some people mighrt be contracted to work on OSS on behalf of companies. This does not make them _less_ affiliated, and it might be used to circumvent the affiliation rules.