### PR TITLE
ci: declare contents:read on CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ on:
       - .github/workflows/ci.yml
       - .github/workflows/remark-lint-problem-matcher.json
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins `ci.yml` to `contents: read` at workflow scope. The lint job runs `npm ci`, remark-lint over markdown, and yamllint after downloading the Node.js project's `.yamllint.yaml` via curl. Nothing writes to the repo or calls the GitHub API.

Defense-in-depth motivation is [CVE-2025-30066](https://github.com/advisories/GHSA-mrrh-fwg8-r2c3) (`tj-actions/changed-files`): a compromised third-party action runs inside the existing job context and exfiltrates whatever scope the workflow token holds via build logs. The explicit cap bounds that.

Style matches the workflow-level permissions blocks already used in `closeVote.yml`, `initiateNewVote.yml`, and `watchVote.yml` (those declare `contents: write` + `pull-requests: write` because the vote bot needs those scopes; this one only needs read). YAML validated locally with `yaml.safe_load`.