### PR TITLE
chore: only run the CI on `main` and PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 on:
   push:
-    branches-ignore:
-      - dependabot/**
+    branches:
+      - main
     paths:
       - package*.json
       - '**/*.md'


### PR DESCRIPTION
Currently opening a PR for adding minutes run the CI twice, just is pure waste. 