### PR TITLE
Update offboarding instructions

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -32,8 +32,8 @@ invalid and are superseded by the TSC Charter.
   reason other than TSC membership:
   * [`@nodejs-private`](https://github.com/orgs/nodejs-private/people)
   * [`@nodejs`](https://github.com/orgs/nodejs/people)
-  * [`@pkgjs`](https://github.com/orgs/pkgjs/people) (unless they're listed on
-    [ADMINISTRATIVE-MEMBERS](https://github.com/nodejs/package-maintenance/blob/main/ADMINISTRATIVE-MEMBERS.md))
+  * [`@pkgjs`](https://github.com/orgs/pkgjs/people) (unless they're listed on the
+    [MEMBERS](https://github.com/nodejs/package-maintenance/blob/main/MEMBERS.md) list)
 * Change the member's role from `Owner` to `Member`
   (unless they have `Owner` role for a reason other than TSC membership)
   in the following GitHub orgs:

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -28,21 +28,22 @@ invalid and are superseded by the TSC Charter.
 
 ## Offboarding of voting members
 
-* Remove the member from the following teams:
-  * [`@nodejs/tsc`](https://github.com/orgs/nodejs/teams/tsc/members)
-  * [`@nodejs/security-tsc`](https://github.com/orgs/nodejs/teams/security-tsc/members)
-  * [`@nodejs-private/security-tsc`](https://github.com/orgs/nodejs-private/teams/security-tsc/members)
-  * [`@pkgjs/node-tsc`](https://github.com/orgs/pkgjs/teams/node-tsc/members)
-* Change the member's role from `Owner` to `Member`
-  (unless they have `Owner` role for a reason other than TSC membership)
-  in the following GitHub orgs:
-  * [`@nodejs-private`](https://github.com/orgs/nodejs-private/people)
-  * [`@nodejs`](https://github.com/orgs/nodejs/people)
 * Remove them from the following GitHub orgs unless they are members for a
   reason other than TSC membership:
   * [`@nodejs-private`](https://github.com/orgs/nodejs-private/people)
   * [`@nodejs`](https://github.com/orgs/nodejs/people)
   * [`@pkgjs`](https://github.com/orgs/pkgjs/people)
+* Change the member's role from `Owner` to `Member`
+  (unless they have `Owner` role for a reason other than TSC membership)
+  in the following GitHub orgs:
+  * [`@nodejs-private`](https://github.com/orgs/nodejs-private/people)
+  * [`@nodejs`](https://github.com/orgs/nodejs/people)
+  * [`@pkgjs`](https://github.com/orgs/pkgjs/people)
+* Remove the member from the following teams:
+  * [`@nodejs/tsc`](https://github.com/orgs/nodejs/teams/tsc/members)
+  * [`@nodejs/security-tsc`](https://github.com/orgs/nodejs/teams/security-tsc/members)
+  * [`@nodejs-private/security-tsc`](https://github.com/orgs/nodejs-private/teams/security-tsc/members)
+  * [`@pkgjs/node-tsc`](https://github.com/orgs/pkgjs/teams/node-tsc/members)
 * Remove them from the HackerOne [Node.js team](https://hackerone.com/organizations/nodejs/settings/users) unless they need access for a
   reason other than TSC membership.
 * Remove them from the `tsc` mailing lists: <https://github.com/nodejs/email/edit/main/iojs.org/aliases.json>.

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -33,14 +33,14 @@ invalid and are superseded by the TSC Charter.
   * [`@nodejs-private`](https://github.com/orgs/nodejs-private/people)
   * [`@nodejs`](https://github.com/orgs/nodejs/people)
   * [`@pkgjs`](https://github.com/orgs/pkgjs/people) (unless they're listed on
-     [ADMINISTRATIVE-MEMBERS](https://github.com/nodejs/package-maintenance/blob/main/ADMINISTRATIVE-MEMBERS.md))
+    [ADMINISTRATIVE-MEMBERS](https://github.com/nodejs/package-maintenance/blob/main/ADMINISTRATIVE-MEMBERS.md))
 * Change the member's role from `Owner` to `Member`
   (unless they have `Owner` role for a reason other than TSC membership)
   in the following GitHub orgs:
   * [`@nodejs-private`](https://github.com/orgs/nodejs-private/people)
   * [`@nodejs`](https://github.com/orgs/nodejs/people)
   * [`@pkgjs`](https://github.com/orgs/pkgjs/people) (unless they're listed on
-     [ADMINISTRATIVE-MEMBERS](https://github.com/nodejs/package-maintenance/blob/main/ADMINISTRATIVE-MEMBERS.md))
+    [ADMINISTRATIVE-MEMBERS](https://github.com/nodejs/package-maintenance/blob/main/ADMINISTRATIVE-MEMBERS.md))
 * Remove the member from the following teams:
   * [`@nodejs/tsc`](https://github.com/orgs/nodejs/teams/tsc/members)
   * [`@nodejs/security-tsc`](https://github.com/orgs/nodejs/teams/security-tsc/members)

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -32,13 +32,15 @@ invalid and are superseded by the TSC Charter.
   reason other than TSC membership:
   * [`@nodejs-private`](https://github.com/orgs/nodejs-private/people)
   * [`@nodejs`](https://github.com/orgs/nodejs/people)
-  * [`@pkgjs`](https://github.com/orgs/pkgjs/people)
+  * [`@pkgjs`](https://github.com/orgs/pkgjs/people) (unless they're listed on
+     [ADMINISTRATIVE-MEMBERS](https://github.com/nodejs/package-maintenance/blob/main/ADMINISTRATIVE-MEMBERS.md))
 * Change the member's role from `Owner` to `Member`
   (unless they have `Owner` role for a reason other than TSC membership)
   in the following GitHub orgs:
   * [`@nodejs-private`](https://github.com/orgs/nodejs-private/people)
   * [`@nodejs`](https://github.com/orgs/nodejs/people)
-  * [`@pkgjs`](https://github.com/orgs/pkgjs/people)
+  * [`@pkgjs`](https://github.com/orgs/pkgjs/people) (unless they're listed on
+     [ADMINISTRATIVE-MEMBERS](https://github.com/nodejs/package-maintenance/blob/main/ADMINISTRATIVE-MEMBERS.md))
 * Remove the member from the following teams:
   * [`@nodejs/tsc`](https://github.com/orgs/nodejs/teams/tsc/members)
   * [`@nodejs/security-tsc`](https://github.com/orgs/nodejs/teams/security-tsc/members)


### PR DESCRIPTION
Currently, our offboarding instructions does not indicate to remove "ownership" over the pkgjs org, probably relying on the next instructions that tells to remove them from the org altogether. However, there's an exception, they might member of pkgjs for another reason then TSC membership, in which case we should probably change their role to Member.

I've also changed the order a bit to give less work when offboarding (if you start by removing the member from the org, you don't need to change the role or remove them from the team)