### PR TITLE
Remove Addon API working group

### DIFF
--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -237,7 +237,6 @@ The [Node.js Code of Conduct][] applies to this WG.
 * [Build](#build)
 * [Diagnostics](#diagnostics)
 * [Docker](#docker)
-* [Addon API](#addon-api)
 * [Release](#release)
 * [Package Maintenance](#package-maintenance)
 * [Undici](#undici)


### PR DESCRIPTION
Remove `Addon API` working group from the outline list.

Ref: https://github.com/nodejs/TSC/commit/d8d7cb2c630a42f2974fef1edc837d95478df1f1